### PR TITLE
add MessagePort event types.

### DIFF
--- a/src/EventAPI.res
+++ b/src/EventAPI.res
@@ -43,6 +43,8 @@ type eventType =
   | @as("loadeddata") Loadeddata
   | @as("loadedmetadata") Loadedmetadata
   | @as("loadstart") Loadstart
+  | @as("message") Message
+  | @as("messageerror") MessageError
   | @as("mousedown") Mousedown
   | @as("mouseenter") Mouseenter
   | @as("mouseleave") Mouseleave


### PR DESCRIPTION
This PR adds the [MessagePort](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) events to addEventListener. 

At your leisure, let me know what you think. 