### PR TITLE
Promise.t -> promise

### DIFF
--- a/docs/content/docs/contributing/code-generation.mdx
+++ b/docs/content/docs/contributing/code-generation.mdx
@@ -16,14 +16,14 @@ For example the `window.fetch` function was generated as:
 */
 @send
 external fetch: (window, ~input: request, ~init: requestInit=?)
-  => Promise.t<response> = "fetch"
+  => promise<response> = "fetch"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
 @send
 external fetch2: (window, ~input: string, ~init: requestInit=?)
-  => Promise.t<response> = "fetch"
+  => promise<response> = "fetch"
 ```
 
 While not that bad and usable, it can be improved:
@@ -39,12 +39,12 @@ While not that bad and usable, it can be improved:
 /** TODO: add better docs */
 @send
 external fetch: (window, string, ~init: requestInit=?)
-  => Promise.t<response> = "fetch"
+  => promise<response> = "fetch"
 
 /** TODO: add better docs */
 @send
 external fetch_withRequest: (window, request, ~init: requestInit=?)
-  => Promise.t<response> = "fetch"
+  => promise<response> = "fetch"
 ```
 
 Once these changes are made, the bindings can be tested and then committed to the repository.

--- a/docs/content/docs/contributing/documentation.mdx
+++ b/docs/content/docs/contributing/documentation.mdx
@@ -42,5 +42,5 @@ window->Window.fetch("https://rescript-lang.org")
 */
 @send
 external fetch: (window, string, ~init: requestInit=?)
-  => Promise.t<response> = "fetch"
+  => promise<response> = "fetch"
 ````

--- a/src/CSSFontLoadingAPI.res
+++ b/src/CSSFontLoadingAPI.res
@@ -70,7 +70,7 @@ type rec fontFace = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace/loaded)
     */
-  loaded: Promise.t<fontFace>,
+  loaded: promise<fontFace>,
 }
 
 /**
@@ -81,7 +81,7 @@ type rec fontFaceSet = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/ready)
     */
-  ready: Promise.t<fontFaceSet>,
+  ready: promise<fontFaceSet>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/status)
     */

--- a/src/CSSFontLoadingAPI/FontFace.res
+++ b/src/CSSFontLoadingAPI/FontFace.res
@@ -31,4 +31,4 @@ external make3: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace/load)
 */
 @send
-external load: fontFace => Promise.t<fontFace> = "load"
+external load: fontFace => promise<fontFace> = "load"

--- a/src/CSSFontLoadingAPI/FontFaceSet.res
+++ b/src/CSSFontLoadingAPI/FontFaceSet.res
@@ -27,7 +27,7 @@ external clear: fontFaceSet => unit = "clear"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/load)
 */
 @send
-external load: (fontFaceSet, ~font: string, ~text: string=?) => Promise.t<array<fontFace>> = "load"
+external load: (fontFaceSet, ~font: string, ~text: string=?) => promise<array<fontFace>> = "load"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/check)

--- a/src/CanvasAPI/OffscreenCanvas.res
+++ b/src/CanvasAPI/OffscreenCanvas.res
@@ -87,5 +87,5 @@ The argument, if provided, is a dictionary that controls the encoding options of
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/convertToBlob)
 */
 @send
-external convertToBlob: (offscreenCanvas, ~options: imageEncodeOptions=?) => Promise.t<blob> =
+external convertToBlob: (offscreenCanvas, ~options: imageEncodeOptions=?) => promise<blob> =
   "convertToBlob"

--- a/src/ClipboardAPI/Clipboard.res
+++ b/src/ClipboardAPI/Clipboard.res
@@ -8,22 +8,22 @@ include EventTarget.Impl({
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clipboard/read)
 */
 @send
-external read: clipboard => Promise.t<array<clipboardItem>> = "read"
+external read: clipboard => promise<array<clipboardItem>> = "read"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clipboard/readText)
 */
 @send
-external readText: clipboard => Promise.t<string> = "readText"
+external readText: clipboard => promise<string> = "readText"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clipboard/write)
 */
 @send
-external write: (clipboard, array<clipboardItem>) => Promise.t<unit> = "write"
+external write: (clipboard, array<clipboardItem>) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clipboard/writeText)
 */
 @send
-external writeText: (clipboard, string) => Promise.t<unit> = "writeText"
+external writeText: (clipboard, string) => promise<unit> = "writeText"

--- a/src/ClipboardAPI/ClipboardItem.res
+++ b/src/ClipboardAPI/ClipboardItem.res
@@ -12,7 +12,7 @@ external make: (~items: any, ~options: clipboardItemOptions=?) => clipboardItem 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ClipboardItem/getType)
 */
 @send
-external getType: (clipboardItem, string) => Promise.t<blob> = "getType"
+external getType: (clipboardItem, string) => promise<blob> = "getType"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ClipboardItem/supports_static)

--- a/src/CredentialManagementAPI/CredentialsContainer.res
+++ b/src/CredentialManagementAPI/CredentialsContainer.res
@@ -7,13 +7,13 @@ open CredentialManagementAPI
 external get: (
   credentialsContainer,
   ~options: credentialRequestOptions=?,
-) => Promise.t<credential> = "get"
+) => promise<credential> = "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/store)
 */
 @send
-external store: (credentialsContainer, credential) => Promise.t<unit> = "store"
+external store: (credentialsContainer, credential) => promise<unit> = "store"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/create)
@@ -22,10 +22,10 @@ external store: (credentialsContainer, credential) => Promise.t<unit> = "store"
 external create: (
   credentialsContainer,
   ~options: credentialCreationOptions=?,
-) => Promise.t<credential> = "create"
+) => promise<credential> = "create"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/preventSilentAccess)
 */
 @send
-external preventSilentAccess: credentialsContainer => Promise.t<unit> = "preventSilentAccess"
+external preventSilentAccess: credentialsContainer => promise<unit> = "preventSilentAccess"

--- a/src/DOMAPI.res
+++ b/src/DOMAPI.res
@@ -9524,11 +9524,11 @@ type rec animation = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Animation/ready)
     */
-  ready: Promise.t<animation>,
+  ready: promise<animation>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Animation/finished)
     */
-  finished: Promise.t<animation>,
+  finished: promise<animation>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Animation/startTime)
     */

--- a/src/DOMAPI/CSSStyleSheet.res
+++ b/src/DOMAPI/CSSStyleSheet.res
@@ -23,7 +23,7 @@ external deleteRule: (cssStyleSheet, int) => unit = "deleteRule"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replace)
 */
 @send
-external replace: (cssStyleSheet, string) => Promise.t<cssStyleSheet> = "replace"
+external replace: (cssStyleSheet, string) => promise<cssStyleSheet> = "replace"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replaceSync)

--- a/src/DOMAPI/CustomElementRegistry.res
+++ b/src/DOMAPI/CustomElementRegistry.res
@@ -21,7 +21,7 @@ external getName: (customElementRegistry, customElementConstructor) => string = 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/whenDefined)
 */
 @send
-external whenDefined: (customElementRegistry, string) => Promise.t<customElementConstructor> =
+external whenDefined: (customElementRegistry, string) => promise<customElementConstructor> =
   "whenDefined"
 
 /**

--- a/src/DOMAPI/Document.res
+++ b/src/DOMAPI/Document.res
@@ -360,7 +360,7 @@ Stops document's fullscreen element from being displayed fullscreen and resolves
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/exitFullscreen)
 */
 @send
-external exitFullscreen: document => Promise.t<unit> = "exitFullscreen"
+external exitFullscreen: document => promise<unit> = "exitFullscreen"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/parseHTMLUnsafe_static)
@@ -432,7 +432,7 @@ external hasFocus: document => bool = "hasFocus"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/exitPictureInPicture)
 */
 @send
-external exitPictureInPicture: document => Promise.t<unit> = "exitPictureInPicture"
+external exitPictureInPicture: document => promise<unit> = "exitPictureInPicture"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/exitPointerLock)
@@ -451,10 +451,10 @@ external getSelection: document => selection = "getSelection"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess)
 */
 @send
-external hasStorageAccess: document => Promise.t<bool> = "hasStorageAccess"
+external hasStorageAccess: document => promise<bool> = "hasStorageAccess"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/requestStorageAccess)
 */
 @send
-external requestStorageAccess: document => Promise.t<unit> = "requestStorageAccess"
+external requestStorageAccess: document => promise<unit> = "requestStorageAccess"

--- a/src/DOMAPI/Element.res
+++ b/src/DOMAPI/Element.res
@@ -353,14 +353,14 @@ When supplied, options's navigationUI member indicates whether showing navigatio
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/requestFullscreen)
 */
   @send
-  external requestFullscreen: (T.t, ~options: fullscreenOptions=?) => Promise.t<unit> =
+  external requestFullscreen: (T.t, ~options: fullscreenOptions=?) => promise<unit> =
     "requestFullscreen"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/requestPointerLock)
 */
   @send
-  external requestPointerLock: (T.t, ~options: pointerLockOptions=?) => Promise.t<unit> =
+  external requestPointerLock: (T.t, ~options: pointerLockOptions=?) => promise<unit> =
     "requestPointerLock"
 
   /**

--- a/src/DOMAPI/HTMLImageElement.res
+++ b/src/DOMAPI/HTMLImageElement.res
@@ -8,4 +8,4 @@ include HTMLElement.Impl({
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/decode)
 */
 @send
-external decode: htmlImageElement => Promise.t<unit> = "decode"
+external decode: htmlImageElement => promise<unit> = "decode"

--- a/src/DOMAPI/HTMLMediaElement.res
+++ b/src/DOMAPI/HTMLMediaElement.res
@@ -56,19 +56,19 @@ Loads and starts playback of a media resource.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/play)
 */
   @send
-  external play: T.t => Promise.t<unit> = "play"
+  external play: T.t => promise<unit> = "play"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys)
 */
   @send
-  external setMediaKeys: (T.t, mediaKeys) => Promise.t<unit> = "setMediaKeys"
+  external setMediaKeys: (T.t, mediaKeys) => promise<unit> = "setMediaKeys"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setSinkId)
 */
   @send
-  external setSinkId: (T.t, string) => Promise.t<unit> = "setSinkId"
+  external setSinkId: (T.t, string) => promise<unit> = "setSinkId"
 }
 
 include Impl({

--- a/src/DOMAPI/HTMLVideoElement.res
+++ b/src/DOMAPI/HTMLVideoElement.res
@@ -16,7 +16,7 @@ external getVideoPlaybackQuality: htmlVideoElement => videoPlaybackQuality =
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/requestPictureInPicture)
 */
 @send
-external requestPictureInPicture: htmlVideoElement => Promise.t<pictureInPictureWindow> =
+external requestPictureInPicture: htmlVideoElement => promise<pictureInPictureWindow> =
   "requestPictureInPicture"
 
 /**

--- a/src/DOMAPI/Navigator.res
+++ b/src/DOMAPI/Navigator.res
@@ -9,13 +9,13 @@ open WebMIDIAPI
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/setAppBadge)
 */
 @send
-external setAppBadge: (navigator, ~contents: int=?) => Promise.t<unit> = "setAppBadge"
+external setAppBadge: (navigator, ~contents: int=?) => promise<unit> = "setAppBadge"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/clearAppBadge)
 */
 @send
-external clearAppBadge: navigator => Promise.t<unit> = "clearAppBadge"
+external clearAppBadge: navigator => promise<unit> = "clearAppBadge"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/registerProtocolHandler)
@@ -74,7 +74,7 @@ external requestMediaKeySystemAccess: (
   navigator,
   ~keySystem: string,
   ~supportedConfigurations: array<mediaKeySystemConfiguration>,
-) => Promise.t<mediaKeySystemAccess> = "requestMediaKeySystemAccess"
+) => promise<mediaKeySystemAccess> = "requestMediaKeySystemAccess"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/getGamepads)
@@ -98,7 +98,7 @@ external vibrate2: (navigator, array<int>) => bool = "vibrate"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/share)
 */
 @send
-external share: (navigator, ~data: shareData=?) => Promise.t<unit> = "share"
+external share: (navigator, ~data: shareData=?) => promise<unit> = "share"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/canShare)
@@ -110,5 +110,5 @@ external canShare: (navigator, ~data: shareData=?) => bool = "canShare"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/requestMIDIAccess)
 */
 @send
-external requestMIDIAccess: (navigator, ~options: midiOptions=?) => Promise.t<midiAccess> =
+external requestMIDIAccess: (navigator, ~options: midiOptions=?) => promise<midiAccess> =
   "requestMIDIAccess"

--- a/src/DOMAPI/VideoFrame.res
+++ b/src/DOMAPI/VideoFrame.res
@@ -76,7 +76,7 @@ external copyTo: (
   videoFrame,
   ~destination: ArrayBuffer.t,
   ~options: videoFrameCopyToOptions=?,
-) => Promise.t<array<planeLayout>> = "copyTo"
+) => promise<array<planeLayout>> = "copyTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame/copyTo)
@@ -86,7 +86,7 @@ external copyTo2: (
   videoFrame,
   ~destination: sharedArrayBuffer,
   ~options: videoFrameCopyToOptions=?,
-) => Promise.t<array<planeLayout>> = "copyTo"
+) => promise<array<planeLayout>> = "copyTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame/copyTo)
@@ -96,7 +96,7 @@ external copyTo3: (
   videoFrame,
   ~destination: DataView.t,
   ~options: videoFrameCopyToOptions=?,
-) => Promise.t<array<planeLayout>> = "copyTo"
+) => promise<array<planeLayout>> = "copyTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame/clone)

--- a/src/DOMAPI/Window.res
+++ b/src/DOMAPI/Window.res
@@ -78,7 +78,7 @@ external createImageBitmap: (
   window,
   ~image: htmlImageElement,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -88,7 +88,7 @@ external createImageBitmap2: (
   window,
   ~image: svgImageElement,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -98,7 +98,7 @@ external createImageBitmap3: (
   window,
   ~image: htmlVideoElement,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -108,7 +108,7 @@ external createImageBitmap4: (
   window,
   ~image: htmlCanvasElement,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -118,7 +118,7 @@ external createImageBitmap5: (
   window,
   ~image: imageBitmap,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -128,7 +128,7 @@ external createImageBitmap6: (
   window,
   ~image: offscreenCanvas,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -138,7 +138,7 @@ external createImageBitmap7: (
   window,
   ~image: videoFrame,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -148,7 +148,7 @@ external createImageBitmap8: (
   window,
   ~image: blob,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -158,7 +158,7 @@ external createImageBitmap9: (
   window,
   ~image: imageData,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -172,7 +172,7 @@ external createImageBitmap10: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -186,7 +186,7 @@ external createImageBitmap11: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -200,7 +200,7 @@ external createImageBitmap12: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -214,7 +214,7 @@ external createImageBitmap13: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -228,7 +228,7 @@ external createImageBitmap14: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -242,7 +242,7 @@ external createImageBitmap15: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -256,7 +256,7 @@ external createImageBitmap16: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -270,7 +270,7 @@ external createImageBitmap17: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -284,7 +284,7 @@ external createImageBitmap18: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/structuredClone)
@@ -306,7 +306,7 @@ let response = await window->Window.fetch("https://rescript-lang.org")
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
 @send
-external fetch: (window, string, ~init: requestInit=?) => Promise.t<response> = "fetch"
+external fetch: (window, string, ~init: requestInit=?) => promise<response> = "fetch"
 
 /**
 `fetch_withRequest(window, request, init)`
@@ -320,7 +320,7 @@ let response = await window->Window.fetch(myRequest)
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
 @send
-external fetch_withRequest: (window, request, ~init: requestInit=?) => Promise.t<response> = "fetch"
+external fetch_withRequest: (window, request, ~init: requestInit=?) => promise<response> = "fetch"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)

--- a/src/EncryptedMediaExtensionsAPI.res
+++ b/src/EncryptedMediaExtensionsAPI.res
@@ -74,7 +74,7 @@ type mediaKeySession = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/closed)
     */
-  closed: Promise.t<mediaKeySessionClosedReason>,
+  closed: promise<mediaKeySessionClosedReason>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/keyStatuses)
     */

--- a/src/EncryptedMediaExtensionsAPI/MediaKeySession.res
+++ b/src/EncryptedMediaExtensionsAPI/MediaKeySession.res
@@ -12,7 +12,7 @@ external generateRequest: (
   mediaKeySession,
   ~initDataType: string,
   ~initData: DataView.t,
-) => Promise.t<unit> = "generateRequest"
+) => promise<unit> = "generateRequest"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/generateRequest)
@@ -22,34 +22,34 @@ external generateRequest2: (
   mediaKeySession,
   ~initDataType: string,
   ~initData: ArrayBuffer.t,
-) => Promise.t<unit> = "generateRequest"
+) => promise<unit> = "generateRequest"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/load)
 */
 @send
-external load: (mediaKeySession, string) => Promise.t<bool> = "load"
+external load: (mediaKeySession, string) => promise<bool> = "load"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/update)
 */
 @send
-external update: (mediaKeySession, DataView.t) => Promise.t<unit> = "update"
+external update: (mediaKeySession, DataView.t) => promise<unit> = "update"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/update)
 */
 @send
-external update2: (mediaKeySession, ArrayBuffer.t) => Promise.t<unit> = "update"
+external update2: (mediaKeySession, ArrayBuffer.t) => promise<unit> = "update"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/close)
 */
 @send
-external close: mediaKeySession => Promise.t<unit> = "close"
+external close: mediaKeySession => promise<unit> = "close"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/remove)
 */
 @send
-external remove: mediaKeySession => Promise.t<unit> = "remove"
+external remove: mediaKeySession => promise<unit> = "remove"

--- a/src/EncryptedMediaExtensionsAPI/MediaKeySystemAccess.res
+++ b/src/EncryptedMediaExtensionsAPI/MediaKeySystemAccess.res
@@ -10,4 +10,4 @@ external getConfiguration: mediaKeySystemAccess => mediaKeySystemConfiguration =
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySystemAccess/createMediaKeys)
 */
 @send
-external createMediaKeys: mediaKeySystemAccess => Promise.t<mediaKeys> = "createMediaKeys"
+external createMediaKeys: mediaKeySystemAccess => promise<mediaKeys> = "createMediaKeys"

--- a/src/EncryptedMediaExtensionsAPI/MediaKeys.res
+++ b/src/EncryptedMediaExtensionsAPI/MediaKeys.res
@@ -11,18 +11,18 @@ external createSession: (mediaKeys, ~sessionType: mediaKeySessionType=?) => medi
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeys/getStatusForPolicy)
 */
 @send
-external getStatusForPolicy: (mediaKeys, ~policy: mediaKeysPolicy=?) => Promise.t<mediaKeyStatus> =
+external getStatusForPolicy: (mediaKeys, ~policy: mediaKeysPolicy=?) => promise<mediaKeyStatus> =
   "getStatusForPolicy"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeys/setServerCertificate)
 */
 @send
-external setServerCertificate: (mediaKeys, DataView.t) => Promise.t<bool> = "setServerCertificate"
+external setServerCertificate: (mediaKeys, DataView.t) => promise<bool> = "setServerCertificate"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeys/setServerCertificate)
 */
 @send
-external setServerCertificate2: (mediaKeys, ArrayBuffer.t) => Promise.t<bool> =
+external setServerCertificate2: (mediaKeys, ArrayBuffer.t) => promise<bool> =
   "setServerCertificate"

--- a/src/FetchAPI/Request.res
+++ b/src/FetchAPI/Request.res
@@ -18,37 +18,37 @@ external make2: (~input: string, ~init: requestInit=?) => request = "Request"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer)
 */
 @send
-external arrayBuffer: request => Promise.t<ArrayBuffer.t> = "arrayBuffer"
+external arrayBuffer: request => promise<ArrayBuffer.t> = "arrayBuffer"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/blob)
 */
 @send
-external blob: request => Promise.t<blob> = "blob"
+external blob: request => promise<blob> = "blob"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/bytes)
 */
 @send
-external bytes: request => Promise.t<array<int>> = "bytes"
+external bytes: request => promise<array<int>> = "bytes"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/formData)
 */
 @send
-external formData: request => Promise.t<formData> = "formData"
+external formData: request => promise<formData> = "formData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/json)
 */
 @send
-external json: request => Promise.t<JSON.t> = "json"
+external json: request => promise<JSON.t> = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/text)
 */
 @send
-external text: request => Promise.t<string> = "text"
+external text: request => promise<string> = "text"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/clone)

--- a/src/FetchAPI/Response.res
+++ b/src/FetchAPI/Response.res
@@ -48,37 +48,37 @@ external make7: (~body: string=?, ~init: responseInit=?) => response = "Response
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer)
 */
 @send
-external arrayBuffer: response => Promise.t<ArrayBuffer.t> = "arrayBuffer"
+external arrayBuffer: response => promise<ArrayBuffer.t> = "arrayBuffer"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/blob)
 */
 @send
-external blob: response => Promise.t<blob> = "blob"
+external blob: response => promise<blob> = "blob"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/bytes)
 */
 @send
-external bytes: response => Promise.t<array<int>> = "bytes"
+external bytes: response => promise<array<int>> = "bytes"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/formData)
 */
 @send
-external formData: response => Promise.t<formData> = "formData"
+external formData: response => promise<formData> = "formData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/json)
 */
 @send
-external json: response => Promise.t<JSON.t> = "json"
+external json: response => promise<JSON.t> = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/text)
 */
 @send
-external text: response => Promise.t<string> = "text"
+external text: response => promise<string> = "text"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/error_static)

--- a/src/FileAPI.res
+++ b/src/FileAPI.res
@@ -139,7 +139,7 @@ type writableStreamDefaultWriter<'t> = any
 
 type fileSystemWriteChunkType = any
 
-type underlyingSourceCancelCallback = JSON.t => Promise.t<unit>
+type underlyingSourceCancelCallback = JSON.t => promise<unit>
 
 type blobPropertyBag = {
   @as("type") mutable type_?: string,

--- a/src/FileAPI/Blob.res
+++ b/src/FileAPI/Blob.res
@@ -28,19 +28,19 @@ module Impl = (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob/text)
 */
   @send
-  external text: T.t => Promise.t<string> = "text"
+  external text: T.t => promise<string> = "text"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob/arrayBuffer)
 */
   @send
-  external arrayBuffer: T.t => Promise.t<ArrayBuffer.t> = "arrayBuffer"
+  external arrayBuffer: T.t => promise<ArrayBuffer.t> = "arrayBuffer"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob/bytes)
 */
   @send
-  external bytes: T.t => Promise.t<array<int>> = "bytes"
+  external bytes: T.t => promise<array<int>> = "bytes"
 }
 
 include Impl({

--- a/src/FileAPI/FileSystemDirectoryHandle.res
+++ b/src/FileAPI/FileSystemDirectoryHandle.res
@@ -5,7 +5,7 @@ external asFileSystemHandle: fileSystemDirectoryHandle => fileSystemHandle = "%i
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry)
 */
 @send
-external isSameEntry: (fileSystemDirectoryHandle, fileSystemHandle) => Promise.t<bool> =
+external isSameEntry: (fileSystemDirectoryHandle, fileSystemHandle) => promise<bool> =
   "isSameEntry"
 
 /**
@@ -16,7 +16,7 @@ external getFileHandle: (
   fileSystemDirectoryHandle,
   ~name: string,
   ~options: fileSystemGetFileOptions=?,
-) => Promise.t<fileSystemFileHandle> = "getFileHandle"
+) => promise<fileSystemFileHandle> = "getFileHandle"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/getDirectoryHandle)
@@ -26,7 +26,7 @@ external getDirectoryHandle: (
   fileSystemDirectoryHandle,
   ~name: string,
   ~options: fileSystemGetDirectoryOptions=?,
-) => Promise.t<fileSystemDirectoryHandle> = "getDirectoryHandle"
+) => promise<fileSystemDirectoryHandle> = "getDirectoryHandle"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/removeEntry)
@@ -36,11 +36,11 @@ external removeEntry: (
   fileSystemDirectoryHandle,
   ~name: string,
   ~options: fileSystemRemoveOptions=?,
-) => Promise.t<unit> = "removeEntry"
+) => promise<unit> = "removeEntry"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/resolve)
 */
 @send
-external resolve: (fileSystemDirectoryHandle, fileSystemHandle) => Promise.t<array<string>> =
+external resolve: (fileSystemDirectoryHandle, fileSystemHandle) => promise<array<string>> =
   "resolve"

--- a/src/FileAPI/FileSystemFileHandle.res
+++ b/src/FileAPI/FileSystemFileHandle.res
@@ -5,13 +5,13 @@ external asFileSystemHandle: fileSystemFileHandle => fileSystemHandle = "%identi
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry)
 */
 @send
-external isSameEntry: (fileSystemFileHandle, fileSystemHandle) => Promise.t<bool> = "isSameEntry"
+external isSameEntry: (fileSystemFileHandle, fileSystemHandle) => promise<bool> = "isSameEntry"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/getFile)
 */
 @send
-external getFile: fileSystemFileHandle => Promise.t<file> = "getFile"
+external getFile: fileSystemFileHandle => promise<file> = "getFile"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/createWritable)
@@ -20,4 +20,4 @@ external getFile: fileSystemFileHandle => Promise.t<file> = "getFile"
 external createWritable: (
   fileSystemFileHandle,
   ~options: fileSystemCreateWritableOptions=?,
-) => Promise.t<fileSystemWritableFileStream> = "createWritable"
+) => promise<fileSystemWritableFileStream> = "createWritable"

--- a/src/FileAPI/FileSystemHandle.res
+++ b/src/FileAPI/FileSystemHandle.res
@@ -4,4 +4,4 @@ open FileAPI
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry)
 */
 @send
-external isSameEntry: (fileSystemHandle, fileSystemHandle) => Promise.t<bool> = "isSameEntry"
+external isSameEntry: (fileSystemHandle, fileSystemHandle) => promise<bool> = "isSameEntry"

--- a/src/FileAPI/FileSystemWritableFileStream.res
+++ b/src/FileAPI/FileSystemWritableFileStream.res
@@ -6,13 +6,13 @@ external asWritableStream: fileSystemWritableFileStream => writableStream<'w> = 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/abort)
 */
 @send
-external abort: (fileSystemWritableFileStream, ~reason: JSON.t=?) => Promise.t<unit> = "abort"
+external abort: (fileSystemWritableFileStream, ~reason: JSON.t=?) => promise<unit> = "abort"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/close)
 */
 @send
-external close: fileSystemWritableFileStream => Promise.t<unit> = "close"
+external close: fileSystemWritableFileStream => promise<unit> = "close"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter)
@@ -24,40 +24,40 @@ external getWriter: fileSystemWritableFileStream => writableStreamDefaultWriter<
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write: (fileSystemWritableFileStream, DataView.t) => Promise.t<unit> = "write"
+external write: (fileSystemWritableFileStream, DataView.t) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write2: (fileSystemWritableFileStream, ArrayBuffer.t) => Promise.t<unit> = "write"
+external write2: (fileSystemWritableFileStream, ArrayBuffer.t) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write3: (fileSystemWritableFileStream, blob) => Promise.t<unit> = "write"
+external write3: (fileSystemWritableFileStream, blob) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write4: (fileSystemWritableFileStream, string) => Promise.t<unit> = "write"
+external write4: (fileSystemWritableFileStream, string) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write5: (fileSystemWritableFileStream, writeParams) => Promise.t<unit> = "write"
+external write5: (fileSystemWritableFileStream, writeParams) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/seek)
 */
 @send
-external seek: (fileSystemWritableFileStream, int) => Promise.t<unit> = "seek"
+external seek: (fileSystemWritableFileStream, int) => promise<unit> = "seek"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/truncate)
 */
 @send
-external truncate: (fileSystemWritableFileStream, int) => Promise.t<unit> = "truncate"
+external truncate: (fileSystemWritableFileStream, int) => promise<unit> = "truncate"

--- a/src/FileAPI/ReadableStream.res
+++ b/src/FileAPI/ReadableStream.res
@@ -23,7 +23,7 @@ external make3: unit => unknown = "ReadableStream"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/cancel)
 */
 @send
-external cancel: (readableStream<'r>, ~reason: JSON.t=?) => Promise.t<unit> = "cancel"
+external cancel: (readableStream<'r>, ~reason: JSON.t=?) => promise<unit> = "cancel"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader)
@@ -52,7 +52,7 @@ external pipeTo: (
   readableStream<'r>,
   ~destination: writableStream<'r>,
   ~options: streamPipeOptions=?,
-) => Promise.t<unit> = "pipeTo"
+) => promise<unit> = "pipeTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee)

--- a/src/FileAPI/WritableStream.res
+++ b/src/FileAPI/WritableStream.res
@@ -14,13 +14,13 @@ external make: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/abort)
 */
 @send
-external abort: (writableStream<'w>, ~reason: JSON.t=?) => Promise.t<unit> = "abort"
+external abort: (writableStream<'w>, ~reason: JSON.t=?) => promise<unit> = "abort"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/close)
 */
 @send
-external close: writableStream<'w> => Promise.t<unit> = "close"
+external close: writableStream<'w> => promise<unit> = "close"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter)

--- a/src/GamepadAPI/GamepadHapticActuator.res
+++ b/src/GamepadAPI/GamepadHapticActuator.res
@@ -8,10 +8,10 @@ external playEffect: (
   gamepadHapticActuator,
   ~type_: gamepadHapticEffectType,
   ~params: gamepadEffectParameters=?,
-) => Promise.t<gamepadHapticsResult> = "playEffect"
+) => promise<gamepadHapticsResult> = "playEffect"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator/reset)
 */
 @send
-external reset: gamepadHapticActuator => Promise.t<gamepadHapticsResult> = "reset"
+external reset: gamepadHapticActuator => promise<gamepadHapticsResult> = "reset"

--- a/src/Global.res
+++ b/src/Global.res
@@ -300,7 +300,7 @@ external queueMicrotask: voidFunction => unit = "queueMicrotask"
 external createImageBitmap: (
   ~image: htmlImageElement,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -308,7 +308,7 @@ external createImageBitmap: (
 external createImageBitmap2: (
   ~image: svgImageElement,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -316,7 +316,7 @@ external createImageBitmap2: (
 external createImageBitmap3: (
   ~image: htmlVideoElement,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -324,7 +324,7 @@ external createImageBitmap3: (
 external createImageBitmap4: (
   ~image: htmlCanvasElement,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -332,7 +332,7 @@ external createImageBitmap4: (
 external createImageBitmap5: (
   ~image: imageBitmap,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -340,7 +340,7 @@ external createImageBitmap5: (
 external createImageBitmap6: (
   ~image: offscreenCanvas,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -348,7 +348,7 @@ external createImageBitmap6: (
 external createImageBitmap7: (
   ~image: videoFrame,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -356,7 +356,7 @@ external createImageBitmap7: (
 external createImageBitmap8: (
   ~image: blob,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -364,7 +364,7 @@ external createImageBitmap8: (
 external createImageBitmap9: (
   ~image: imageData,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -376,7 +376,7 @@ external createImageBitmap10: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -388,7 +388,7 @@ external createImageBitmap11: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -400,7 +400,7 @@ external createImageBitmap12: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -412,7 +412,7 @@ external createImageBitmap13: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -424,7 +424,7 @@ external createImageBitmap14: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -436,7 +436,7 @@ external createImageBitmap15: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -448,7 +448,7 @@ external createImageBitmap16: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -460,7 +460,7 @@ external createImageBitmap17: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
@@ -472,7 +472,7 @@ external createImageBitmap18: (
   ~sw: int,
   ~sh: int,
   ~options: imageBitmapOptions=?,
-) => Promise.t<imageBitmap> = "createImageBitmap"
+) => promise<imageBitmap> = "createImageBitmap"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/structuredClone)
@@ -491,7 +491,7 @@ let response = await fetch("https://rescript-lang.org")
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
-external fetch: (string, ~init: requestInit=?) => Promise.t<response> = "fetch"
+external fetch: (string, ~init: requestInit=?) => promise<response> = "fetch"
 
 /**
 `fetch_withRequest(request, init)`
@@ -506,7 +506,7 @@ let response = await fetch(myRequest)
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
 @send
-external fetch_withRequest: (request, ~init: requestInit=?) => Promise.t<response> = "fetch"
+external fetch_withRequest: (request, ~init: requestInit=?) => promise<response> = "fetch"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)

--- a/src/IndexedDBAPI/IDBFactory.res
+++ b/src/IndexedDBAPI/IDBFactory.res
@@ -19,7 +19,7 @@ external deleteDatabase: (idbFactory, string) => idbOpenDBRequest = "deleteDatab
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBFactory/databases)
 */
 @send
-external databases: idbFactory => Promise.t<array<idbDatabaseInfo>> = "databases"
+external databases: idbFactory => promise<array<idbDatabaseInfo>> = "databases"
 
 /**
 Compares two values as keys. Returns -1 if key1 precedes key2, 1 if key2 precedes key1, and 0 if the keys are equal.

--- a/src/MediaCapabilitiesAPI/MediaCapabilities.res
+++ b/src/MediaCapabilitiesAPI/MediaCapabilities.res
@@ -7,7 +7,7 @@ open MediaCapabilitiesAPI
 external decodingInfo: (
   mediaCapabilities,
   mediaDecodingConfiguration,
-) => Promise.t<mediaCapabilitiesDecodingInfo> = "decodingInfo"
+) => promise<mediaCapabilitiesDecodingInfo> = "decodingInfo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo)
@@ -16,4 +16,4 @@ external decodingInfo: (
 external encodingInfo: (
   mediaCapabilities,
   mediaEncodingConfiguration,
-) => Promise.t<mediaCapabilitiesEncodingInfo> = "encodingInfo"
+) => promise<mediaCapabilitiesEncodingInfo> = "encodingInfo"

--- a/src/MediaCaptureAndStreamsAPI/MediaDevices.res
+++ b/src/MediaCaptureAndStreamsAPI/MediaDevices.res
@@ -9,7 +9,7 @@ include EventTarget.Impl({
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaDevices/enumerateDevices)
 */
 @send
-external enumerateDevices: mediaDevices => Promise.t<array<mediaDeviceInfo>> = "enumerateDevices"
+external enumerateDevices: mediaDevices => promise<array<mediaDeviceInfo>> = "enumerateDevices"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaDevices/getSupportedConstraints)
@@ -25,7 +25,7 @@ external getSupportedConstraints: mediaDevices => mediaTrackSupportedConstraints
 external getUserMedia: (
   mediaDevices,
   ~constraints: mediaStreamConstraints=?,
-) => Promise.t<mediaStream> = "getUserMedia"
+) => promise<mediaStream> = "getUserMedia"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia)
@@ -34,4 +34,4 @@ external getUserMedia: (
 external getDisplayMedia: (
   mediaDevices,
   ~options: displayMediaStreamOptions=?,
-) => Promise.t<mediaStream> = "getDisplayMedia"
+) => promise<mediaStream> = "getDisplayMedia"

--- a/src/MediaCaptureAndStreamsAPI/MediaStreamTrack.res
+++ b/src/MediaCaptureAndStreamsAPI/MediaStreamTrack.res
@@ -41,4 +41,4 @@ external getSettings: mediaStreamTrack => mediaTrackSettings = "getSettings"
 external applyConstraints: (
   mediaStreamTrack,
   ~constraints: mediaTrackConstraints=?,
-) => Promise.t<unit> = "applyConstraints"
+) => promise<unit> = "applyConstraints"

--- a/src/NotificationAPI/Notification.res
+++ b/src/NotificationAPI/Notification.res
@@ -16,7 +16,7 @@ include EventTarget.Impl({
 @scope("Notification")
 external requestPermission: (
   ~deprecatedCallback: notificationPermissionCallback=?,
-) => Promise.t<notificationPermission> = "requestPermission"
+) => promise<notificationPermission> = "requestPermission"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Notification/close)

--- a/src/PermissionsAPI/Permissions.res
+++ b/src/PermissionsAPI/Permissions.res
@@ -4,4 +4,4 @@ open PermissionsAPI
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Permissions/query)
 */
 @send
-external query: (permissions, permissionDescriptor) => Promise.t<permissionStatus> = "query"
+external query: (permissions, permissionDescriptor) => promise<permissionStatus> = "query"

--- a/src/PushManagerAPI/PushManager.res
+++ b/src/PushManagerAPI/PushManager.res
@@ -7,13 +7,13 @@ open PushManagerAPI
 external subscribe: (
   pushManager,
   ~options: pushSubscriptionOptionsInit=?,
-) => Promise.t<pushSubscription> = "subscribe"
+) => promise<pushSubscription> = "subscribe"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushManager/getSubscription)
 */
 @send
-external getSubscription: pushManager => Promise.t<pushSubscription> = "getSubscription"
+external getSubscription: pushManager => promise<pushSubscription> = "getSubscription"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushManager/permissionState)
@@ -22,4 +22,4 @@ external getSubscription: pushManager => Promise.t<pushSubscription> = "getSubsc
 external permissionState: (
   pushManager,
   ~options: pushSubscriptionOptionsInit=?,
-) => Promise.t<permissionState> = "permissionState"
+) => promise<permissionState> = "permissionState"

--- a/src/PushManagerAPI/PushSubscription.res
+++ b/src/PushManagerAPI/PushSubscription.res
@@ -10,7 +10,7 @@ external getKey: (pushSubscription, pushEncryptionKeyName) => ArrayBuffer.t = "g
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushSubscription/unsubscribe)
 */
 @send
-external unsubscribe: pushSubscription => Promise.t<bool> = "unsubscribe"
+external unsubscribe: pushSubscription => promise<bool> = "unsubscribe"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushSubscription/toJSON)

--- a/src/RemotePlaybackAPI/RemotePlayback.res
+++ b/src/RemotePlaybackAPI/RemotePlayback.res
@@ -8,18 +8,18 @@ include EventTarget.Impl({
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/RemotePlayback/watchAvailability)
 */
 @send
-external watchAvailability: (remotePlayback, remotePlaybackAvailabilityCallback) => Promise.t<int> =
+external watchAvailability: (remotePlayback, remotePlaybackAvailabilityCallback) => promise<int> =
   "watchAvailability"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/RemotePlayback/cancelWatchAvailability)
 */
 @send
-external cancelWatchAvailability: (remotePlayback, ~id: int=?) => Promise.t<unit> =
+external cancelWatchAvailability: (remotePlayback, ~id: int=?) => promise<unit> =
   "cancelWatchAvailability"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/RemotePlayback/prompt)
 */
 @send
-external prompt: remotePlayback => Promise.t<unit> = "prompt"
+external prompt: remotePlayback => promise<unit> = "prompt"

--- a/src/ScreenWakeLockAPI/WakeLock.res
+++ b/src/ScreenWakeLockAPI/WakeLock.res
@@ -4,4 +4,4 @@ open ScreenWakeLockAPI
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WakeLock/request)
 */
 @send
-external request: (wakeLock, ~type_: wakeLockType=?) => Promise.t<wakeLockSentinel> = "request"
+external request: (wakeLock, ~type_: wakeLockType=?) => promise<wakeLockSentinel> = "request"

--- a/src/ScreenWakeLockAPI/WakeLockSentinel.res
+++ b/src/ScreenWakeLockAPI/WakeLockSentinel.res
@@ -9,4 +9,4 @@ include EventTarget.Impl({
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/release)
 */
 @send
-external release: wakeLockSentinel => Promise.t<unit> = "release"
+external release: wakeLockSentinel => promise<unit> = "release"

--- a/src/ServiceWorkerAPI.res
+++ b/src/ServiceWorkerAPI.res
@@ -94,7 +94,7 @@ type serviceWorkerContainer = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/ready)
     */
-  ready: Promise.t<serviceWorkerRegistration>,
+  ready: promise<serviceWorkerRegistration>,
 }
 
 /**

--- a/src/ServiceWorkerAPI/Cache.res
+++ b/src/ServiceWorkerAPI/Cache.res
@@ -23,7 +23,7 @@ external matchAll: (
   cache,
   ~request: request=?,
   ~options: cacheQueryOptions=?,
-) => Promise.t<array<response>> = "matchAll"
+) => promise<array<response>> = "matchAll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/matchAll)
@@ -33,50 +33,50 @@ external matchAll2: (
   cache,
   ~request: string=?,
   ~options: cacheQueryOptions=?,
-) => Promise.t<array<response>> = "matchAll"
+) => promise<array<response>> = "matchAll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/add)
 */
 @send
-external add: (cache, request) => Promise.t<unit> = "add"
+external add: (cache, request) => promise<unit> = "add"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/add)
 */
 @send
-external add2: (cache, string) => Promise.t<unit> = "add"
+external add2: (cache, string) => promise<unit> = "add"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/addAll)
 */
 @send
-external addAll: (cache, array<requestInfo>) => Promise.t<unit> = "addAll"
+external addAll: (cache, array<requestInfo>) => promise<unit> = "addAll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/put)
 */
 @send
-external put: (cache, ~request: request, ~response: response) => Promise.t<unit> = "put"
+external put: (cache, ~request: request, ~response: response) => promise<unit> = "put"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/put)
 */
 @send
-external put2: (cache, ~request: string, ~response: response) => Promise.t<unit> = "put"
+external put2: (cache, ~request: string, ~response: response) => promise<unit> = "put"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/delete)
 */
 @send
-external delete: (cache, ~request: request, ~options: cacheQueryOptions=?) => Promise.t<bool> =
+external delete: (cache, ~request: request, ~options: cacheQueryOptions=?) => promise<bool> =
   "delete"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/delete)
 */
 @send
-external delete2: (cache, ~request: string, ~options: cacheQueryOptions=?) => Promise.t<bool> =
+external delete2: (cache, ~request: string, ~options: cacheQueryOptions=?) => promise<bool> =
   "delete"
 
 /**
@@ -87,7 +87,7 @@ external keys: (
   cache,
   ~request: request=?,
   ~options: cacheQueryOptions=?,
-) => Promise.t<array<request>> = "keys"
+) => promise<array<request>> = "keys"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/keys)
@@ -97,4 +97,4 @@ external keys2: (
   cache,
   ~request: string=?,
   ~options: cacheQueryOptions=?,
-) => Promise.t<array<request>> = "keys"
+) => promise<array<request>> = "keys"

--- a/src/ServiceWorkerAPI/CacheStorage.res
+++ b/src/ServiceWorkerAPI/CacheStorage.res
@@ -25,22 +25,22 @@ external match2: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CacheStorage/has)
 */
 @send
-external has: (cacheStorage, string) => Promise.t<bool> = "has"
+external has: (cacheStorage, string) => promise<bool> = "has"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CacheStorage/open)
 */
 @send
-external open_: (cacheStorage, string) => Promise.t<cache> = "open"
+external open_: (cacheStorage, string) => promise<cache> = "open"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CacheStorage/delete)
 */
 @send
-external delete: (cacheStorage, string) => Promise.t<bool> = "delete"
+external delete: (cacheStorage, string) => promise<bool> = "delete"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CacheStorage/keys)
 */
 @send
-external keys: cacheStorage => Promise.t<array<string>> = "keys"
+external keys: cacheStorage => promise<array<string>> = "keys"

--- a/src/ServiceWorkerAPI/NavigationPreloadManager.res
+++ b/src/ServiceWorkerAPI/NavigationPreloadManager.res
@@ -4,22 +4,22 @@ open ServiceWorkerAPI
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/enable)
 */
 @send
-external enable: navigationPreloadManager => Promise.t<unit> = "enable"
+external enable: navigationPreloadManager => promise<unit> = "enable"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/disable)
 */
 @send
-external disable: navigationPreloadManager => Promise.t<unit> = "disable"
+external disable: navigationPreloadManager => promise<unit> = "disable"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/setHeaderValue)
 */
 @send
-external setHeaderValue: (navigationPreloadManager, string) => Promise.t<unit> = "setHeaderValue"
+external setHeaderValue: (navigationPreloadManager, string) => promise<unit> = "setHeaderValue"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/getState)
 */
 @send
-external getState: navigationPreloadManager => Promise.t<navigationPreloadState> = "getState"
+external getState: navigationPreloadManager => promise<navigationPreloadState> = "getState"

--- a/src/ServiceWorkerAPI/ServiceWorkerContainer.res
+++ b/src/ServiceWorkerAPI/ServiceWorkerContainer.res
@@ -13,7 +13,7 @@ external register: (
   serviceWorkerContainer,
   ~scriptURL: string,
   ~options: registrationOptions=?,
-) => Promise.t<serviceWorkerRegistration> = "register"
+) => promise<serviceWorkerRegistration> = "register"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/getRegistration)
@@ -28,7 +28,7 @@ external getRegistration: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/getRegistrations)
 */
 @send
-external getRegistrations: serviceWorkerContainer => Promise.t<array<serviceWorkerRegistration>> =
+external getRegistrations: serviceWorkerContainer => promise<array<serviceWorkerRegistration>> =
   "getRegistrations"
 
 /**

--- a/src/ServiceWorkerAPI/ServiceWorkerRegistration.res
+++ b/src/ServiceWorkerAPI/ServiceWorkerRegistration.res
@@ -10,13 +10,13 @@ include EventTarget.Impl({
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/update)
 */
 @send
-external update: serviceWorkerRegistration => Promise.t<unit> = "update"
+external update: serviceWorkerRegistration => promise<unit> = "update"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/unregister)
 */
 @send
-external unregister: serviceWorkerRegistration => Promise.t<bool> = "unregister"
+external unregister: serviceWorkerRegistration => promise<bool> = "unregister"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/showNotification)
@@ -26,7 +26,7 @@ external showNotification: (
   serviceWorkerRegistration,
   ~title: string,
   ~options: notificationOptions=?,
-) => Promise.t<unit> = "showNotification"
+) => promise<unit> = "showNotification"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/getNotifications)
@@ -35,4 +35,4 @@ external showNotification: (
 external getNotifications: (
   serviceWorkerRegistration,
   ~filter: getNotificationOptions=?,
-) => Promise.t<array<notification>> = "getNotifications"
+) => promise<array<notification>> = "getNotifications"

--- a/src/StorageAPI/StorageManager.res
+++ b/src/StorageAPI/StorageManager.res
@@ -5,22 +5,22 @@ open FileAPI
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StorageManager/persisted)
 */
 @send
-external persisted: storageManager => Promise.t<bool> = "persisted"
+external persisted: storageManager => promise<bool> = "persisted"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StorageManager/persist)
 */
 @send
-external persist: storageManager => Promise.t<bool> = "persist"
+external persist: storageManager => promise<bool> = "persist"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StorageManager/estimate)
 */
 @send
-external estimate: storageManager => Promise.t<storageEstimate> = "estimate"
+external estimate: storageManager => promise<storageEstimate> = "estimate"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StorageManager/getDirectory)
 */
 @send
-external getDirectory: storageManager => Promise.t<fileSystemDirectoryHandle> = "getDirectory"
+external getDirectory: storageManager => promise<fileSystemDirectoryHandle> = "getDirectory"

--- a/src/ViewTransitionsAPI.res
+++ b/src/ViewTransitionsAPI.res
@@ -9,15 +9,15 @@ type viewTransition = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ViewTransition/updateCallbackDone)
     */
-  updateCallbackDone: Promise.t<unit>,
+  updateCallbackDone: promise<unit>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ViewTransition/ready)
     */
-  ready: Promise.t<unit>,
+  ready: promise<unit>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ViewTransition/finished)
     */
-  finished: Promise.t<unit>,
+  finished: promise<unit>,
 }
 
-type viewTransitionUpdateCallback = Promise.t<JSON.t>
+type viewTransitionUpdateCallback = promise<JSON.t>

--- a/src/WebAudioAPI/AudioContext.res
+++ b/src/WebAudioAPI/AudioContext.res
@@ -22,19 +22,19 @@ external getOutputTimestamp: audioContext => audioTimestamp = "getOutputTimestam
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/resume)
 */
 @send
-external resume: audioContext => Promise.t<unit> = "resume"
+external resume: audioContext => promise<unit> = "resume"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/suspend)
 */
 @send
-external suspend: audioContext => Promise.t<unit> = "suspend"
+external suspend: audioContext => promise<unit> = "suspend"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/close)
 */
 @send
-external close: audioContext => Promise.t<unit> = "close"
+external close: audioContext => promise<unit> = "close"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaElementSource)

--- a/src/WebAudioAPI/BaseAudioContext.res
+++ b/src/WebAudioAPI/BaseAudioContext.res
@@ -138,5 +138,5 @@ module Impl = (
     ~audioData: ArrayBuffer.t,
     ~successCallback: decodeSuccessCallback=?,
     ~errorCallback: decodeErrorCallback=?,
-  ) => Promise.t<audioBuffer> = "decodeAudioData"
+  ) => promise<audioBuffer> = "decodeAudioData"
 }

--- a/src/WebAudioAPI/OfflineAudioContext.res
+++ b/src/WebAudioAPI/OfflineAudioContext.res
@@ -21,16 +21,16 @@ external make2: (~numberOfChannels: int, ~length: int, ~sampleRate: float) => of
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/startRendering)
 */
 @send
-external startRendering: offlineAudioContext => Promise.t<audioBuffer> = "startRendering"
+external startRendering: offlineAudioContext => promise<audioBuffer> = "startRendering"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/resume)
 */
 @send
-external resume: offlineAudioContext => Promise.t<unit> = "resume"
+external resume: offlineAudioContext => promise<unit> = "resume"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/suspend)
 */
 @send
-external suspend: (offlineAudioContext, float) => Promise.t<unit> = "suspend"
+external suspend: (offlineAudioContext, float) => promise<unit> = "suspend"

--- a/src/WebAudioAPI/Worklet.res
+++ b/src/WebAudioAPI/Worklet.res
@@ -9,5 +9,5 @@ Any failures in fetching the script or its dependencies will cause the returned 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Worklet/addModule)
 */
 @send
-external addModule: (worklet, ~moduleURL: string, ~options: workletOptions=?) => Promise.t<unit> =
+external addModule: (worklet, ~moduleURL: string, ~options: workletOptions=?) => promise<unit> =
   "addModule"

--- a/src/WebCryptoAPI/SubtleCrypto.res
+++ b/src/WebCryptoAPI/SubtleCrypto.res
@@ -10,7 +10,7 @@ external encrypt: (
   ~algorithm: algorithmIdentifier,
   ~key: cryptoKey,
   ~data: bufferSource,
-) => Promise.t<ArrayBuffer.t> = "encrypt"
+) => promise<ArrayBuffer.t> = "encrypt"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt)
@@ -21,7 +21,7 @@ external decrypt: (
   ~algorithm: algorithmIdentifier,
   ~key: cryptoKey,
   ~data: bufferSource,
-) => Promise.t<ArrayBuffer.t> = "decrypt"
+) => promise<ArrayBuffer.t> = "decrypt"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign)
@@ -32,7 +32,7 @@ external sign: (
   ~algorithm: algorithmIdentifier,
   ~key: cryptoKey,
   ~data: bufferSource,
-) => Promise.t<JSON.t> = "sign"
+) => promise<JSON.t> = "sign"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify)
@@ -44,7 +44,7 @@ external verify: (
   ~key: cryptoKey,
   ~signature: bufferSource,
   ~data: bufferSource,
-) => Promise.t<JSON.t> = "verify"
+) => promise<JSON.t> = "verify"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/digest)
@@ -54,7 +54,7 @@ external digest: (
   subtleCrypto,
   ~algorithm: algorithmIdentifier,
   ~data: bufferSource,
-) => Promise.t<JSON.t> = "digest"
+) => promise<JSON.t> = "digest"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey)
@@ -65,7 +65,7 @@ external generateKey: (
   ~algorithm: algorithm,
   ~extractable: bool,
   ~keyUsages: array<keyUsage>,
-) => Promise.t<JSON.t> = "generateKey"
+) => promise<JSON.t> = "generateKey"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey)
@@ -76,7 +76,7 @@ external generateKey2: (
   ~algorithm: string,
   ~extractable: bool,
   ~keyUsages: array<keyUsage>,
-) => Promise.t<JSON.t> = "generateKey"
+) => promise<JSON.t> = "generateKey"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey)
@@ -89,7 +89,7 @@ external deriveKey: (
   ~derivedKeyType: algorithmIdentifier,
   ~extractable: bool,
   ~keyUsages: array<keyUsage>,
-) => Promise.t<JSON.t> = "deriveKey"
+) => promise<JSON.t> = "deriveKey"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits)
@@ -100,7 +100,7 @@ external deriveBits: (
   ~algorithm: algorithm,
   ~baseKey: cryptoKey,
   ~length: int=?,
-) => Promise.t<ArrayBuffer.t> = "deriveBits"
+) => promise<ArrayBuffer.t> = "deriveBits"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits)
@@ -111,7 +111,7 @@ external deriveBits2: (
   ~algorithm: string,
   ~baseKey: cryptoKey,
   ~length: int=?,
-) => Promise.t<ArrayBuffer.t> = "deriveBits"
+) => promise<ArrayBuffer.t> = "deriveBits"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey)
@@ -124,13 +124,13 @@ external importKey: (
   ~algorithm: algorithmIdentifier,
   ~extractable: bool,
   ~keyUsages: array<keyUsage>,
-) => Promise.t<cryptoKey> = "importKey"
+) => promise<cryptoKey> = "importKey"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey)
 */
 @send
-external exportKey: (subtleCrypto, ~format: keyFormat, ~key: cryptoKey) => Promise.t<JSON.t> =
+external exportKey: (subtleCrypto, ~format: keyFormat, ~key: cryptoKey) => promise<JSON.t> =
   "exportKey"
 
 /**
@@ -143,7 +143,7 @@ external wrapKey: (
   ~key: cryptoKey,
   ~wrappingKey: cryptoKey,
   ~wrapAlgorithm: algorithm,
-) => Promise.t<JSON.t> = "wrapKey"
+) => promise<JSON.t> = "wrapKey"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey)
@@ -155,7 +155,7 @@ external wrapKey2: (
   ~key: cryptoKey,
   ~wrappingKey: cryptoKey,
   ~wrapAlgorithm: string,
-) => Promise.t<JSON.t> = "wrapKey"
+) => promise<JSON.t> = "wrapKey"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/unwrapKey)
@@ -170,4 +170,4 @@ external unwrapKey: (
   ~unwrappedKeyAlgorithm: algorithmIdentifier,
   ~extractable: bool,
   ~keyUsages: array<keyUsage>,
-) => Promise.t<cryptoKey> = "unwrapKey"
+) => promise<cryptoKey> = "unwrapKey"

--- a/src/WebLocksAPI.res
+++ b/src/WebLocksAPI.res
@@ -44,4 +44,4 @@ type lockOptions = {
   mutable signal?: abortSignal,
 }
 
-type lockGrantedCallback = lock => Promise.t<JSON.t>
+type lockGrantedCallback = lock => promise<JSON.t>

--- a/src/WebLocksAPI/LockManager.res
+++ b/src/WebLocksAPI/LockManager.res
@@ -9,7 +9,7 @@ external request: (
   lockManager,
   ~name: string,
   ~callback: lockGrantedCallback,
-) => Promise.t<JSON.t> = "request"
+) => promise<JSON.t> = "request"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/LockManager/request)
@@ -20,10 +20,10 @@ external request2: (
   ~name: string,
   ~options: lockOptions,
   ~callback: lockGrantedCallback,
-) => Promise.t<JSON.t> = "request"
+) => promise<JSON.t> = "request"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/LockManager/query)
 */
 @send
-external query: lockManager => Promise.t<lockManagerSnapshot> = "query"
+external query: lockManager => promise<lockManagerSnapshot> = "query"

--- a/tools/TypeScript-DOM-lib-generator/src/build/emitter.ts
+++ b/tools/TypeScript-DOM-lib-generator/src/build/emitter.ts
@@ -465,7 +465,7 @@ export async function emitRescriptBindings(webidl: Browser.WebIdl) {
         return "array<clipboardItem>";
 
       case "Promise":
-        return "Promise.t";
+        return "promise";
 
       case "ArrayBuffer":
         return "ArrayBuffer.t";


### PR DESCRIPTION
Directly use the built-in type `promise` instead of the alias `Promise.t` everywhere.