### PR TITLE
Add group for documentation packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      astro-and-starlight:
+        patterns:
+          - "astro"
+          - "@astrojs/starlight"


### PR DESCRIPTION
This tells Dependabot to always bundle astro and starlight