### PR TITLE
Improve setTimeout ergonomics

### DIFF
--- a/src/DOMAPI.res
+++ b/src/DOMAPI.res
@@ -9917,3 +9917,5 @@ type blobCallback = blob => unit
 type videoFrameRequestCallback = float => videoFrameCallbackMetadata => unit
 
 type frameRequestCallback = float => unit
+
+type timeoutId

--- a/src/DOMAPI/Window.res
+++ b/src/DOMAPI/Window.res
@@ -27,22 +27,20 @@ external btoa: (window, string) => string = "btoa"
 external atob: (window, string) => string = "atob"
 
 /**
+Executes a function after a delay given in milliseconds expires.
+
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setTimeout)
 */
 @send
-external setTimeout: (window, ~handler: string, ~timeout: int=?) => int = "setTimeout"
+external setTimeout: (window, ~handler: unit => unit, ~timeout: int=?) => timeoutId = "setTimeout"
 
 /**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setTimeout)
-*/
-@send
-external setTimeout2: (window, ~handler: unit => unit, ~timeout: int=?) => int = "setTimeout"
+Cancels the execution of a timeout created with setTimeout.
 
-/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/clearTimeout)
 */
 @send
-external clearTimeout: (window, int) => unit = "clearTimeout"
+external clearTimeout: (window, timeoutId) => unit = "clearTimeout"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setInterval)

--- a/src/Global.res
+++ b/src/Global.res
@@ -260,19 +260,18 @@ external btoa: string => string = "btoa"
 external atob: string => string = "atob"
 
 /**
+Executes a function after a delay given in milliseconds expires.
+
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setTimeout)
 */
-external setTimeout: (~handler: string, ~timeout: int=?) => int = "setTimeout"
+external setTimeout: (~handler: unit => unit, ~timeout: int=?) => timeoutId = "setTimeout"
 
 /**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setTimeout)
-*/
-external setTimeout2: (~handler: unit => unit, ~timeout: int=?) => int = "setTimeout"
+Cancels the execution of a timeout created with setTimeout.
 
-/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/clearTimeout)
 */
-external clearTimeout: int => unit = "clearTimeout"
+external clearTimeout: timeoutId => unit = "clearTimeout"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setInterval)


### PR DESCRIPTION
This draft proposes a very conservative change to improve timeout-related bindings, but is mostly meant to help me align with the project's strategy:

- Do we want to remove the possibility of calling `setTimeout` with a string altogether, as suggested in #27?
- Should we introduce a `timeoutId` phantom type like in the Core library? If so, should we make use of the existing one or should we declare our own in a place like DOMAPI.res (which makes my editor crash btw)?
- Do we want to allow float timeouts like Core? [This Stackoverflow thread](https://stackoverflow.com/questions/7286178/does-settimeout-in-javascript-accept-real-floating-point-delay-times) suggests that `setTimeout`'s behaviour with floats isn't specified and thus could be inconsistent across runtimes.