### PR TITLE
Rename a few bindings with a proper descriptive naming

### DIFF
--- a/src/CSSFontLoadingAPI/FontFace.res
+++ b/src/CSSFontLoadingAPI/FontFace.res
@@ -11,7 +11,7 @@ external make: (~family: string, ~source: string, ~descriptors: fontFaceDescript
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace)
 */
 @new
-external make2: (
+external fromDataView: (
   ~family: string,
   ~source: DataView.t,
   ~descriptors: fontFaceDescriptors=?,
@@ -21,7 +21,7 @@ external make2: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace)
 */
 @new
-external make3: (
+external fromArrayBuffer: (
   ~family: string,
   ~source: ArrayBuffer.t,
   ~descriptors: fontFaceDescriptors=?,

--- a/src/CanvasAPI/Path2D.res
+++ b/src/CanvasAPI/Path2D.res
@@ -11,7 +11,7 @@ external make: (~path: path2D=?) => path2D = "Path2D"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Path2D)
 */
 @new
-external make2: (~path: string=?) => path2D = "Path2D"
+external fromString: (~path: string=?) => path2D = "Path2D"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/closePath)
@@ -70,32 +70,6 @@ external rect: (path2D, ~x: float, ~y: float, ~w: float, ~h: float) => unit = "r
 */
 @send
 external roundRect: (
-  path2D,
-  ~x: float,
-  ~y: float,
-  ~w: float,
-  ~h: float,
-  ~radii_: array<float>=?,
-) => unit = "roundRect"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
-*/
-@send
-external roundRect2: (
-  path2D,
-  ~x: float,
-  ~y: float,
-  ~w: float,
-  ~h: float,
-  ~radii_: array<float>=?,
-) => unit = "roundRect"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
-*/
-@send
-external roundRect3: (
   path2D,
   ~x: float,
   ~y: float,

--- a/src/ChannelMessagingAPI/MessagePort.res
+++ b/src/ChannelMessagingAPI/MessagePort.res
@@ -19,7 +19,7 @@ Throws a "DataCloneError" DOMException if transfer contains duplicate objects or
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessagePort/postMessage)
 */
 @send
-external postMessage2: (
+external postMessageWithOptions: (
   messagePort,
   ~message: JSON.t,
   ~options: structuredSerializeOptions=?,

--- a/src/DOMAPI/CanvasRenderingContext2D.res
+++ b/src/DOMAPI/CanvasRenderingContext2D.res
@@ -81,7 +81,7 @@ external setTransform: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/setTransform)
 */
 @send
-external setTransform2: (canvasRenderingContext2D, ~transform: domMatrix2DInit=?) => unit =
+external setTransformWithMatrix: (canvasRenderingContext2D, ~transform: domMatrix2DInit=?) => unit =
   "setTransform"
 
 /**
@@ -141,7 +141,7 @@ external createPattern: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
 @send
-external createPattern2: (
+external createPatternFromSvg: (
   canvasRenderingContext2D,
   ~image: svgImageElement,
   ~repetition: string,
@@ -151,7 +151,7 @@ external createPattern2: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
 @send
-external createPattern3: (
+external createPatternFromVideo: (
   canvasRenderingContext2D,
   ~image: htmlVideoElement,
   ~repetition: string,
@@ -161,7 +161,7 @@ external createPattern3: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
 @send
-external createPattern4: (
+external createPatternFromCanvas: (
   canvasRenderingContext2D,
   ~image: htmlCanvasElement,
   ~repetition: string,
@@ -171,7 +171,7 @@ external createPattern4: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
 @send
-external createPattern5: (
+external createPatternFromImageBitmap: (
   canvasRenderingContext2D,
   ~image: imageBitmap,
   ~repetition: string,
@@ -181,7 +181,7 @@ external createPattern5: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
 @send
-external createPattern6: (
+external createPatternFromOffscreenCanvas: (
   canvasRenderingContext2D,
   ~image: offscreenCanvas,
   ~repetition: string,
@@ -191,7 +191,7 @@ external createPattern6: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
 @send
-external createPattern7: (
+external createPatternFromVideoFrame: (
   canvasRenderingContext2D,
   ~image: videoFrame,
   ~repetition: string,
@@ -239,8 +239,11 @@ external fill: (canvasRenderingContext2D, ~fillRule: canvasFillRule=?) => unit =
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fill)
 */
 @send
-external fill2: (canvasRenderingContext2D, ~path: path2D, ~fillRule: canvasFillRule=?) => unit =
-  "fill"
+external fillWithPath: (
+  canvasRenderingContext2D,
+  ~path: path2D,
+  ~fillRule: canvasFillRule=?,
+) => unit = "fill"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/stroke)
@@ -252,7 +255,7 @@ external stroke: canvasRenderingContext2D => unit = "stroke"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/stroke)
 */
 @send
-external stroke2: (canvasRenderingContext2D, path2D) => unit = "stroke"
+external strokeWithPath: (canvasRenderingContext2D, path2D) => unit = "stroke"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/clip)
@@ -264,8 +267,11 @@ external clip: (canvasRenderingContext2D, ~fillRule: canvasFillRule=?) => unit =
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/clip)
 */
 @send
-external clip2: (canvasRenderingContext2D, ~path: path2D, ~fillRule: canvasFillRule=?) => unit =
-  "clip"
+external clipWithPath: (
+  canvasRenderingContext2D,
+  ~path: path2D,
+  ~fillRule: canvasFillRule=?,
+) => unit = "clip"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isPointInPath)
@@ -282,7 +288,7 @@ external isPointInPath: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isPointInPath)
 */
 @send
-external isPointInPath2: (
+external isPointInPathWithPath: (
   canvasRenderingContext2D,
   ~path: path2D,
   ~x: float,
@@ -301,8 +307,12 @@ external isPointInStroke: (canvasRenderingContext2D, ~x: float, ~y: float) => bo
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isPointInStroke)
 */
 @send
-external isPointInStroke2: (canvasRenderingContext2D, ~path: path2D, ~x: float, ~y: float) => bool =
-  "isPointInStroke"
+external isPointInStrokeWithPath: (
+  canvasRenderingContext2D,
+  ~path: path2D,
+  ~x: float,
+  ~y: float,
+) => bool = "isPointInStroke"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawFocusIfNeeded)
@@ -314,8 +324,11 @@ external drawFocusIfNeeded: (canvasRenderingContext2D, element) => unit = "drawF
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawFocusIfNeeded)
 */
 @send
-external drawFocusIfNeeded2: (canvasRenderingContext2D, ~path: path2D, ~element: element) => unit =
-  "drawFocusIfNeeded"
+external drawFocusIfNeededWithPath: (
+  canvasRenderingContext2D,
+  ~path: path2D,
+  ~element: element,
+) => unit = "drawFocusIfNeeded"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fillText)
@@ -649,7 +662,7 @@ external createImageData: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createImageData)
 */
 @send
-external createImageData2: (canvasRenderingContext2D, imageData) => imageData = "createImageData"
+external createImageDataFrom: (canvasRenderingContext2D, imageData) => imageData = "createImageData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getImageData)
@@ -679,7 +692,7 @@ external putImageData: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/putImageData)
 */
 @send
-external putImageData2: (
+external putImageDataWithDirtyRect: (
   canvasRenderingContext2D,
   ~imagedata: imageData,
   ~dx: int,
@@ -780,33 +793,6 @@ external roundRect: (
 ) => unit = "roundRect"
 
 /**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
-*/
-@send
-external roundRect2: (
-  canvasRenderingContext2D,
-  ~x: float,
-  ~y: float,
-  ~w: float,
-  ~h: float,
-  ~radii_: array<float>=?,
-) => unit = "roundRect"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
-*/
-@send
-external roundRect3: (
-  canvasRenderingContext2D,
-  ~x: float,
-  ~y: float,
-  ~w: float,
-  ~h: float,
-  ~radii_: array<float>=?,
-) => unit = "roundRect"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/arc)
 */
 @send
 external arc: (

--- a/src/DOMAPI/CharacterData.res
+++ b/src/DOMAPI/CharacterData.res
@@ -25,7 +25,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/after)
 */
   @send
-  external after2: (T.t, string) => unit = "after"
+  external afterText: (T.t, string) => unit = "after"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/appendData)
@@ -49,7 +49,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/before)
 */
   @send
-  external before2: (T.t, string) => unit = "before"
+  external beforeText: (T.t, string) => unit = "before"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/deleteData)
@@ -92,7 +92,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
 */
   @send
-  external replaceWith2: (T.t, string) => unit = "replaceWith"
+  external replaceWithText: (T.t, string) => unit = "replaceWith"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/substringData)

--- a/src/DOMAPI/DOMMatrix.res
+++ b/src/DOMAPI/DOMMatrix.res
@@ -11,7 +11,7 @@ external make: (~init: string=?) => domMatrix = "DOMMatrix"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMMatrix)
 */
 @new
-external make2: (~init: array<float>=?) => domMatrix = "DOMMatrix"
+external fromFloatArray: (~init: array<float>=?) => domMatrix = "DOMMatrix"
 
 external asDOMMatrixReadOnly: domMatrix => domMatrixReadOnly = "%identity"
 @scope("DOMMatrix")

--- a/src/DOMAPI/DOMMatrixReadOnly.res
+++ b/src/DOMAPI/DOMMatrixReadOnly.res
@@ -11,7 +11,7 @@ external make: (~init: string=?) => domMatrixReadOnly = "DOMMatrixReadOnly"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly)
 */
 @new
-external make2: (~init: array<float>=?) => domMatrixReadOnly = "DOMMatrixReadOnly"
+external fromFloatArray: (~init: array<float>=?) => domMatrixReadOnly = "DOMMatrixReadOnly"
 
 @scope("DOMMatrixReadOnly")
 external fromMatrix: (~other: domMatrixInit=?) => domMatrixReadOnly = "fromMatrix"

--- a/src/DOMAPI/Document.res
+++ b/src/DOMAPI/Document.res
@@ -39,7 +39,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/prepend)
 */
 @send
-external prepend2: (document, string) => unit = "prepend"
+external prependText: (document, string) => unit = "prepend"
 
 /**
 Inserts nodes after the last child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -57,7 +57,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/append)
 */
 @send
-external append2: (document, string) => unit = "append"
+external appendText: (document, string) => unit = "append"
 
 /**
 Replace all children of node with nodes, while replacing strings in nodes with equivalent Text nodes.
@@ -75,7 +75,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
 */
 @send
-external replaceChildren2: (document, string) => unit = "replaceChildren"
+external replaceChildrenText: (document, string) => unit = "replaceChildren"
 
 /**
 Returns the first element that is a descendant of node that matches selectors.
@@ -162,7 +162,7 @@ Creates an instance of the element for the specified tag.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createElement)
 */
 @send
-external createElement2: (
+external createElementWithOptions: (
   document,
   ~localName: string,
   ~options: elementCreationOptions=?,
@@ -209,7 +209,7 @@ When supplied, options's is can be used to create a customized built-in element.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createElementNS)
 */
 @send
-external createElementNS2: (
+external createElementNSWithOptions: (
   document,
   ~namespace: string,
   ~qualifiedName: string,
@@ -394,7 +394,7 @@ Opens a new window and loads a document specified by a given URL. Also, opens a 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/open)
 */
 @send
-external open2: (document, ~url: string, ~name: string, ~features: string) => window = "open"
+external openWindow: (document, ~url: string, ~name: string, ~features: string) => window = "open"
 
 /**
 Closes an output stream and forces the sent data to display.

--- a/src/DOMAPI/DocumentFragment.res
+++ b/src/DOMAPI/DocumentFragment.res
@@ -31,7 +31,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/append)
 */
   @send
-  external append2: (T.t, string) => unit = "append"
+  external appendText: (T.t, string) => unit = "append"
 
   /**
 Returns the first element within node's descendants whose ID is elementId.
@@ -56,7 +56,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/prepend)
 */
   @send
-  external prepend2: (T.t, string) => unit = "prepend"
+  external prependText: (T.t, string) => unit = "prepend"
 
   /**
 Returns the first element that is a descendant of node that matches selectors.
@@ -88,7 +88,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/replaceChildren)
 */
   @send
-  external replaceChildren2: (T.t, string) => unit = "replaceChildren"
+  external replaceChildrenText: (T.t, string) => unit = "replaceChildren"
 }
 
 include Impl({type t = documentFragment})

--- a/src/DOMAPI/Element.res
+++ b/src/DOMAPI/Element.res
@@ -26,7 +26,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/after)
 */
   @send
-  external after2: (T.t, string) => unit = "after"
+  external afterText: (T.t, string) => unit = "after"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/animate)
@@ -38,8 +38,11 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/animate)
 */
   @send
-  external animate2: (T.t, ~keyframes: any, ~options: keyframeAnimationOptions=?) => animation =
-    "animate"
+  external animateWithOptions: (
+    T.t,
+    ~keyframes: any,
+    ~options: keyframeAnimationOptions=?,
+  ) => animation = "animate"
 
   /**
 Inserts nodes after the last child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -57,7 +60,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/append)
 */
   @send
-  external append2: (T.t, string) => unit = "append"
+  external appendText: (T.t, string) => unit = "append"
 
   /**
 Creates a shadow root for element and returns it.
@@ -82,7 +85,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/before)
 */
   @send
-  external before2: (T.t, string) => unit = "before"
+  external beforeText: (T.t, string) => unit = "before"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/checkVisibility)
@@ -258,7 +261,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/prepend)
 */
   @send
-  external prepend2: (T.t, string) => unit = "prepend"
+  external prependText: (T.t, string) => unit = "prepend"
 
   /**
 Returns the first element that is a descendant of node that matches selectors.
@@ -324,7 +327,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
 */
   @send
-  external replaceChildren2: (T.t, string) => unit = "replaceChildren"
+  external replaceChildrenText: (T.t, string) => unit = "replaceChildren"
 
   /**
 Replaces node with nodes, while replacing strings in nodes with equivalent Text nodes.
@@ -342,7 +345,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
 */
   @send
-  external replaceWith2: (T.t, string) => unit = "replaceWith"
+  external replaceWithText: (T.t, string) => unit = "replaceWith"
 
   /**
 Displays element fullscreen and resolves promise when done.
@@ -371,7 +374,7 @@ When supplied, options's navigationUI member indicates whether showing navigatio
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scroll)
 */
   @send
-  external scroll2: (T.t, ~x: float, ~y: float) => unit = "scroll"
+  external scrollXY: (T.t, ~x: float, ~y: float) => unit = "scroll"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollBy)
@@ -383,7 +386,7 @@ When supplied, options's navigationUI member indicates whether showing navigatio
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollBy)
 */
   @send
-  external scrollBy2: (T.t, ~x: float, ~y: float) => unit = "scrollBy"
+  external scrollByXY: (T.t, ~x: float, ~y: float) => unit = "scrollBy"
 
   /**
 `scrollIntoView()`
@@ -437,7 +440,7 @@ element->Element.scrollIntoViewWithOptions({ behavior: DOMAPI.Smooth })
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollTo)
 */
   @send
-  external scrollTo2: (T.t, ~x: float, ~y: float) => unit = "scrollTo"
+  external scrollToXY: (T.t, ~x: float, ~y: float) => unit = "scrollTo"
 
   /**
 Sets the value of element's first attribute whose qualified name is qualifiedName to value.

--- a/src/DOMAPI/HTMLInputElement.res
+++ b/src/DOMAPI/HTMLInputElement.res
@@ -56,7 +56,7 @@ external setRangeText: (htmlInputElement, string) => unit = "setRangeText"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setRangeText)
 */
 @send
-external setRangeText2: (
+external setRangeTextWithRange: (
   htmlInputElement,
   ~replacement: string,
   ~start: int,

--- a/src/DOMAPI/HTMLSelectElement.res
+++ b/src/DOMAPI/HTMLSelectElement.res
@@ -40,7 +40,7 @@ Removes an element from the collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/remove)
 */
 @send
-external removeH2: (htmlSelectElement, int) => unit = "remove"
+external removeByIndex: (htmlSelectElement, int) => unit = "remove"
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.

--- a/src/DOMAPI/HTMLSlotElement.res
+++ b/src/DOMAPI/HTMLSlotElement.res
@@ -26,4 +26,4 @@ external assign: (htmlSlotElement, element) => unit = "assign"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assign)
 */
 @send
-external assign2: (htmlSlotElement, text) => unit = "assign"
+external assignText: (htmlSlotElement, text) => unit = "assign"

--- a/src/DOMAPI/HTMLTextAreaElement.res
+++ b/src/DOMAPI/HTMLTextAreaElement.res
@@ -40,7 +40,7 @@ external setRangeText: (htmlTextAreaElement, string) => unit = "setRangeText"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/setRangeText)
 */
 @send
-external setRangeText2: (
+external setRangeTextWithRange: (
   htmlTextAreaElement,
   ~replacement: string,
   ~start: int,

--- a/src/DOMAPI/Navigator.res
+++ b/src/DOMAPI/Navigator.res
@@ -35,37 +35,40 @@ external sendBeacon: (navigator, ~url: string, ~data: readableStream<unit>=?) =>
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon)
 */
 @send
-external sendBeacon2: (navigator, ~url: string, ~data: blob=?) => bool = "sendBeacon"
+external sendBeaconWithBlob: (navigator, ~url: string, ~data: blob=?) => bool = "sendBeacon"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon)
 */
 @send
-external sendBeacon3: (navigator, ~url: string, ~data: DataView.t=?) => bool = "sendBeacon"
+external sendBeaconWithDataView: (navigator, ~url: string, ~data: DataView.t=?) => bool =
+  "sendBeacon"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon)
 */
 @send
-external sendBeacon4: (navigator, ~url: string, ~data: ArrayBuffer.t=?) => bool = "sendBeacon"
+external sendBeaconWithArrayBuffer: (navigator, ~url: string, ~data: ArrayBuffer.t=?) => bool =
+  "sendBeacon"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon)
 */
 @send
-external sendBeacon5: (navigator, ~url: string, ~data: formData=?) => bool = "sendBeacon"
+external sendBeaconWithFormData: (navigator, ~url: string, ~data: formData=?) => bool = "sendBeacon"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon)
 */
 @send
-external sendBeacon6: (navigator, ~url: string, ~data: urlSearchParams=?) => bool = "sendBeacon"
+external sendBeaconWithSearchParams: (navigator, ~url: string, ~data: urlSearchParams=?) => bool =
+  "sendBeacon"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon)
 */
 @send
-external sendBeacon7: (navigator, ~url: string, ~data: string=?) => bool = "sendBeacon"
+external sendBeaconWithString: (navigator, ~url: string, ~data: string=?) => bool = "sendBeacon"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/requestMediaKeySystemAccess)
@@ -93,7 +96,7 @@ external vibrate: (navigator, int) => bool = "vibrate"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/vibrate)
 */
 @send
-external vibrate2: (navigator, array<int>) => bool = "vibrate"
+external vibrateWithPattern: (navigator, array<int>) => bool = "vibrate"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/share)

--- a/src/DOMAPI/StylePropertyMap.res
+++ b/src/DOMAPI/StylePropertyMap.res
@@ -23,7 +23,7 @@ external set: (stylePropertyMap, ~property: string, ~values: cssStyleValue) => u
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/set)
 */
 @send
-external set2: (stylePropertyMap, ~property: string, ~values: string) => unit = "set"
+external setString: (stylePropertyMap, ~property: string, ~values: string) => unit = "set"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/append)
@@ -35,7 +35,7 @@ external append: (stylePropertyMap, ~property: string, ~values: cssStyleValue) =
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/append)
 */
 @send
-external append2: (stylePropertyMap, ~property: string, ~values: string) => unit = "append"
+external appendString: (stylePropertyMap, ~property: string, ~values: string) => unit = "append"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/delete)

--- a/src/DOMAPI/VideoFrame.res
+++ b/src/DOMAPI/VideoFrame.res
@@ -12,55 +12,64 @@ external make: (~image: htmlImageElement, ~init: videoFrameInit=?) => videoFrame
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make2: (~image: svgImageElement, ~init: videoFrameInit=?) => videoFrame = "VideoFrame"
+external fromSvgImage: (~image: svgImageElement, ~init: videoFrameInit=?) => videoFrame =
+  "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make3: (~image: htmlVideoElement, ~init: videoFrameInit=?) => videoFrame = "VideoFrame"
+external fromVideoElement: (~image: htmlVideoElement, ~init: videoFrameInit=?) => videoFrame =
+  "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make4: (~image: htmlCanvasElement, ~init: videoFrameInit=?) => videoFrame = "VideoFrame"
+external fromCanvasElement: (~image: htmlCanvasElement, ~init: videoFrameInit=?) => videoFrame =
+  "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make5: (~image: imageBitmap, ~init: videoFrameInit=?) => videoFrame = "VideoFrame"
+external fromImageBitmap: (~image: imageBitmap, ~init: videoFrameInit=?) => videoFrame =
+  "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make6: (~image: offscreenCanvas, ~init: videoFrameInit=?) => videoFrame = "VideoFrame"
+external fromOffscreenCanvas: (~image: offscreenCanvas, ~init: videoFrameInit=?) => videoFrame =
+  "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make7: (~image: videoFrame, ~init: videoFrameInit=?) => videoFrame = "VideoFrame"
+external fromVideoFrame: (~image: videoFrame, ~init: videoFrameInit=?) => videoFrame = "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make8: (~data: ArrayBuffer.t, ~init: videoFrameBufferInit) => videoFrame = "VideoFrame"
+external fromArrayBuffer: (~data: ArrayBuffer.t, ~init: videoFrameBufferInit) => videoFrame =
+  "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make9: (~data: sharedArrayBuffer, ~init: videoFrameBufferInit) => videoFrame = "VideoFrame"
+external fromSharedArrayBuffer: (
+  ~data: sharedArrayBuffer,
+  ~init: videoFrameBufferInit,
+) => videoFrame = "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame)
 */
 @new
-external make10: (~data: DataView.t, ~init: videoFrameBufferInit) => videoFrame = "VideoFrame"
+external fromDataView: (~data: DataView.t, ~init: videoFrameBufferInit) => videoFrame = "VideoFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame/allocationSize)
@@ -82,7 +91,7 @@ external copyTo: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame/copyTo)
 */
 @send
-external copyTo2: (
+external copyToSharedArrayBuffer: (
   videoFrame,
   ~destination: sharedArrayBuffer,
   ~options: videoFrameCopyToOptions=?,
@@ -92,7 +101,7 @@ external copyTo2: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame/copyTo)
 */
 @send
-external copyTo3: (
+external copyToDataView: (
   videoFrame,
   ~destination: DataView.t,
   ~options: videoFrameCopyToOptions=?,

--- a/src/DOMAPI/Window.res
+++ b/src/DOMAPI/Window.res
@@ -50,7 +50,8 @@ external setInterval: (window, ~handler: string, ~timeout: int=?) => int = "setI
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setInterval)
 */
 @send
-external setInterval2: (window, ~handler: unit => unit, ~timeout: int=?) => int = "setInterval"
+external setIntervalWithCallback: (window, ~handler: unit => unit, ~timeout: int=?) => int =
+  "setInterval"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/clearInterval)
@@ -78,7 +79,7 @@ external createImageBitmap: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap2: (
+external createImageBitmapFromSvg: (
   window,
   ~image: svgImageElement,
   ~options: imageBitmapOptions=?,
@@ -88,7 +89,7 @@ external createImageBitmap2: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap3: (
+external createImageBitmapFromVideo: (
   window,
   ~image: htmlVideoElement,
   ~options: imageBitmapOptions=?,
@@ -98,7 +99,7 @@ external createImageBitmap3: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap4: (
+external createImageBitmapFromCanvas: (
   window,
   ~image: htmlCanvasElement,
   ~options: imageBitmapOptions=?,
@@ -108,7 +109,7 @@ external createImageBitmap4: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap5: (
+external createImageBitmapFromImageBitmap: (
   window,
   ~image: imageBitmap,
   ~options: imageBitmapOptions=?,
@@ -118,7 +119,7 @@ external createImageBitmap5: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap6: (
+external createImageBitmapFromOffscreenCanvas: (
   window,
   ~image: offscreenCanvas,
   ~options: imageBitmapOptions=?,
@@ -128,7 +129,7 @@ external createImageBitmap6: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap7: (
+external createImageBitmapFromVideoFrame: (
   window,
   ~image: videoFrame,
   ~options: imageBitmapOptions=?,
@@ -138,7 +139,7 @@ external createImageBitmap7: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap8: (
+external createImageBitmapFromBlob: (
   window,
   ~image: blob,
   ~options: imageBitmapOptions=?,
@@ -148,7 +149,7 @@ external createImageBitmap8: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap9: (
+external createImageBitmapFromImageData: (
   window,
   ~image: imageData,
   ~options: imageBitmapOptions=?,
@@ -158,7 +159,7 @@ external createImageBitmap9: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap10: (
+external createImageBitmapWithCrop: (
   window,
   ~image: htmlImageElement,
   ~sx: int,
@@ -172,7 +173,7 @@ external createImageBitmap10: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap11: (
+external createImageBitmapFromSvgWithCrop: (
   window,
   ~image: svgImageElement,
   ~sx: int,
@@ -186,7 +187,7 @@ external createImageBitmap11: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap12: (
+external createImageBitmapFromVideoWithCrop: (
   window,
   ~image: htmlVideoElement,
   ~sx: int,
@@ -200,7 +201,7 @@ external createImageBitmap12: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap13: (
+external createImageBitmapFromCanvasWithCrop: (
   window,
   ~image: htmlCanvasElement,
   ~sx: int,
@@ -214,7 +215,7 @@ external createImageBitmap13: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap14: (
+external createImageBitmapFromImageBitmapWithCrop: (
   window,
   ~image: imageBitmap,
   ~sx: int,
@@ -228,7 +229,7 @@ external createImageBitmap14: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap15: (
+external createImageBitmapFromOffscreenCanvasWithCrop: (
   window,
   ~image: offscreenCanvas,
   ~sx: int,
@@ -242,7 +243,7 @@ external createImageBitmap15: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap16: (
+external createImageBitmapFromVideoFrameWithCrop: (
   window,
   ~image: videoFrame,
   ~sx: int,
@@ -256,7 +257,7 @@ external createImageBitmap16: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap17: (
+external createImageBitmapFromBlobWithCrop: (
   window,
   ~image: blob,
   ~sx: int,
@@ -270,7 +271,7 @@ external createImageBitmap17: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
 @send
-external createImageBitmap18: (
+external createImageBitmapFromImageDataWithCrop: (
   window,
   ~image: imageData,
   ~sx: int,
@@ -365,7 +366,7 @@ external alert: window => unit = "alert"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/alert)
 */
 @send
-external alert2: (window, string) => unit = "alert"
+external alertWithMessage: (window, string) => unit = "alert"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/confirm)
@@ -418,8 +419,11 @@ Throws a "DataCloneError" DOMException if transfer array contains duplicate obje
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
 */
 @send
-external postMessage2: (window, ~message: JSON.t, ~options: windowPostMessageOptions=?) => unit =
-  "postMessage"
+external postMessageWithOptions: (
+  window,
+  ~message: JSON.t,
+  ~options: windowPostMessageOptions=?,
+) => unit = "postMessage"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/matchMedia)
@@ -461,7 +465,7 @@ external scroll: (window, ~options: scrollToOptions=?) => unit = "scroll"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scroll)
 */
 @send
-external scroll2: (window, ~x: float, ~y: float) => unit = "scroll"
+external scrollXY: (window, ~x: float, ~y: float) => unit = "scroll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollTo)
@@ -473,7 +477,7 @@ external scrollTo: (window, ~options: scrollToOptions=?) => unit = "scrollTo"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollTo)
 */
 @send
-external scrollTo2: (window, ~x: float, ~y: float) => unit = "scrollTo"
+external scrollToXY: (window, ~x: float, ~y: float) => unit = "scrollTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollBy)
@@ -485,7 +489,7 @@ external scrollBy: (window, ~options: scrollToOptions=?) => unit = "scrollBy"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollBy)
 */
 @send
-external scrollBy2: (window, ~x: float, ~y: float) => unit = "scrollBy"
+external scrollByXY: (window, ~x: float, ~y: float) => unit = "scrollBy"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)

--- a/src/EncryptedMediaExtensionsAPI/MediaKeySession.res
+++ b/src/EncryptedMediaExtensionsAPI/MediaKeySession.res
@@ -16,7 +16,7 @@ external generateRequest: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/generateRequest)
 */
 @send
-external generateRequest2: (
+external generateRequestWithArrayBuffer: (
   mediaKeySession,
   ~initDataType: string,
   ~initData: ArrayBuffer.t,
@@ -38,7 +38,7 @@ external update: (mediaKeySession, DataView.t) => promise<unit> = "update"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/update)
 */
 @send
-external update2: (mediaKeySession, ArrayBuffer.t) => promise<unit> = "update"
+external updateWithArrayBuffer: (mediaKeySession, ArrayBuffer.t) => promise<unit> = "update"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeySession/close)

--- a/src/EncryptedMediaExtensionsAPI/MediaKeyStatusMap.res
+++ b/src/EncryptedMediaExtensionsAPI/MediaKeyStatusMap.res
@@ -10,4 +10,4 @@ external has: (mediaKeyStatusMap, DataView.t) => bool = "has"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap/has)
 */
 @send
-external has2: (mediaKeyStatusMap, ArrayBuffer.t) => bool = "has"
+external hasArrayBuffer: (mediaKeyStatusMap, ArrayBuffer.t) => bool = "has"

--- a/src/EncryptedMediaExtensionsAPI/MediaKeys.res
+++ b/src/EncryptedMediaExtensionsAPI/MediaKeys.res
@@ -24,4 +24,5 @@ external setServerCertificate: (mediaKeys, DataView.t) => promise<bool> = "setSe
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaKeys/setServerCertificate)
 */
 @send
-external setServerCertificate2: (mediaKeys, ArrayBuffer.t) => promise<bool> = "setServerCertificate"
+external setServerCertificateWithArrayBuffer: (mediaKeys, ArrayBuffer.t) => promise<bool> =
+  "setServerCertificate"

--- a/src/FileAPI/FileSystemWritableFileStream.res
+++ b/src/FileAPI/FileSystemWritableFileStream.res
@@ -29,25 +29,25 @@ external write: (fileSystemWritableFileStream, DataView.t) => promise<unit> = "w
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write2: (fileSystemWritableFileStream, ArrayBuffer.t) => promise<unit> = "write"
+external writeArrayBuffer: (fileSystemWritableFileStream, ArrayBuffer.t) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write3: (fileSystemWritableFileStream, blob) => promise<unit> = "write"
+external writeBlob: (fileSystemWritableFileStream, blob) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write4: (fileSystemWritableFileStream, string) => promise<unit> = "write"
+external writeString: (fileSystemWritableFileStream, string) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write)
 */
 @send
-external write5: (fileSystemWritableFileStream, writeParams) => promise<unit> = "write"
+external writeWithParams: (fileSystemWritableFileStream, writeParams) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/seek)

--- a/src/FileAPI/ReadableStream.res
+++ b/src/FileAPI/ReadableStream.res
@@ -7,18 +7,6 @@ open FileAPI
 external make: unit => readableStream<array<int>> = "ReadableStream"
 
 /**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)
-*/
-@new
-external make2: unit => unknown = "ReadableStream"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)
-*/
-@new
-external make3: unit => unknown = "ReadableStream"
-
-/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/cancel)
 */
 @send

--- a/src/Global.res
+++ b/src/Global.res
@@ -281,7 +281,7 @@ external setInterval: (~handler: string, ~timeout: int=?) => int = "setInterval"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setInterval)
 */
-external setInterval2: (~handler: unit => unit, ~timeout: int=?) => int = "setInterval"
+external setIntervalWithCallback: (~handler: unit => unit, ~timeout: int=?) => int = "setInterval"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/clearInterval)
@@ -304,7 +304,7 @@ external createImageBitmap: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap2: (
+external createImageBitmapFromSvg: (
   ~image: svgImageElement,
   ~options: imageBitmapOptions=?,
 ) => promise<imageBitmap> = "createImageBitmap"
@@ -312,7 +312,7 @@ external createImageBitmap2: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap3: (
+external createImageBitmapFromVideo: (
   ~image: htmlVideoElement,
   ~options: imageBitmapOptions=?,
 ) => promise<imageBitmap> = "createImageBitmap"
@@ -320,7 +320,7 @@ external createImageBitmap3: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap4: (
+external createImageBitmapFromCanvas: (
   ~image: htmlCanvasElement,
   ~options: imageBitmapOptions=?,
 ) => promise<imageBitmap> = "createImageBitmap"
@@ -328,7 +328,7 @@ external createImageBitmap4: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap5: (
+external createImageBitmapFromImageBitmap: (
   ~image: imageBitmap,
   ~options: imageBitmapOptions=?,
 ) => promise<imageBitmap> = "createImageBitmap"
@@ -336,7 +336,7 @@ external createImageBitmap5: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap6: (
+external createImageBitmapFromOffscreenCanvas: (
   ~image: offscreenCanvas,
   ~options: imageBitmapOptions=?,
 ) => promise<imageBitmap> = "createImageBitmap"
@@ -344,7 +344,7 @@ external createImageBitmap6: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap7: (
+external createImageBitmapFromVideoFrame: (
   ~image: videoFrame,
   ~options: imageBitmapOptions=?,
 ) => promise<imageBitmap> = "createImageBitmap"
@@ -352,7 +352,7 @@ external createImageBitmap7: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap8: (
+external createImageBitmapFromBlob: (
   ~image: blob,
   ~options: imageBitmapOptions=?,
 ) => promise<imageBitmap> = "createImageBitmap"
@@ -360,7 +360,7 @@ external createImageBitmap8: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap9: (
+external createImageBitmapFromImageData: (
   ~image: imageData,
   ~options: imageBitmapOptions=?,
 ) => promise<imageBitmap> = "createImageBitmap"
@@ -368,7 +368,7 @@ external createImageBitmap9: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap10: (
+external createImageBitmapWithCrop: (
   ~image: htmlImageElement,
   ~sx: int,
   ~sy: int,
@@ -380,7 +380,7 @@ external createImageBitmap10: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap11: (
+external createImageBitmapFromSvgWithCrop: (
   ~image: svgImageElement,
   ~sx: int,
   ~sy: int,
@@ -392,7 +392,7 @@ external createImageBitmap11: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap12: (
+external createImageBitmapFromVideoWithCrop: (
   ~image: htmlVideoElement,
   ~sx: int,
   ~sy: int,
@@ -404,7 +404,7 @@ external createImageBitmap12: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap13: (
+external createImageBitmapFromCanvasWithCrop: (
   ~image: htmlCanvasElement,
   ~sx: int,
   ~sy: int,
@@ -416,7 +416,7 @@ external createImageBitmap13: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap14: (
+external createImageBitmapFromImageBitmapWithCrop: (
   ~image: imageBitmap,
   ~sx: int,
   ~sy: int,
@@ -428,7 +428,7 @@ external createImageBitmap14: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap15: (
+external createImageBitmapFromOffscreenCanvasWithCrop: (
   ~image: offscreenCanvas,
   ~sx: int,
   ~sy: int,
@@ -440,7 +440,7 @@ external createImageBitmap15: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap16: (
+external createImageBitmapFromVideoFrameWithCrop: (
   ~image: videoFrame,
   ~sx: int,
   ~sy: int,
@@ -452,7 +452,7 @@ external createImageBitmap16: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap17: (
+external createImageBitmapFromBlobWithCrop: (
   ~image: blob,
   ~sx: int,
   ~sy: int,
@@ -464,7 +464,7 @@ external createImageBitmap17: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
 */
-external createImageBitmap18: (
+external createImageBitmapFromImageDataWithCrop: (
   ~image: imageData,
   ~sx: int,
   ~sy: int,
@@ -617,7 +617,7 @@ external alert: unit => unit = "alert"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/alert)
 */
-external alert2: string => unit = "alert"
+external alertWithMessage: string => unit = "alert"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/confirm)
@@ -664,7 +664,7 @@ If the origin of the target window doesn't match the given target origin, the me
 Throws a "DataCloneError" DOMException if transfer array contains duplicate objects or if message could not be cloned.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
 */
-external postMessage2: (~message: JSON.t, ~options: windowPostMessageOptions=?) => unit =
+external postMessageWithOptions: (~message: JSON.t, ~options: windowPostMessageOptions=?) => unit =
   "postMessage"
 
 /**
@@ -700,7 +700,7 @@ external scroll: (~options: scrollToOptions=?) => unit = "scroll"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scroll)
 */
-external scroll2: (~x: float, ~y: float) => unit = "scroll"
+external scrollXY: (~x: float, ~y: float) => unit = "scroll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollTo)
@@ -710,7 +710,7 @@ external scrollTo: (~options: scrollToOptions=?) => unit = "scrollTo"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollTo)
 */
-external scrollTo2: (~x: float, ~y: float) => unit = "scrollTo"
+external scrollToXY: (~x: float, ~y: float) => unit = "scrollTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollBy)
@@ -720,7 +720,7 @@ external scrollBy: (~options: scrollToOptions=?) => unit = "scrollBy"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollBy)
 */
-external scrollBy2: (~x: float, ~y: float) => unit = "scrollBy"
+external scrollByXY: (~x: float, ~y: float) => unit = "scrollBy"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)

--- a/src/IndexedDBAPI/IDBDatabase.res
+++ b/src/IndexedDBAPI/IDBDatabase.res
@@ -19,7 +19,7 @@ Returns a new transaction with the given mode ("readonly" or "readwrite") and sc
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBDatabase/transaction)
 */
 @send
-external transaction2: (
+external transactionWithStoreNames: (
   idbDatabase,
   ~storeNames: array<string>,
   ~mode: idbTransactionMode=?,

--- a/src/IndexedDBAPI/IDBObjectStore.res
+++ b/src/IndexedDBAPI/IDBObjectStore.res
@@ -150,7 +150,7 @@ Throws an "InvalidStateError" DOMException if not called within an upgrade trans
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/createIndex)
 */
 @send
-external createIndex2: (
+external createIndexWithKeyPaths: (
   idbObjectStore,
   ~name: string,
   ~keyPath: array<string>,

--- a/src/MediaCaptureAndStreamsAPI/MediaStream.res
+++ b/src/MediaCaptureAndStreamsAPI/MediaStream.res
@@ -10,13 +10,13 @@ external make: unit => mediaStream = "MediaStream"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream)
 */
 @new
-external make2: mediaStream => mediaStream = "MediaStream"
+external fromStream: mediaStream => mediaStream = "MediaStream"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream)
 */
 @new
-external make3: array<mediaStreamTrack> => mediaStream = "MediaStream"
+external fromTracks: array<mediaStreamTrack> => mediaStream = "MediaStream"
 
 include EventTarget.Impl({type t = mediaStream})
 

--- a/src/PerformanceAPI/Performance.res
+++ b/src/PerformanceAPI/Performance.res
@@ -76,7 +76,7 @@ external measure: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/measure)
 */
 @send
-external measure2: (
+external measureWithOptions: (
   performance,
   ~measureName: string,
   ~startOrMeasureOptions: performanceMeasureOptions=?,

--- a/src/ServiceWorkerAPI/Cache.res
+++ b/src/ServiceWorkerAPI/Cache.res
@@ -12,8 +12,11 @@ external match: (cache, ~request: request, ~options: cacheQueryOptions=?) => Nul
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/match)
 */
 @send
-external match2: (cache, ~request: string, ~options: cacheQueryOptions=?) => Nullable.t<response> =
-  "match"
+external matchByUrl: (
+  cache,
+  ~request: string,
+  ~options: cacheQueryOptions=?,
+) => Nullable.t<response> = "match"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/matchAll)
@@ -29,7 +32,7 @@ external matchAll: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/matchAll)
 */
 @send
-external matchAll2: (
+external matchAllByUrl: (
   cache,
   ~request: string=?,
   ~options: cacheQueryOptions=?,
@@ -45,7 +48,7 @@ external add: (cache, request) => promise<unit> = "add"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/add)
 */
 @send
-external add2: (cache, string) => promise<unit> = "add"
+external addByUrl: (cache, string) => promise<unit> = "add"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/addAll)
@@ -63,7 +66,7 @@ external put: (cache, ~request: request, ~response: response) => promise<unit> =
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/put)
 */
 @send
-external put2: (cache, ~request: string, ~response: response) => promise<unit> = "put"
+external putByUrl: (cache, ~request: string, ~response: response) => promise<unit> = "put"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/delete)
@@ -76,7 +79,7 @@ external delete: (cache, ~request: request, ~options: cacheQueryOptions=?) => pr
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/delete)
 */
 @send
-external delete2: (cache, ~request: string, ~options: cacheQueryOptions=?) => promise<bool> =
+external deleteByUrl: (cache, ~request: string, ~options: cacheQueryOptions=?) => promise<bool> =
   "delete"
 
 /**
@@ -93,7 +96,7 @@ external keys: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/keys)
 */
 @send
-external keys2: (
+external keysByUrl: (
   cache,
   ~request: string=?,
   ~options: cacheQueryOptions=?,

--- a/src/ServiceWorkerAPI/ServiceWorker.res
+++ b/src/ServiceWorkerAPI/ServiceWorker.res
@@ -14,7 +14,7 @@ external postMessage: (serviceWorker, ~message: JSON.t, ~transfer: array<Dict.t<
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorker/postMessage)
 */
 @send
-external postMessage2: (
+external postMessageWithOptions: (
   serviceWorker,
   ~message: JSON.t,
   ~options: structuredSerializeOptions=?,

--- a/src/WebAudioAPI/AudioNode.res
+++ b/src/WebAudioAPI/AudioNode.res
@@ -20,7 +20,7 @@ module Impl = (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/connect)
 */
   @send
-  external connect2: (T.t, ~destinationParam: audioParam, ~output: int=?) => unit = "connect"
+  external connectParam: (T.t, ~destinationParam: audioParam, ~output: int=?) => unit = "connect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
@@ -32,36 +32,42 @@ module Impl = (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
   @send
-  external disconnect2: (T.t, int) => unit = "disconnect"
+  external disconnectOutput: (T.t, int) => unit = "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
   @send
-  external disconnect3: (T.t, audioNode) => unit = "disconnect"
+  external disconnectNode: (T.t, audioNode) => unit = "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
   @send
-  external disconnect4: (T.t, ~destinationNode: audioNode, ~output: int) => unit = "disconnect"
-
-  /**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
-*/
-  @send
-  external disconnect5: (T.t, ~destinationNode: audioNode, ~output: int, ~input: int) => unit =
+  external disconnectNodeOutput: (T.t, ~destinationNode: audioNode, ~output: int) => unit =
     "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
   @send
-  external disconnect6: (T.t, audioParam) => unit = "disconnect"
+  external disconnectNodeOutputInput: (
+    T.t,
+    ~destinationNode: audioNode,
+    ~output: int,
+    ~input: int,
+  ) => unit = "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
   @send
-  external disconnect7: (T.t, ~destinationParam: audioParam, ~output: int) => unit = "disconnect"
+  external disconnectParam: (T.t, audioParam) => unit = "disconnect"
+
+  /**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
+*/
+  @send
+  external disconnectParamOutput: (T.t, ~destinationParam: audioParam, ~output: int) => unit =
+    "disconnect"
 }

--- a/src/WebAudioAPI/OfflineAudioContext.res
+++ b/src/WebAudioAPI/OfflineAudioContext.res
@@ -12,8 +12,11 @@ external make: offlineAudioContextOptions => offlineAudioContext = "OfflineAudio
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext)
 */
 @new
-external make2: (~numberOfChannels: int, ~length: int, ~sampleRate: float) => offlineAudioContext =
-  "OfflineAudioContext"
+external makeWithParams: (
+  ~numberOfChannels: int,
+  ~length: int,
+  ~sampleRate: float,
+) => offlineAudioContext = "OfflineAudioContext"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/startRendering)

--- a/src/WebCryptoAPI/SubtleCrypto.res
+++ b/src/WebCryptoAPI/SubtleCrypto.res
@@ -71,7 +71,7 @@ external generateKey: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey)
 */
 @send
-external generateKey2: (
+external generateKeyWithAlgorithmName: (
   subtleCrypto,
   ~algorithm: string,
   ~extractable: bool,
@@ -106,7 +106,7 @@ external deriveBits: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits)
 */
 @send
-external deriveBits2: (
+external deriveBitsWithAlgorithmName: (
   subtleCrypto,
   ~algorithm: string,
   ~baseKey: cryptoKey,
@@ -149,7 +149,7 @@ external wrapKey: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey)
 */
 @send
-external wrapKey2: (
+external wrapKeyWithAlgorithmName: (
   subtleCrypto,
   ~format: keyFormat,
   ~key: cryptoKey,

--- a/src/WebLocksAPI/LockManager.res
+++ b/src/WebLocksAPI/LockManager.res
@@ -11,7 +11,7 @@ external request: (lockManager, ~name: string, ~callback: lockGrantedCallback) =
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/LockManager/request)
 */
 @send
-external request2: (
+external requestWithOptions: (
   lockManager,
   ~name: string,
   ~options: lockOptions,

--- a/src/WebSocketsAPI/WebSocket.res
+++ b/src/WebSocketsAPI/WebSocket.res
@@ -11,7 +11,7 @@ external make: (~url: string, ~protocols: string=?) => webSocket = "WebSocket"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket)
 */
 @new
-external make2: (~url: string, ~protocols: array<string>=?) => webSocket = "WebSocket"
+external makeWithProtocols: (~url: string, ~protocols: array<string>=?) => webSocket = "WebSocket"
 
 include EventTarget.Impl({type t = webSocket})
 
@@ -34,18 +34,18 @@ Transmits data using the WebSocket connection. data can be a string, a Blob, an 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external send2: (webSocket, ArrayBuffer.t) => unit = "send"
+external sendArrayBuffer: (webSocket, ArrayBuffer.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external send3: (webSocket, blob) => unit = "send"
+external sendBlob: (webSocket, blob) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external send4: (webSocket, string) => unit = "send"
+external sendString: (webSocket, string) => unit = "send"

--- a/src/WebWorkersAPI/CacheStorage.res
+++ b/src/WebWorkersAPI/CacheStorage.res
@@ -15,7 +15,7 @@ external match: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CacheStorage/match)
 */
 @send
-external match2: (
+external matchByUrl: (
   cacheStorage,
   ~request: string,
   ~options: multiCacheQueryOptions=?,


### PR DESCRIPTION
We have a few constructor bindings lacking good naming. 

For example, VideoFrame has about 10 bindings for the same function targeting different signatures, and we were using `make2`, `make3`, `make4` and to define those bindings. 

This pull request renames these bindings with better names based on their arguments.

**These are breaking changes.**