### PR TITLE
Rename _useCapture

### DIFF
--- a/docs/content/docs/contributing/api-modelling.mdx
+++ b/docs/content/docs/contributing/api-modelling.mdx
@@ -48,7 +48,7 @@ We can use [a fixed argument](https://rescript-lang.org/docs/manual/latest/bind-
 
 ```ReScript
 @send
-external addEventListener_useCapture: (
+external addEventListenerWithCapture: (
   htmlButtonElement,
   ~type_: eventType,
   ~callback: eventListener<'event>,
@@ -56,11 +56,7 @@ external addEventListener_useCapture: (
 ) => unit = "addEventListener"
 ```
 
-<Aside type="caution" title="Improving methods">
-  Be aware that inherited interfaces duplicate their inherited methods. This
-  means that improving `addEventListener` in the `EventTarget` interface
-  requires to update all interfaces that inherit from `EventTarget`.
-</Aside>
+When naming an overloaded function, we can use the `With` suffix to indicate that it is an overloaded function.
 
 ### Decoded variants
 

--- a/src/EventAPI/EventTarget.res
+++ b/src/EventAPI/EventTarget.res
@@ -54,7 +54,7 @@ The event listener is appended to target's event listener list and is not append
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
 */
   @send
-  external addEventListener_useCapture: (
+  external addEventListenerWithCapture: (
     T.t,
     eventType,
     eventListener<'event>,

--- a/src/Global.res
+++ b/src/Global.res
@@ -554,7 +554,7 @@ If an AbortSignal is passed for options's signal, then the event listener will b
 The event listener is appended to target's event listener list and is not appended if it has the same type, callback, and capture.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
 */
-external addEventListener_useCapture: (
+external addEventListenerWithCapture: (
   eventType,
   eventListener<'event>,
   @as(json`true`) _,


### PR DESCRIPTION
The `_` is not really a ReScript convention.