### PR TITLE
Fixed type constraint for AudioScheduledSourceNode's implementation

### DIFF
--- a/src/WebAudioAPI/AudioScheduledSourceNode.res
+++ b/src/WebAudioAPI/AudioScheduledSourceNode.res
@@ -6,7 +6,7 @@ module Impl = (
   },
 ) => {
   include AudioNode.Impl({
-    type t = audioScheduledSourceNode
+    type t = T.t
   })
 
   external asAudioScheduledSourceNode: T.t => audioScheduledSourceNode = "%identity"


### PR DESCRIPTION
This gives subclasses of AudioScheduledSourceNode access to functions from the full inheritance chain