### PR TITLE
refactor: simplify DOM, event, and observer module surfaces

### DIFF
--- a/src/DOMAPI/Document.res
+++ b/src/DOMAPI/Document.res
@@ -2,6 +2,8 @@ open DOMTypes
 open EventTypes
 open ViewTransitionsTypes
 
+type t = document
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document)
 */

--- a/src/DOMAPI/Document.res
+++ b/src/DOMAPI/Document.res
@@ -2,7 +2,7 @@ open DOMTypes
 open EventTypes
 open ViewTransitionsTypes
 
-type t = document
+type t = document = {...document}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document)

--- a/src/DOMAPI/Element.res
+++ b/src/DOMAPI/Element.res
@@ -1,6 +1,8 @@
 open DOMTypes
 open Prelude
 
+type t = element
+
 module Impl = (
   T: {
     type t

--- a/src/DOMAPI/Element.res
+++ b/src/DOMAPI/Element.res
@@ -1,7 +1,7 @@
 open DOMTypes
 open Prelude
 
-type t = element
+type t = element = {...element}
 
 module Impl = (
   T: {

--- a/src/DOMAPI/HTMLCanvasElement.res
+++ b/src/DOMAPI/HTMLCanvasElement.res
@@ -2,7 +2,7 @@ open DOMTypes
 open CanvasTypes
 open MediaCaptureAndStreamsTypes
 
-type t = htmlCanvasElement
+type t = htmlCanvasElement = {...htmlCanvasElement}
 
 include HTMLElement.Impl({type t = htmlCanvasElement})
 

--- a/src/DOMAPI/HTMLCanvasElement.res
+++ b/src/DOMAPI/HTMLCanvasElement.res
@@ -2,6 +2,8 @@ open DOMTypes
 open CanvasTypes
 open MediaCaptureAndStreamsTypes
 
+type t = htmlCanvasElement
+
 include HTMLElement.Impl({type t = htmlCanvasElement})
 
 /**

--- a/src/DOMAPI/HTMLElement.res
+++ b/src/DOMAPI/HTMLElement.res
@@ -1,5 +1,7 @@
 open DOMTypes
 
+type t = htmlElement
+
 module Impl = (
   T: {
     type t

--- a/src/DOMAPI/HTMLElement.res
+++ b/src/DOMAPI/HTMLElement.res
@@ -1,6 +1,6 @@
 open DOMTypes
 
-type t = htmlElement
+type t = htmlElement = {...htmlElement}
 
 module Impl = (
   T: {

--- a/src/DOMAPI/HTMLImageElement.res
+++ b/src/DOMAPI/HTMLImageElement.res
@@ -1,5 +1,7 @@
 open DOMTypes
 
+type t = htmlImageElement
+
 include HTMLElement.Impl({type t = htmlImageElement})
 
 /**

--- a/src/DOMAPI/HTMLImageElement.res
+++ b/src/DOMAPI/HTMLImageElement.res
@@ -1,6 +1,6 @@
 open DOMTypes
 
-type t = htmlImageElement
+type t = htmlImageElement = {...htmlImageElement}
 
 include HTMLElement.Impl({type t = htmlImageElement})
 

--- a/src/DOMAPI/HTMLInputElement.res
+++ b/src/DOMAPI/HTMLInputElement.res
@@ -1,5 +1,7 @@
 open DOMTypes
 
+type t = htmlInputElement
+
 include HTMLElement.Impl({type t = htmlInputElement})
 
 /**

--- a/src/DOMAPI/HTMLInputElement.res
+++ b/src/DOMAPI/HTMLInputElement.res
@@ -1,6 +1,6 @@
 open DOMTypes
 
-type t = htmlInputElement
+type t = htmlInputElement = {...htmlInputElement}
 
 include HTMLElement.Impl({type t = htmlInputElement})
 

--- a/src/DOMAPI/Location.res
+++ b/src/DOMAPI/Location.res
@@ -1,6 +1,6 @@
 open DOMTypes
 
-type t = location
+type t = location = {...location}
 
 /**
 Navigates to the given URL.

--- a/src/DOMAPI/Location.res
+++ b/src/DOMAPI/Location.res
@@ -1,5 +1,7 @@
 open DOMTypes
 
+type t = location
+
 /**
 Navigates to the given URL.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Location/assign)

--- a/src/DOMAPI/Node.res
+++ b/src/DOMAPI/Node.res
@@ -1,5 +1,7 @@
 open DOMTypes
 
+type t = node
+
 module Impl = (
   T: {
     type t

--- a/src/DOMAPI/Node.res
+++ b/src/DOMAPI/Node.res
@@ -1,6 +1,6 @@
 open DOMTypes
 
-type t = node
+type t = node = {...node}
 
 module Impl = (
   T: {

--- a/src/DOMAPI/Window.res
+++ b/src/DOMAPI/Window.res
@@ -66,7 +66,7 @@ external clearInterval: (window, int) => unit = "clearInterval"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/queueMicrotask)
 */
 @send
-external queueMicrotask: (window, voidFunction) => unit = "queueMicrotask"
+external queueMicrotask: (window, unit => unit) => unit = "queueMicrotask"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)

--- a/src/EventAPI/AbortController.res
+++ b/src/EventAPI/AbortController.res
@@ -1,6 +1,6 @@
 open EventTypes
 
-type t = abortController
+type t = abortController = {...abortController}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AbortController)

--- a/src/EventAPI/AbortController.res
+++ b/src/EventAPI/AbortController.res
@@ -1,5 +1,7 @@
 open EventTypes
 
+type t = abortController
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AbortController)
 */

--- a/src/EventAPI/AbortSignal.res
+++ b/src/EventAPI/AbortSignal.res
@@ -1,5 +1,7 @@
 open EventTypes
 
+type t = abortSignal
+
 include EventTarget.Impl({type t = abortSignal})
 
 /**

--- a/src/EventAPI/AbortSignal.res
+++ b/src/EventAPI/AbortSignal.res
@@ -1,6 +1,6 @@
 open EventTypes
 
-type t = abortSignal
+type t = abortSignal = {...abortSignal}
 
 include EventTarget.Impl({type t = abortSignal})
 

--- a/src/EventAPI/Event.res
+++ b/src/EventAPI/Event.res
@@ -1,5 +1,7 @@
 open EventTypes
 
+type t = event
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Event)
 */

--- a/src/EventAPI/Event.res
+++ b/src/EventAPI/Event.res
@@ -1,6 +1,6 @@
 open EventTypes
 
-type t = event
+type t = event = {...event}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Event)

--- a/src/EventAPI/EventTarget.res
+++ b/src/EventAPI/EventTarget.res
@@ -1,6 +1,6 @@
 open EventTypes
 
-type t = eventTarget
+type t = eventTarget = {...eventTarget}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/EventTarget)

--- a/src/EventAPI/EventTarget.res
+++ b/src/EventAPI/EventTarget.res
@@ -1,5 +1,7 @@
 open EventTypes
 
+type t = eventTarget
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/EventTarget)
 */

--- a/src/EventAPI/ExtendableEvent.res
+++ b/src/EventAPI/ExtendableEvent.res
@@ -1,6 +1,6 @@
 open EventTypes
 
-type t = extendableEvent
+type t = extendableEvent = {...extendableEvent}
 
 module Impl = (
   T: {

--- a/src/EventAPI/ExtendableEvent.res
+++ b/src/EventAPI/ExtendableEvent.res
@@ -1,5 +1,7 @@
 open EventTypes
 
+type t = extendableEvent
+
 module Impl = (
   T: {
     type t

--- a/src/IntersectionObserverAPI/IntersectionObserver.res
+++ b/src/IntersectionObserverAPI/IntersectionObserver.res
@@ -1,7 +1,7 @@
 open DOMTypes
 open IntersectionObserverTypes
 
-type t = intersectionObserver
+type t = intersectionObserver = {...intersectionObserver}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IntersectionObserver)

--- a/src/IntersectionObserverAPI/IntersectionObserver.res
+++ b/src/IntersectionObserverAPI/IntersectionObserver.res
@@ -1,6 +1,8 @@
 open DOMTypes
 open IntersectionObserverTypes
 
+type t = intersectionObserver
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IntersectionObserver)
 */

--- a/src/IntersectionObserverAPI/IntersectionObserverRoot.res
+++ b/src/IntersectionObserverAPI/IntersectionObserverRoot.res
@@ -1,6 +1,8 @@
 open DOMTypes
 open IntersectionObserverTypes
 
+type t = root
+
 external fromDocument: document => root = "%identity"
 external fromElement: element => root = "%identity"
 external fromNull: root = "null"

--- a/src/MutationObserverAPI/MutationObserver.res
+++ b/src/MutationObserverAPI/MutationObserver.res
@@ -1,6 +1,8 @@
 open DOMTypes
 open MutationObserverTypes
 
+type t = mutationObserver
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationObserver)
 */

--- a/src/ResizeObserverAPI/ResizeObserver.res
+++ b/src/ResizeObserverAPI/ResizeObserver.res
@@ -1,6 +1,8 @@
 open DOMTypes
 open ResizeObserverTypes
 
+type t = resizeObserver
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ResizeObserver)
 */

--- a/src/ResizeObserverAPI/ResizeObserver.res
+++ b/src/ResizeObserverAPI/ResizeObserver.res
@@ -1,7 +1,7 @@
 open DOMTypes
 open ResizeObserverTypes
 
-type t = resizeObserver
+type t = resizeObserver = {...resizeObserver}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ResizeObserver)

--- a/src/UIEventsAPI/CompositionEvent.res
+++ b/src/UIEventsAPI/CompositionEvent.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = compositionEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CompositionEvent)
 */

--- a/src/UIEventsAPI/CompositionEvent.res
+++ b/src/UIEventsAPI/CompositionEvent.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = compositionEvent
+type t = compositionEvent = {...compositionEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CompositionEvent)

--- a/src/UIEventsAPI/DataTransfer.res
+++ b/src/UIEventsAPI/DataTransfer.res
@@ -1,6 +1,8 @@
 open UIEventsTypes
 open DOMTypes
 
+type t = dataTransfer
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransfer)
 */

--- a/src/UIEventsAPI/DataTransfer.res
+++ b/src/UIEventsAPI/DataTransfer.res
@@ -1,7 +1,7 @@
 open UIEventsTypes
 open DOMTypes
 
-type t = dataTransfer
+type t = dataTransfer = {...dataTransfer}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransfer)

--- a/src/UIEventsAPI/DataTransferItem.res
+++ b/src/UIEventsAPI/DataTransferItem.res
@@ -2,6 +2,8 @@ open UIEventsTypes
 open FileTypes
 open FileAndDirectoryEntriesTypes
 
+type t = dataTransferItem
+
 /**
 Invokes the callback with the string data as the argument, if the drag data item kind is text.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransferItem/getAsString)

--- a/src/UIEventsAPI/DataTransferItem.res
+++ b/src/UIEventsAPI/DataTransferItem.res
@@ -2,7 +2,7 @@ open UIEventsTypes
 open FileTypes
 open FileAndDirectoryEntriesTypes
 
-type t = dataTransferItem
+type t = dataTransferItem = {...dataTransferItem}
 
 /**
 Invokes the callback with the string data as the argument, if the drag data item kind is text.

--- a/src/UIEventsAPI/DataTransferItemList.res
+++ b/src/UIEventsAPI/DataTransferItemList.res
@@ -1,6 +1,8 @@
 open UIEventsTypes
 open FileTypes
 
+type t = dataTransferItemList
+
 /**
 Adds a new entry for the given data to the drag data store. If the data is plain text then a type string has to be provided also.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransferItemList/add)

--- a/src/UIEventsAPI/DataTransferItemList.res
+++ b/src/UIEventsAPI/DataTransferItemList.res
@@ -1,7 +1,7 @@
 open UIEventsTypes
 open FileTypes
 
-type t = dataTransferItemList
+type t = dataTransferItemList = {...dataTransferItemList}
 
 /**
 Adds a new entry for the given data to the drag data store. If the data is plain text then a type string has to be provided also.

--- a/src/UIEventsAPI/FocusEvent.res
+++ b/src/UIEventsAPI/FocusEvent.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = focusEvent
+type t = focusEvent = {...focusEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FocusEvent)

--- a/src/UIEventsAPI/FocusEvent.res
+++ b/src/UIEventsAPI/FocusEvent.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = focusEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FocusEvent)
 */

--- a/src/UIEventsAPI/InputEvent.res
+++ b/src/UIEventsAPI/InputEvent.res
@@ -1,6 +1,8 @@
 open UIEventsTypes
 open DOMTypes
 
+type t = inputEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/InputEvent)
 */

--- a/src/UIEventsAPI/InputEvent.res
+++ b/src/UIEventsAPI/InputEvent.res
@@ -1,7 +1,7 @@
 open UIEventsTypes
 open DOMTypes
 
-type t = inputEvent
+type t = inputEvent = {...inputEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/InputEvent)

--- a/src/UIEventsAPI/KeyboardEvent.res
+++ b/src/UIEventsAPI/KeyboardEvent.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = keyboardEvent
+type t = keyboardEvent = {...keyboardEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/KeyboardEvent)

--- a/src/UIEventsAPI/KeyboardEvent.res
+++ b/src/UIEventsAPI/KeyboardEvent.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = keyboardEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/KeyboardEvent)
 */

--- a/src/UIEventsAPI/MouseEvent.res
+++ b/src/UIEventsAPI/MouseEvent.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = mouseEvent
+type t = mouseEvent = {...mouseEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MouseEvent)

--- a/src/UIEventsAPI/MouseEvent.res
+++ b/src/UIEventsAPI/MouseEvent.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = mouseEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MouseEvent)
 */

--- a/src/UIEventsAPI/PointerEvent.res
+++ b/src/UIEventsAPI/PointerEvent.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = pointerEvent
+type t = pointerEvent = {...pointerEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PointerEvent)

--- a/src/UIEventsAPI/PointerEvent.res
+++ b/src/UIEventsAPI/PointerEvent.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = pointerEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PointerEvent)
 */

--- a/src/UIEventsAPI/Touch.res
+++ b/src/UIEventsAPI/Touch.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = touch
+type t = touch = {...touch}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Touch)

--- a/src/UIEventsAPI/Touch.res
+++ b/src/UIEventsAPI/Touch.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = touch
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Touch)
 */

--- a/src/UIEventsAPI/TouchEvent.res
+++ b/src/UIEventsAPI/TouchEvent.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = touchEvent
+type t = touchEvent = {...touchEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TouchEvent)

--- a/src/UIEventsAPI/TouchEvent.res
+++ b/src/UIEventsAPI/TouchEvent.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = touchEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TouchEvent)
 */

--- a/src/UIEventsAPI/TouchList.res
+++ b/src/UIEventsAPI/TouchList.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = touchList
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TouchList/item)
 */

--- a/src/UIEventsAPI/TouchList.res
+++ b/src/UIEventsAPI/TouchList.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = touchList
+type t = touchList = {...touchList}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TouchList/item)

--- a/src/UIEventsAPI/UIEvent.res
+++ b/src/UIEventsAPI/UIEvent.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = uiEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/UIEvent)
 */

--- a/src/UIEventsAPI/UIEvent.res
+++ b/src/UIEventsAPI/UIEvent.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = uiEvent
+type t = uiEvent = {...uiEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/UIEvent)

--- a/src/UIEventsAPI/WheelEvent.res
+++ b/src/UIEventsAPI/WheelEvent.res
@@ -1,6 +1,6 @@
 open UIEventsTypes
 
-type t = wheelEvent
+type t = wheelEvent = {...wheelEvent}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WheelEvent)

--- a/src/UIEventsAPI/WheelEvent.res
+++ b/src/UIEventsAPI/WheelEvent.res
@@ -1,5 +1,7 @@
 open UIEventsTypes
 
+type t = wheelEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WheelEvent)
 */

--- a/src/ViewTransitionsAPI/ViewTransition.res
+++ b/src/ViewTransitionsAPI/ViewTransition.res
@@ -1,6 +1,6 @@
 open ViewTransitionsTypes
 
-type t = viewTransition
+type t = viewTransition = {...viewTransition}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ViewTransition/skipTransition)

--- a/src/ViewTransitionsAPI/ViewTransition.res
+++ b/src/ViewTransitionsAPI/ViewTransition.res
@@ -1,5 +1,7 @@
 open ViewTransitionsTypes
 
+type t = viewTransition
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ViewTransition/skipTransition)
 */

--- a/tests/DOMAPI/AddEventListener__test.res
+++ b/tests/DOMAPI/AddEventListener__test.res
@@ -1,12 +1,10 @@
 open WebAPI
-open WebAPI.Global
-
-let button = document->Document.querySelector("button")->Null.toOption
-let h2 = document->Document.querySelector("h2")->Null.toOption
+let button = Window.current.document->Document.querySelector("button")->Null.toOption
+let h2 = Window.current.document->Document.querySelector("h2")->Null.toOption
 
 switch (button, h2) {
 | (Some(button), Some(h2)) =>
-  button->Element.addEventListener(EventTypes.Click, (e: UIEventsTypes.mouseEvent) => {
+  button->Element.addEventListener(EventTypes.Click, (e: MouseEvent.t) => {
     Console.log(`Button clicked, ${Int.toString(e.button)}`)
     switch h2.textContent {
     | Null => h2.textContent = Value("1")

--- a/tests/DOMAPI/Element__test.res
+++ b/tests/DOMAPI/Element__test.res
@@ -1,4 +1,4 @@
-external myElement: DOMTypes.element = "myElement"
+external myElement: Element.t = "myElement"
 
 switch myElement->Element.getAttribute("foo") {
 | Null.Value(value) => value->Console.log

--- a/tests/DOMAPI/HTMLCanvasElement__test.res
+++ b/tests/DOMAPI/HTMLCanvasElement__test.res
@@ -1,7 +1,5 @@
-open WebAPI.Global
-
-let myCanvas: DOMTypes.htmlCanvasElement =
-  document->Document.getElementById("myCanvas")->Prelude.unsafeConversation
+let myCanvas: HTMLCanvasElement.t =
+  Window.current.document->Document.getElementById("myCanvas")->Prelude.unsafeConversation
 let ctx = myCanvas->HTMLCanvasElement.getContext2D
 
 ctx.fillStyle = FillStyle.fromString("red")
@@ -18,7 +16,7 @@ switch ctx.fillStyle->FillStyle.decode {
 | FillStyle.CanvasPattern(_) => Console.log("CanvasPattern")
 }
 
-let img: DOMTypes.htmlImageElement = document->Document.createElement("img")->Obj.magic
+let img: HTMLImageElement.t = Window.current.document->Document.createElement("img")->Obj.magic
 ctx->CanvasRenderingContext2D.drawImageWithDimensions(
   ~image=img,
   ~dx=0.,

--- a/tests/DOMAPI/HTMLElement__test.res
+++ b/tests/DOMAPI/HTMLElement__test.res
@@ -1,7 +1,6 @@
 open WebAPI
-open WebAPI.Global
 
-document
+Window.current.document
 ->Document.querySelector("form")
 ->Null.toOption
 ->Option.forEach(form => {

--- a/tests/DOMAPI/HTMLInputElement__test.res
+++ b/tests/DOMAPI/HTMLInputElement__test.res
@@ -1,5 +1,3 @@
-open Global
-
-let input: DOMTypes.htmlInputElement =
-  document->Document.createElement("input")->Prelude.unsafeConversation
+let input: HTMLInputElement.t =
+  Window.current.document->Document.createElement("input")->Prelude.unsafeConversation
 let value = input.value

--- a/tests/DOMAPI/Location__test.res
+++ b/tests/DOMAPI/Location__test.res
@@ -1,7 +1,4 @@
-open Global
-
-// Note that this only works when you added the `-open Global` bsc flag.
-let location = window.location
+let location = Window.current.location
 
 // Access properties using `.`
 let href = location.href

--- a/tests/IntersectionObserverAPI/IntersectionObserver__test.res
+++ b/tests/IntersectionObserverAPI/IntersectionObserver__test.res
@@ -1,10 +1,10 @@
-let observer = IntersectionObserver.make(~callback=(entry, observer) => {
+let observer: IntersectionObserver.t = IntersectionObserver.make(~callback=(entry, observer) => {
   Console.log2(entry, observer)
 })
 
-let root = Global.document->Document.querySelector("#root")->Null.getUnsafe
+let root = Window.current.document->Document.querySelector("#root")->Null.getUnsafe
 
-let observer2 = IntersectionObserver.make(
+let observer2: IntersectionObserver.t = IntersectionObserver.make(
   ~callback=(entry, observer) => {
     Console.log2(entry, observer)
   },
@@ -22,7 +22,7 @@ switch observer2.root->IntersectionObserverRoot.decode {
 }
 let rootMargin2 = observer2.rootMargin
 
-let targetElement = Global.document->Document.querySelector("#targetElement")->Null.toOption
+let targetElement = Window.current.document->Document.querySelector("#targetElement")->Null.toOption
 switch targetElement {
 | Some(e) => {
     observer2->IntersectionObserver.observe(e)

--- a/tests/MutationObserverAPI/MutationObserver__test.res
+++ b/tests/MutationObserverAPI/MutationObserver__test.res
@@ -1,5 +1,5 @@
-let observer = MutationObserver.make((mutations, obs) => {
-  let button = Global.document->Document.querySelector("button")
+let observer: MutationObserver.t = MutationObserver.make((mutations, obs) => {
+  let button = Window.current.document->Document.querySelector("button")
   switch button->Null.toOption {
   | Some(button) => {
       Console.log(button)
@@ -11,7 +11,7 @@ let observer = MutationObserver.make((mutations, obs) => {
 })
 
 observer->MutationObserver.observe(
-  ~target=Global.document->Document.asNode,
+  ~target=Window.current.document->Document.asNode,
   ~options={childList: true, subtree: true},
 )
 


### PR DESCRIPTION
## Summary
- add concrete-module `t` aliases across the DOM, event, UIEvents,
  and observer surface
- update DOM-facing tests to use `Window.current` and concrete module
  aliases instead of reaching into raw `*Types` modules
- remove the trivial DOM
  `voidFunction` alias while keeping meaningful callback contracts such as
  `frameRequestCallback`

## Validation
- `npm run build`
- `npm test`

## Related
-
  Refs #238