### PR TITLE
Remove underscores

### DIFF
--- a/docs/content/docs/contributing/code-generation.mdx
+++ b/docs/content/docs/contributing/code-generation.mdx
@@ -29,7 +29,7 @@ external fetch2: (window, ~input: string, ~init: requestInit=?)
 While not that bad and usable, it can be improved:
 
 - Rename `fetch2` to `fetch` because it is the more common usage of the function.
-- Rename `fetch` to `fetch_with_request` for clarity that this is the "overload" with a `Request` object.
+- Rename `fetch` to `fetchWithRequest` for clarity that this is the "overload" with a `Request` object.
 - Consider removing the named `~input` and `~init` arguments and use positional arguments instead.
   Motivation: If the function does not have any parameters with the same type, it is more ergonomic to use positional arguments.
   This heuristic is not set in stone and can be adjusted based on the specific function.
@@ -43,7 +43,7 @@ external fetch: (window, string, ~init: requestInit=?)
 
 /** TODO: add better docs */
 @send
-external fetch_withRequest: (window, request, ~init: requestInit=?)
+external fetchWithRequest: (window, request, ~init: requestInit=?)
   => promise<response> = "fetch"
 ```
 

--- a/src/DOMAPI/Element.res
+++ b/src/DOMAPI/Element.res
@@ -419,13 +419,13 @@ element->Element.scrollIntoView_alignToTop()
 Scrolls the element's ancestor containers such that the element on which scrollIntoView() is called is visible to the user.
 
 ```res
-element->Element.scrollIntoView_withOptions({ behavior: DOMAPI.Smooth })
+element->Element.scrollIntoViewWithOptions({ behavior: DOMAPI.Smooth })
 ```
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollIntoView)
 */
   @send
-  external scrollIntoView_withOptions: (T.t, scrollIntoViewOptions) => unit = "scrollIntoView"
+  external scrollIntoViewWithOptions: (T.t, scrollIntoViewOptions) => unit = "scrollIntoView"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollTo)

--- a/src/DOMAPI/Window.res
+++ b/src/DOMAPI/Window.res
@@ -303,7 +303,7 @@ let response = await window->Window.fetch("https://rescript-lang.org")
 external fetch: (window, string, ~init: requestInit=?) => promise<response> = "fetch"
 
 /**
-`fetch_withRequest(window, request, init)`
+`fetchWithRequest(window, request, init)`
 
 Starts the process of fetching a resource from the network,
 returning a promise that is fulfilled once the response is available.
@@ -314,7 +314,7 @@ let response = await window->Window.fetch(myRequest)
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
 @send
-external fetch_withRequest: (window, request, ~init: requestInit=?) => promise<response> = "fetch"
+external fetchWithRequest: (window, request, ~init: requestInit=?) => promise<response> = "fetch"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)

--- a/src/Global.res
+++ b/src/Global.res
@@ -493,7 +493,7 @@ let response = await fetch("https://rescript-lang.org")
 external fetch: (string, ~init: requestInit=?) => promise<response> = "fetch"
 
 /**
-`fetch_withRequest(request, init)`
+`fetchWithRequest(request, init)`
 
 Starts the process of fetching a resource from the network,
 returning a promise that is fulfilled once the response is available.
@@ -504,7 +504,7 @@ let response = await fetch(myRequest)
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
-external fetch_withRequest: (request, ~init: requestInit=?) => promise<response> = "fetch"
+external fetchWithRequest: (request, ~init: requestInit=?) => promise<response> = "fetch"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)

--- a/src/WebWorkersAPI/WorkerGlobalScope.res
+++ b/src/WebWorkersAPI/WorkerGlobalScope.res
@@ -24,7 +24,7 @@ let response = await self->WorkerGlobalScope.fetch("https://rescript-lang.org")
   external fetch: (T.t, string, ~init: requestInit=?) => promise<response> = "fetch"
 
   /**
-`fetch_withRequest(workerGlobalScope, request, init)`
+`fetchWithRequest(workerGlobalScope, request, init)`
 
 The fetch() method of the WorkerGlobalScope interface starts the process of fetching a resource from the network, 
 returning a promise that is fulfilled once the response is available.
@@ -35,7 +35,7 @@ let response = await self->WorkerGlobalScope.fetch(myRequest)
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/fetch)
 */
-  external fetch_withRequest: (T.t, request, ~init: requestInit=?) => promise<response> = "fetch"
+  external fetchWithRequest: (T.t, request, ~init: requestInit=?) => promise<response> = "fetch"
 }
 
 include Impl({type t = workerGlobalScope})

--- a/tests/DOMAPI/HTMLElement__test.res
+++ b/tests/DOMAPI/HTMLElement__test.res
@@ -5,5 +5,5 @@ document
 ->Document.querySelector("form")
 ->Null.toOption
 ->Option.forEach(form => {
-  form->Element.scrollIntoView_withOptions({behavior: DOMAPI.Smooth})
+  form->Element.scrollIntoViewWithOptions({behavior: DOMAPI.Smooth})
 })

--- a/tests/Global__test.res
+++ b/tests/Global__test.res
@@ -15,7 +15,7 @@ let response2 = await fetch(
   },
 )
 
-let response3 = await fetch_withRequest(
+let response3 = await fetchWithRequest(
   Request.fromURL("https://rescript-lang.org/"),
   ~init={
     method: "POST",


### PR DESCRIPTION
CamelCase is considered more idiomatic ReScript naming.