### PR TITLE
Fix publishing with GitHub OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,7 @@ jobs:
 
       - name: Publish to npm
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-        run: npm publish --access public ./*.tgz --tag experimental
+        run: npm publish --provenance --access public --tag experimental ./*.tgz
 
   deploy-docs:
     needs: build


### PR DESCRIPTION
I think the problem was that NODE_AUTH_TOKEN was still set (to an expired token).

Hope this fixes publishing, could not test it.