### PR TITLE
refactor: simplify fetch, file, canvas, URL, and socket module surfaces

### DIFF
--- a/src/CSSFontLoadingAPI/FontFace.res
+++ b/src/CSSFontLoadingAPI/FontFace.res
@@ -1,6 +1,6 @@
 module Types = CSSFontLoadingTypes
 
-type t = Types.fontFace
+type t = Types.fontFace = {...Types.fontFace}
 type fontDisplay = Types.fontDisplay
 type fontFaceLoadStatus = Types.fontFaceLoadStatus
 type fontFaceDescriptors = Types.fontFaceDescriptors = {...Types.fontFaceDescriptors}

--- a/src/CSSFontLoadingAPI/FontFace.res
+++ b/src/CSSFontLoadingAPI/FontFace.res
@@ -1,10 +1,15 @@
-open CSSFontLoadingTypes
+module Types = CSSFontLoadingTypes
+
+type t = Types.fontFace
+type fontDisplay = Types.fontDisplay
+type fontFaceLoadStatus = Types.fontFaceLoadStatus
+type fontFaceDescriptors = Types.fontFaceDescriptors
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace)
 */
 @new
-external make: (~family: string, ~source: string, ~descriptors: fontFaceDescriptors=?) => fontFace =
+external make: (~family: string, ~source: string, ~descriptors: fontFaceDescriptors=?) => t =
   "FontFace"
 
 /**
@@ -15,7 +20,7 @@ external make2: (
   ~family: string,
   ~source: DataView.t,
   ~descriptors: fontFaceDescriptors=?,
-) => fontFace = "FontFace"
+) => t = "FontFace"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace)
@@ -25,10 +30,10 @@ external make3: (
   ~family: string,
   ~source: ArrayBuffer.t,
   ~descriptors: fontFaceDescriptors=?,
-) => fontFace = "FontFace"
+) => t = "FontFace"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace/load)
 */
 @send
-external load: fontFace => promise<fontFace> = "load"
+external load: t => promise<t> = "load"

--- a/src/CSSFontLoadingAPI/FontFace.res
+++ b/src/CSSFontLoadingAPI/FontFace.res
@@ -3,7 +3,7 @@ module Types = CSSFontLoadingTypes
 type t = Types.fontFace
 type fontDisplay = Types.fontDisplay
 type fontFaceLoadStatus = Types.fontFaceLoadStatus
-type fontFaceDescriptors = Types.fontFaceDescriptors
+type fontFaceDescriptors = Types.fontFaceDescriptors = {...Types.fontFaceDescriptors}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace)

--- a/src/CSSFontLoadingAPI/FontFaceSet.res
+++ b/src/CSSFontLoadingAPI/FontFaceSet.res
@@ -1,7 +1,7 @@
 module Types = CSSFontLoadingTypes
 
-type t = Types.fontFaceSet
-type fontFace = Types.fontFace
+type t = Types.fontFaceSet = {...Types.fontFaceSet}
+type fontFace = Types.fontFace = {...Types.fontFace}
 type fontFaceSetLoadStatus = Types.fontFaceSetLoadStatus
 
 include EventTarget.Impl({type t = t})

--- a/src/CSSFontLoadingAPI/FontFaceSet.res
+++ b/src/CSSFontLoadingAPI/FontFaceSet.res
@@ -1,33 +1,37 @@
-open CSSFontLoadingTypes
+module Types = CSSFontLoadingTypes
 
-include EventTarget.Impl({type t = fontFaceSet})
+type t = Types.fontFaceSet
+type fontFace = Types.fontFace
+type fontFaceSetLoadStatus = Types.fontFaceSetLoadStatus
+
+include EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/add)
 */
 @send
-external add: (fontFaceSet, fontFace) => fontFaceSet = "add"
+external add: (t, fontFace) => t = "add"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/delete)
 */
 @send
-external delete: (fontFaceSet, fontFace) => bool = "delete"
+external delete: (t, fontFace) => bool = "delete"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/clear)
 */
 @send
-external clear: fontFaceSet => unit = "clear"
+external clear: t => unit = "clear"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/load)
 */
 @send
-external load: (fontFaceSet, ~font: string, ~text: string=?) => promise<array<fontFace>> = "load"
+external load: (t, ~font: string, ~text: string=?) => promise<array<fontFace>> = "load"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/check)
 */
 @send
-external check: (fontFaceSet, ~font: string, ~text: string=?) => bool = "check"
+external check: (t, ~font: string, ~text: string=?) => bool = "check"

--- a/src/CanvasAPI/CanvasGradient.res
+++ b/src/CanvasAPI/CanvasGradient.res
@@ -1,4 +1,6 @@
-open CanvasTypes
+module Types = CanvasTypes
+
+type t = Types.canvasGradient
 
 /**
 Adds a color stop with the given color to the gradient at the given offset. 0.0 is the offset at one end of the gradient, 1.0 is the offset at the other end.
@@ -7,6 +9,6 @@ Throws an "IndexSizeError" DOMException if the offset is out of range. Throws a 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasGradient/addColorStop)
 */
 @send
-external addColorStop: (canvasGradient, ~offset: float, ~color: string) => unit = "addColorStop"
+external addColorStop: (t, ~offset: float, ~color: string) => unit = "addColorStop"
 
 let isInstanceOf = (_: 't): bool => %raw(`param instanceof CanvasGradient`)

--- a/src/CanvasAPI/CanvasGradient.res
+++ b/src/CanvasAPI/CanvasGradient.res
@@ -1,6 +1,6 @@
 module Types = CanvasTypes
 
-type t = Types.canvasGradient
+type t = Types.canvasGradient = {...Types.canvasGradient}
 
 /**
 Adds a color stop with the given color to the gradient at the given offset. 0.0 is the offset at one end of the gradient, 1.0 is the offset at the other end.

--- a/src/CanvasAPI/CanvasPattern.res
+++ b/src/CanvasAPI/CanvasPattern.res
@@ -1,6 +1,6 @@
 module Types = CanvasTypes
 
-type t = Types.canvasPattern
+type t = Types.canvasPattern = {...Types.canvasPattern}
 
 /**
 Sets the transformation matrix that will be used when rendering the pattern during a fill or stroke painting operation.

--- a/src/CanvasAPI/CanvasPattern.res
+++ b/src/CanvasAPI/CanvasPattern.res
@@ -1,11 +1,12 @@
-open DOMTypes
-open CanvasTypes
+module Types = CanvasTypes
+
+type t = Types.canvasPattern
 
 /**
 Sets the transformation matrix that will be used when rendering the pattern during a fill or stroke painting operation.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasPattern/setTransform)
 */
 @send
-external setTransform: (canvasPattern, ~transform: domMatrix2DInit=?) => unit = "setTransform"
+external setTransform: (t, ~transform: DOMTypes.domMatrix2DInit=?) => unit = "setTransform"
 
 let isInstanceOf = (_: 't): bool => %raw(`param instanceof CanvasPattern`)

--- a/src/CanvasAPI/FillStyle.res
+++ b/src/CanvasAPI/FillStyle.res
@@ -3,8 +3,8 @@ open Prelude
 module Types = CanvasTypes
 
 type t = Types.fillStyle
-type canvasGradient = Types.canvasGradient
-type canvasPattern = Types.canvasPattern
+type canvasGradient = Types.canvasGradient = {...Types.canvasGradient}
+type canvasPattern = Types.canvasPattern = {...Types.canvasPattern}
 
 external fromString: string => t = "%identity"
 external fromCanvasGradient: canvasGradient => t = "%identity"

--- a/src/CanvasAPI/FillStyle.res
+++ b/src/CanvasAPI/FillStyle.res
@@ -1,9 +1,14 @@
 open Prelude
-open CanvasTypes
 
-external fromString: string => fillStyle = "%identity"
-external fromCanvasGradient: canvasGradient => fillStyle = "%identity"
-external fromCanvasPattern: canvasGradient => fillStyle = "%identity"
+module Types = CanvasTypes
+
+type t = Types.fillStyle
+type canvasGradient = Types.canvasGradient
+type canvasPattern = Types.canvasPattern
+
+external fromString: string => t = "%identity"
+external fromCanvasGradient: canvasGradient => t = "%identity"
+external fromCanvasPattern: canvasPattern => t = "%identity"
 
 /**
 Represents a decoded version of the abstract `fillStyle` type, used in Context2D.
@@ -13,12 +18,12 @@ type decoded =
   | CanvasGradient(canvasGradient)
   | CanvasPattern(canvasPattern)
 
-let decode = (t: fillStyle): decoded => {
-  if CanvasGradient.isInstanceOf(t) {
-    CanvasGradient(unsafeConversation(t))
-  } else if CanvasPattern.isInstanceOf(t) {
-    CanvasPattern(unsafeConversation(t))
+let decode = (value: t): decoded => {
+  if CanvasGradient.isInstanceOf(value) {
+    CanvasGradient(unsafeConversation(value))
+  } else if CanvasPattern.isInstanceOf(value) {
+    CanvasPattern(unsafeConversation(value))
   } else {
-    String(unsafeConversation(t))
+    String(unsafeConversation(value))
   }
 }

--- a/src/CanvasAPI/ImageBitmap.res
+++ b/src/CanvasAPI/ImageBitmap.res
@@ -1,6 +1,6 @@
 module Types = CanvasTypes
 
-type t = Types.imageBitmap
+type t = Types.imageBitmap = {...Types.imageBitmap}
 
 /**
 Releases imageBitmap's underlying bitmap data.

--- a/src/CanvasAPI/ImageBitmap.res
+++ b/src/CanvasAPI/ImageBitmap.res
@@ -1,8 +1,10 @@
-open CanvasTypes
+module Types = CanvasTypes
+
+type t = Types.imageBitmap
 
 /**
 Releases imageBitmap's underlying bitmap data.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ImageBitmap/close)
 */
 @send
-external close: imageBitmap => unit = "close"
+external close: t => unit = "close"

--- a/src/CanvasAPI/ImageBitmapRenderingContext.res
+++ b/src/CanvasAPI/ImageBitmapRenderingContext.res
@@ -1,7 +1,7 @@
 module Types = CanvasTypes
 
-type t = Types.imageBitmapRenderingContext
-type imageBitmap = Types.imageBitmap
+type t = Types.imageBitmapRenderingContext = {...Types.imageBitmapRenderingContext}
+type imageBitmap = Types.imageBitmap = {...Types.imageBitmap}
 
 /**
 Transfers the underlying bitmap data from imageBitmap to context, and the bitmap becomes the contents of the canvas element to which context is bound.

--- a/src/CanvasAPI/ImageBitmapRenderingContext.res
+++ b/src/CanvasAPI/ImageBitmapRenderingContext.res
@@ -8,5 +8,4 @@ Transfers the underlying bitmap data from imageBitmap to context, and the bitmap
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext/transferFromImageBitmap)
 */
 @send
-external transferFromImageBitmap: (t, imageBitmap) => unit =
-  "transferFromImageBitmap"
+external transferFromImageBitmap: (t, imageBitmap) => unit = "transferFromImageBitmap"

--- a/src/CanvasAPI/ImageBitmapRenderingContext.res
+++ b/src/CanvasAPI/ImageBitmapRenderingContext.res
@@ -1,9 +1,12 @@
-open CanvasTypes
+module Types = CanvasTypes
+
+type t = Types.imageBitmapRenderingContext
+type imageBitmap = Types.imageBitmap
 
 /**
 Transfers the underlying bitmap data from imageBitmap to context, and the bitmap becomes the contents of the canvas element to which context is bound.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext/transferFromImageBitmap)
 */
 @send
-external transferFromImageBitmap: (imageBitmapRenderingContext, imageBitmap) => unit =
+external transferFromImageBitmap: (t, imageBitmap) => unit =
   "transferFromImageBitmap"

--- a/src/CanvasAPI/OffscreenCanvas.res
+++ b/src/CanvasAPI/OffscreenCanvas.res
@@ -4,15 +4,18 @@ module Types = CanvasTypes
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas)
 */
 @new
-type t = Types.offscreenCanvas
-type imageBitmap = Types.imageBitmap
-type offscreenCanvasRenderingContext2D = Types.offscreenCanvasRenderingContext2D
-type webGLRenderingContext = Types.webGLRenderingContext
-type webGL2RenderingContext = Types.webGL2RenderingContext
-type webGLContextAttributes = Types.webGLContextAttributes
-type imageBitmapRenderingContext = Types.imageBitmapRenderingContext
-type imageBitmapRenderingContextSettings = Types.imageBitmapRenderingContextSettings
-type imageEncodeOptions = Types.imageEncodeOptions
+type t = Types.offscreenCanvas = {...Types.offscreenCanvas}
+type imageBitmap = Types.imageBitmap = {...Types.imageBitmap}
+type offscreenCanvasRenderingContext2D =
+  Types.offscreenCanvasRenderingContext2D = {...Types.offscreenCanvasRenderingContext2D}
+type webGLRenderingContext = Types.webGLRenderingContext = {...Types.webGLRenderingContext}
+type webGL2RenderingContext = Types.webGL2RenderingContext = {...Types.webGL2RenderingContext}
+type webGLContextAttributes = Types.webGLContextAttributes = {...Types.webGLContextAttributes}
+type imageBitmapRenderingContext =
+  Types.imageBitmapRenderingContext = {...Types.imageBitmapRenderingContext}
+type imageBitmapRenderingContextSettings =
+  Types.imageBitmapRenderingContextSettings = {...Types.imageBitmapRenderingContextSettings}
+type imageEncodeOptions = Types.imageEncodeOptions = {...Types.imageEncodeOptions}
 
 external make: (~width: int, ~height: int) => t = "OffscreenCanvas"
 

--- a/src/CanvasAPI/OffscreenCanvas.res
+++ b/src/CanvasAPI/OffscreenCanvas.res
@@ -1,13 +1,22 @@
-open CanvasTypes
-open FileTypes
+module Types = CanvasTypes
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas)
 */
 @new
-external make: (~width: int, ~height: int) => offscreenCanvas = "OffscreenCanvas"
+type t = Types.offscreenCanvas
+type imageBitmap = Types.imageBitmap
+type offscreenCanvasRenderingContext2D = Types.offscreenCanvasRenderingContext2D
+type webGLRenderingContext = Types.webGLRenderingContext
+type webGL2RenderingContext = Types.webGL2RenderingContext
+type webGLContextAttributes = Types.webGLContextAttributes
+type imageBitmapRenderingContext = Types.imageBitmapRenderingContext
+type imageBitmapRenderingContextSettings = Types.imageBitmapRenderingContextSettings
+type imageEncodeOptions = Types.imageEncodeOptions
 
-include EventTarget.Impl({type t = offscreenCanvas})
+external make: (~width: int, ~height: int) => t = "OffscreenCanvas"
+
+include EventTarget.Impl({type t = t})
 
 /**
 Returns an object that exposes an API for drawing on the OffscreenCanvas object. contextId specifies the desired API: "2d", "bitmaprenderer", "webgl", or "webgl2". options is handled by that API.
@@ -19,7 +28,7 @@ Returns null if the canvas has already been initialized with another context typ
 */
 @send
 external getContext2D: (
-  offscreenCanvas,
+  t,
   @as("2d") _,
   ~options: JSON.t=?,
 ) => offscreenCanvasRenderingContext2D = "getContext"
@@ -34,7 +43,7 @@ Returns null if the canvas has already been initialized with another context typ
 */
 @send
 external getContextWebGL: (
-  offscreenCanvas,
+  t,
   @as("webgl") _,
   ~options: webGLContextAttributes=?,
 ) => webGLRenderingContext = "getContext"
@@ -49,7 +58,7 @@ Returns null if the canvas has already been initialized with another context typ
 */
 @send
 external getContextWebGL2: (
-  offscreenCanvas,
+  t,
   @as("webgl2") _,
   ~options: webGLContextAttributes=?,
 ) => webGL2RenderingContext = "getContext"
@@ -64,7 +73,7 @@ Returns null if the canvas has already been initialized with another context typ
 */
 @send
 external getContextBitmapRenderer: (
-  offscreenCanvas,
+  t,
   @as("bitmaprenderer") _,
   ~options: imageBitmapRenderingContextSettings=?,
 ) => imageBitmapRenderingContext = "getContext"
@@ -74,7 +83,7 @@ Returns a newly created ImageBitmap object with the image in the OffscreenCanvas
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/transferToImageBitmap)
 */
 @send
-external transferToImageBitmap: offscreenCanvas => imageBitmap = "transferToImageBitmap"
+external transferToImageBitmap: t => imageBitmap = "transferToImageBitmap"
 
 /**
 Returns a promise that will fulfill with a new Blob object representing a file containing the image in the OffscreenCanvas object.
@@ -83,5 +92,5 @@ The argument, if provided, is a dictionary that controls the encoding options of
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/convertToBlob)
 */
 @send
-external convertToBlob: (offscreenCanvas, ~options: imageEncodeOptions=?) => promise<blob> =
+external convertToBlob: (t, ~options: imageEncodeOptions=?) => promise<FileTypes.blob> =
   "convertToBlob"

--- a/src/CanvasAPI/OffscreenCanvas.res
+++ b/src/CanvasAPI/OffscreenCanvas.res
@@ -6,15 +6,18 @@ module Types = CanvasTypes
 @new
 type t = Types.offscreenCanvas = {...Types.offscreenCanvas}
 type imageBitmap = Types.imageBitmap = {...Types.imageBitmap}
-type offscreenCanvasRenderingContext2D =
-  Types.offscreenCanvasRenderingContext2D = {...Types.offscreenCanvasRenderingContext2D}
+type offscreenCanvasRenderingContext2D = Types.offscreenCanvasRenderingContext2D = {
+  ...Types.offscreenCanvasRenderingContext2D,
+}
 type webGLRenderingContext = Types.webGLRenderingContext = {...Types.webGLRenderingContext}
 type webGL2RenderingContext = Types.webGL2RenderingContext = {...Types.webGL2RenderingContext}
 type webGLContextAttributes = Types.webGLContextAttributes = {...Types.webGLContextAttributes}
-type imageBitmapRenderingContext =
-  Types.imageBitmapRenderingContext = {...Types.imageBitmapRenderingContext}
-type imageBitmapRenderingContextSettings =
-  Types.imageBitmapRenderingContextSettings = {...Types.imageBitmapRenderingContextSettings}
+type imageBitmapRenderingContext = Types.imageBitmapRenderingContext = {
+  ...Types.imageBitmapRenderingContext,
+}
+type imageBitmapRenderingContextSettings = Types.imageBitmapRenderingContextSettings = {
+  ...Types.imageBitmapRenderingContextSettings,
+}
 type imageEncodeOptions = Types.imageEncodeOptions = {...Types.imageEncodeOptions}
 
 external make: (~width: int, ~height: int) => t = "OffscreenCanvas"
@@ -30,11 +33,8 @@ Returns null if the canvas has already been initialized with another context typ
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/getContext)
 */
 @send
-external getContext2D: (
-  t,
-  @as("2d") _,
-  ~options: JSON.t=?,
-) => offscreenCanvasRenderingContext2D = "getContext"
+external getContext2D: (t, @as("2d") _, ~options: JSON.t=?) => offscreenCanvasRenderingContext2D =
+  "getContext"
 
 /**
 Returns an object that exposes an API for drawing on the OffscreenCanvas object. contextId specifies the desired API: "2d", "bitmaprenderer", "webgl", or "webgl2". options is handled by that API.

--- a/src/CanvasAPI/Path2D.res
+++ b/src/CanvasAPI/Path2D.res
@@ -1,41 +1,42 @@
-open CanvasTypes
-open DOMTypes
+module Types = CanvasTypes
+
+type t = Types.path2D
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Path2D)
 */
 @new
-external make: (~path: path2D=?) => path2D = "Path2D"
+external make: (~path: t=?) => t = "Path2D"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Path2D)
 */
 @new
-external make2: (~path: string=?) => path2D = "Path2D"
+external make2: (~path: string=?) => t = "Path2D"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/closePath)
 */
 @send
-external closePath: path2D => unit = "closePath"
+external closePath: t => unit = "closePath"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/moveTo)
 */
 @send
-external moveTo: (path2D, ~x: float, ~y: float) => unit = "moveTo"
+external moveTo: (t, ~x: float, ~y: float) => unit = "moveTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/lineTo)
 */
 @send
-external lineTo: (path2D, ~x: float, ~y: float) => unit = "lineTo"
+external lineTo: (t, ~x: float, ~y: float) => unit = "lineTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/quadraticCurveTo)
 */
 @send
-external quadraticCurveTo: (path2D, ~cpx: float, ~cpy: float, ~x: float, ~y: float) => unit =
+external quadraticCurveTo: (t, ~cpx: float, ~cpy: float, ~x: float, ~y: float) => unit =
   "quadraticCurveTo"
 
 /**
@@ -43,7 +44,7 @@ external quadraticCurveTo: (path2D, ~cpx: float, ~cpy: float, ~x: float, ~y: flo
 */
 @send
 external bezierCurveTo: (
-  path2D,
+  t,
   ~cp1x: float,
   ~cp1y: float,
   ~cp2x: float,
@@ -56,21 +57,21 @@ external bezierCurveTo: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/arcTo)
 */
 @send
-external arcTo: (path2D, ~x1: float, ~y1: float, ~x2: float, ~y2: float, ~radius: float) => unit =
+external arcTo: (t, ~x1: float, ~y1: float, ~x2: float, ~y2: float, ~radius: float) => unit =
   "arcTo"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/rect)
 */
 @send
-external rect: (path2D, ~x: float, ~y: float, ~w: float, ~h: float) => unit = "rect"
+external rect: (t, ~x: float, ~y: float, ~w: float, ~h: float) => unit = "rect"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
 */
 @send
 external roundRect: (
-  path2D,
+  t,
   ~x: float,
   ~y: float,
   ~w: float,
@@ -83,7 +84,7 @@ external roundRect: (
 */
 @send
 external roundRect2: (
-  path2D,
+  t,
   ~x: float,
   ~y: float,
   ~w: float,
@@ -96,7 +97,7 @@ external roundRect2: (
 */
 @send
 external roundRect3: (
-  path2D,
+  t,
   ~x: float,
   ~y: float,
   ~w: float,
@@ -109,7 +110,7 @@ external roundRect3: (
 */
 @send
 external arc: (
-  path2D,
+  t,
   ~x: float,
   ~y: float,
   ~radius: float,
@@ -123,7 +124,7 @@ external arc: (
 */
 @send
 external ellipse: (
-  path2D,
+  t,
   ~x: float,
   ~y: float,
   ~radiusX: float,
@@ -139,4 +140,4 @@ Adds to the path the path given by the argument.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Path2D/addPath)
 */
 @send
-external addPath: (path2D, ~path: path2D, ~transform: domMatrix2DInit=?) => unit = "addPath"
+external addPath: (t, ~path: t, ~transform: DOMTypes.domMatrix2DInit=?) => unit = "addPath"

--- a/src/CanvasAPI/Path2D.res
+++ b/src/CanvasAPI/Path2D.res
@@ -1,6 +1,6 @@
 module Types = CanvasTypes
 
-type t = Types.path2D
+type t = Types.path2D = {...Types.path2D}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Path2D)

--- a/src/ChannelMessagingAPI/MessagePort.res
+++ b/src/ChannelMessagingAPI/MessagePort.res
@@ -1,7 +1,8 @@
 module Types = ChannelMessagingTypes
 
-type t = Types.messagePort
-type structuredSerializeOptions = Types.structuredSerializeOptions
+type t = Types.messagePort = {...Types.messagePort}
+type structuredSerializeOptions =
+  Types.structuredSerializeOptions = {...Types.structuredSerializeOptions}
 
 include EventTarget.Impl({type t = t})
 

--- a/src/ChannelMessagingAPI/MessagePort.res
+++ b/src/ChannelMessagingAPI/MessagePort.res
@@ -1,8 +1,9 @@
 module Types = ChannelMessagingTypes
 
 type t = Types.messagePort = {...Types.messagePort}
-type structuredSerializeOptions =
-  Types.structuredSerializeOptions = {...Types.structuredSerializeOptions}
+type structuredSerializeOptions = Types.structuredSerializeOptions = {
+  ...Types.structuredSerializeOptions,
+}
 
 include EventTarget.Impl({type t = t})
 

--- a/src/ChannelMessagingAPI/MessagePort.res
+++ b/src/ChannelMessagingAPI/MessagePort.res
@@ -1,6 +1,9 @@
-open ChannelMessagingTypes
+module Types = ChannelMessagingTypes
 
-include EventTarget.Impl({type t = messagePort})
+type t = Types.messagePort
+type structuredSerializeOptions = Types.structuredSerializeOptions
+
+include EventTarget.Impl({type t = t})
 
 /**
 Posts a message through the channel. Objects listed in transfer are transferred, not just cloned, meaning that they are no longer usable on the sending side.
@@ -9,7 +12,7 @@ Throws a "DataCloneError" DOMException if transfer contains duplicate objects or
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessagePort/postMessage)
 */
 @send
-external postMessage: (messagePort, ~message: JSON.t, ~transfer: array<Dict.t<string>>) => unit =
+external postMessage: (t, ~message: JSON.t, ~transfer: array<Dict.t<string>>) => unit =
   "postMessage"
 
 /**
@@ -20,7 +23,7 @@ Throws a "DataCloneError" DOMException if transfer contains duplicate objects or
 */
 @send
 external postMessage2: (
-  messagePort,
+  t,
   ~message: JSON.t,
   ~options: structuredSerializeOptions=?,
 ) => unit = "postMessage"
@@ -30,11 +33,11 @@ Begins dispatching messages received on the port.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessagePort/start)
 */
 @send
-external start: messagePort => unit = "start"
+external start: t => unit = "start"
 
 /**
 Disconnects the port, so that it is no longer active.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessagePort/close)
 */
 @send
-external close: messagePort => unit = "close"
+external close: t => unit = "close"

--- a/src/FetchAPI/BodyInit.res
+++ b/src/FetchAPI/BodyInit.res
@@ -1,48 +1,48 @@
-open FileTypes
-open FetchTypes
-open URLTypes
+module Types = FetchTypes
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromString: string => bodyInit = "%identity"
+type t = Types.bodyInit
+
+external fromString: string => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromArrayBuffer: ArrayBuffer.t => bodyInit = "%identity"
+external fromArrayBuffer: ArrayBuffer.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromTypedArray: TypedArray.t<'t> => bodyInit = "%identity"
+external fromTypedArray: TypedArray.t<'t> => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromDataView: DataView.t => bodyInit = "%identity"
+external fromDataView: DataView.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromBlob: blob => bodyInit = "%identity"
+external fromBlob: FileTypes.blob => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromFile: file => bodyInit = "%identity"
+external fromFile: FileTypes.file => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromURLSearchParams: urlSearchParams => bodyInit = "%identity"
+external fromURLSearchParams: URLTypes.urlSearchParams => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromFormData: formData => bodyInit = "%identity"
+external fromFormData: Types.formData => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromReadableStream: readableStream<'t> => bodyInit = "%identity"
+external fromReadableStream: FileTypes.readableStream<'t> => t = "%identity"

--- a/src/FetchAPI/FormData.res
+++ b/src/FetchAPI/FormData.res
@@ -1,70 +1,73 @@
-open FetchTypes
-open FileTypes
-open DOMTypes
+module Types = FetchTypes
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData)
-*/
+ */
 @new
-external make: (~form: htmlFormElement=?, ~submitter: htmlElement=?) => formData = "FormData"
+type t = Types.formData
+type formDataEntryValue = Types.formDataEntryValue
+
+external make: (~form: DOMTypes.htmlFormElement=?, ~submitter: DOMTypes.htmlElement=?) => t =
+  "FormData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/append)
 */
 @send
-external append: (formData, ~name: string, ~value: string) => unit = "append"
+external append: (t, ~name: string, ~value: string) => unit = "append"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/append)
 */
 @send
-external appendBlob: (formData, ~name: string, ~blobValue: blob, ~filename: string=?) => unit =
+external appendBlob: (t, ~name: string, ~blobValue: FileTypes.blob, ~filename: string=?) => unit =
   "append"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/delete)
 */
 @send
-external delete: (formData, string) => unit = "delete"
+external delete: (t, string) => unit = "delete"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/get)
 */
 @send
-external get: (formData, string) => null<formDataEntryValue> = "get"
+external get: (t, string) => null<formDataEntryValue> = "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/getAll)
 */
 @send
-external getAll: (formData, string) => array<formDataEntryValue> = "getAll"
+external getAll: (t, string) => array<formDataEntryValue> = "getAll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/has)
 */
 @send
-external has: (formData, string) => bool = "has"
+external has: (t, string) => bool = "has"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/entries)
 */
 @send
-external entries: formData => Iterator.t<(string, formDataEntryValue)> = "entries"
+external entries: t => Iterator.t<(string, formDataEntryValue)> = "entries"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/keys)
 */
 @send
-external keys: formData => Iterator.t<string> = "keys"
+external keys: t => Iterator.t<string> = "keys"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/set)
 */
 @send
-external set: (formData, ~name: string, ~value: string) => unit = "set"
+external set: (t, ~name: string, ~value: string) => unit = "set"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/set)
 */
 @send
-external setBlob: (formData, ~name: string, ~blobValue: blob, ~filename: string=?) => unit = "set"
+external setBlob: (t, ~name: string, ~blobValue: FileTypes.blob, ~filename: string=?) => unit =
+  "set"

--- a/src/FetchAPI/FormData.res
+++ b/src/FetchAPI/FormData.res
@@ -4,7 +4,7 @@ module Types = FetchTypes
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData)
  */
 @new
-type t = Types.formData
+type t = Types.formData = {...Types.formData}
 type formDataEntryValue = Types.formDataEntryValue
 
 external make: (~form: DOMTypes.htmlFormElement=?, ~submitter: DOMTypes.htmlElement=?) => t =

--- a/src/FetchAPI/FormDataEntryValue.res
+++ b/src/FetchAPI/FormDataEntryValue.res
@@ -1,9 +1,11 @@
 open Prelude
-open FetchTypes
-open FileTypes
 
-external fromString: string => formDataEntryValue = "%identity"
-external fromFile: file => formDataEntryValue = "%identity"
+module Types = FetchTypes
+
+type t = Types.formDataEntryValue
+
+external fromString: string => t = "%identity"
+external fromFile: FileTypes.file => t = "%identity"
 
 /**
 Represents a decoded version of the abstract `formDataEntryValue` type.
@@ -11,12 +13,12 @@ A FormData entry value is either a string or a File.
 */
 type decoded =
   | String(string)
-  | File(file)
+  | File(FileTypes.file)
 
-let decode = (t: formDataEntryValue): decoded => {
-  if File.isInstanceOf(t) {
-    File(unsafeConversation(t))
+let decode = (value: t): decoded => {
+  if File.isInstanceOf(value) {
+    File(unsafeConversation(value))
   } else {
-    String(unsafeConversation(t))
+    String(unsafeConversation(value))
   }
 }

--- a/src/FetchAPI/Headers.res
+++ b/src/FetchAPI/Headers.res
@@ -1,61 +1,63 @@
-open FetchTypes
+module Types = FetchTypes
+
+type t = Types.headers
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers)
+ */
+@new
+external make: unit => t = "Headers"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers)
 */
 @new
-external make: unit => headers = "Headers"
+external fromDict: dict<string> => t = "Headers"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers)
 */
 @new
-external fromDict: dict<string> => headers = "Headers"
+external fromHeaders: t => t = "Headers"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers)
 */
 @new
-external fromHeaders: headers => headers = "Headers"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers)
-*/
-@new
-external fromKeyValueArray: array<(string, string)> => headers = "Headers"
+external fromKeyValueArray: array<(string, string)> => t = "Headers"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/append)
 */
 @send
-external append: (headers, ~name: string, ~value: string) => unit = "append"
+external append: (t, ~name: string, ~value: string) => unit = "append"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/delete)
 */
 @send
-external delete: (headers, string) => unit = "delete"
+external delete: (t, string) => unit = "delete"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/get)
 */
 @send
-external get: (headers, string) => null<string> = "get"
+external get: (t, string) => null<string> = "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie)
 */
 @send
-external getSetCookie: headers => array<string> = "getSetCookie"
+external getSetCookie: t => array<string> = "getSetCookie"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/has)
 */
 @send
-external has: (headers, string) => bool = "has"
+external has: (t, string) => bool = "has"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/set)
 */
 @send
-external set: (headers, ~name: string, ~value: string) => unit = "set"
+external set: (t, ~name: string, ~value: string) => unit = "set"

--- a/src/FetchAPI/Headers.res
+++ b/src/FetchAPI/Headers.res
@@ -1,6 +1,6 @@
 module Types = FetchTypes
 
-type t = Types.headers
+type t = Types.headers = {...Types.headers}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers)

--- a/src/FetchAPI/HeadersInit.res
+++ b/src/FetchAPI/HeadersInit.res
@@ -1,16 +1,18 @@
-open FetchTypes
+module Types = FetchTypes
+
+type t = Types.headersInit
 
 /**
  [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_headers)
  */
-external fromDict: dict<string> => headersInit = "%identity"
+external fromDict: dict<string> => t = "%identity"
 
 /**
  [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_headers)
  */
-external fromHeaders: headers => headersInit = "%identity"
+external fromHeaders: Types.headers => t = "%identity"
 
 /**
  [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_headers)
  */
-external fromKeyValueArray: array<(string, string)> => headersInit = "%identity"
+external fromKeyValueArray: array<(string, string)> => t = "%identity"

--- a/src/FetchAPI/Request.res
+++ b/src/FetchAPI/Request.res
@@ -1,7 +1,7 @@
 module Types = FetchTypes
 
-type t = Types.request
-type requestInit = Types.requestInit
+type t = Types.request = {...Types.request}
+type requestInit = Types.requestInit = {...Types.requestInit}
 type bodyInit = Types.bodyInit
 type headersInit = Types.headersInit
 

--- a/src/FetchAPI/Request.res
+++ b/src/FetchAPI/Request.res
@@ -1,56 +1,60 @@
-open FetchTypes
-open FileTypes
+module Types = FetchTypes
+
+type t = Types.request
+type requestInit = Types.requestInit
+type bodyInit = Types.bodyInit
+type headersInit = Types.headersInit
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
+ */
+@new
+external fromURL: (string, ~init: requestInit=?) => t = "Request"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
 */
 @new
-external fromURL: (string, ~init: requestInit=?) => request = "Request"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
-*/
-@new
-external fromRequest: (request, ~init: requestInit=?) => request = "Request"
+external fromRequest: (t, ~init: requestInit=?) => t = "Request"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer)
 */
 @send
-external arrayBuffer: request => promise<ArrayBuffer.t> = "arrayBuffer"
+external arrayBuffer: t => promise<ArrayBuffer.t> = "arrayBuffer"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/blob)
 */
 @send
-external blob: request => promise<blob> = "blob"
+external blob: t => promise<FileTypes.blob> = "blob"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/bytes)
 */
 @send
-external bytes: request => promise<array<int>> = "bytes"
+external bytes: t => promise<array<int>> = "bytes"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/formData)
 */
 @send
-external formData: request => promise<formData> = "formData"
+external formData: t => promise<Types.formData> = "formData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/json)
 */
 @send
-external json: request => promise<JSON.t> = "json"
+external json: t => promise<JSON.t> = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/text)
 */
 @send
-external text: request => promise<string> = "text"
+external text: t => promise<string> = "text"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/clone)
 */
 @send
-external clone: request => request = "clone"
+external clone: t => t = "clone"

--- a/src/FetchAPI/Response.res
+++ b/src/FetchAPI/Response.res
@@ -51,8 +51,7 @@ external fromFile: (FileTypes.file, ~init: responseInit=?) => t = "Response"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromURLSearchParams: (URLTypes.urlSearchParams, ~init: responseInit=?) => t =
-  "Response"
+external fromURLSearchParams: (URLTypes.urlSearchParams, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
@@ -64,8 +63,7 @@ external fromFormData: (Types.formData, ~init: responseInit=?) => t = "Response"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromReadableStream: (FileTypes.readableStream<'t>, ~init: responseInit=?) => t =
-  "Response"
+external fromReadableStream: (FileTypes.readableStream<'t>, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer)

--- a/src/FetchAPI/Response.res
+++ b/src/FetchAPI/Response.res
@@ -1,123 +1,128 @@
-open FetchTypes
-open FileTypes
-open URLTypes
+module Types = FetchTypes
+
+type t = Types.response
+type responseInit = Types.responseInit
+type bodyInit = Types.bodyInit
+type headersInit = Types.headersInit
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
+ */
+@new
+external fromNull: (@as(json`null`) _, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromNull: (@as(json`null`) _, ~init: responseInit=?) => response = "Response"
+external fromString: (string, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromString: (string, ~init: responseInit=?) => response = "Response"
+external fromArrayBuffer: (ArrayBuffer.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromArrayBuffer: (ArrayBuffer.t, ~init: responseInit=?) => response = "Response"
+external fromTypedArray: (TypedArray.t<'t>, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromTypedArray: (TypedArray.t<'t>, ~init: responseInit=?) => response = "Response"
+external fromDataView: (DataView.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromDataView: (DataView.t, ~init: responseInit=?) => response = "Response"
+external fromBlob: (FileTypes.blob, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromBlob: (blob, ~init: responseInit=?) => response = "Response"
+external fromFile: (FileTypes.file, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromFile: (file, ~init: responseInit=?) => response = "Response"
+external fromURLSearchParams: (URLTypes.urlSearchParams, ~init: responseInit=?) => t =
+  "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromURLSearchParams: (urlSearchParams, ~init: responseInit=?) => response = "Response"
+external fromFormData: (Types.formData, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromFormData: (formData, ~init: responseInit=?) => response = "Response"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
-*/
-@new
-external fromReadableStream: (readableStream<'t>, ~init: responseInit=?) => response = "Response"
+external fromReadableStream: (FileTypes.readableStream<'t>, ~init: responseInit=?) => t =
+  "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer)
 */
 @send
-external arrayBuffer: response => promise<ArrayBuffer.t> = "arrayBuffer"
+external arrayBuffer: t => promise<ArrayBuffer.t> = "arrayBuffer"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/blob)
 */
 @send
-external blob: response => promise<blob> = "blob"
+external blob: t => promise<FileTypes.blob> = "blob"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/bytes)
 */
 @send
-external bytes: response => promise<array<int>> = "bytes"
+external bytes: t => promise<array<int>> = "bytes"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/formData)
 */
 @send
-external formData: response => promise<formData> = "formData"
+external formData: t => promise<Types.formData> = "formData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/json)
 */
 @send
-external json: response => promise<JSON.t> = "json"
+external json: t => promise<JSON.t> = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/text)
 */
 @send
-external text: response => promise<string> = "text"
+external text: t => promise<string> = "text"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/error_static)
 */
 @scope("Response")
-external error: unit => response = "error"
+external error: unit => t = "error"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/redirect_static)
 */
 @scope("Response")
-external redirect: (~url: string, ~status: int=?) => response = "redirect"
+external redirect: (~url: string, ~status: int=?) => t = "redirect"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/json_static)
 */
 @scope("Response")
-external jsonR: (~data: JSON.t, ~init: responseInit=?) => response = "json"
+external jsonR: (~data: JSON.t, ~init: responseInit=?) => t = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/clone)
 */
 @send
-external clone: response => response = "clone"
+external clone: t => t = "clone"

--- a/src/FetchAPI/Response.res
+++ b/src/FetchAPI/Response.res
@@ -1,7 +1,7 @@
 module Types = FetchTypes
 
-type t = Types.response
-type responseInit = Types.responseInit
+type t = Types.response = {...Types.response}
+type responseInit = Types.responseInit = {...Types.responseInit}
 type bodyInit = Types.bodyInit
 type headersInit = Types.headersInit
 

--- a/src/FileAPI/Blob.res
+++ b/src/FileAPI/Blob.res
@@ -4,10 +4,10 @@ module Types = FileTypes
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob)
 */
 @new
-type t = Types.blob
+type t = Types.blob = {...Types.blob}
 type blobPart = Types.blobPart
-type blobPropertyBag = Types.blobPropertyBag
-type readableStream<'r> = Types.readableStream<'r>
+type blobPropertyBag = Types.blobPropertyBag = {...Types.blobPropertyBag}
+type readableStream<'r> = Types.readableStream<'r> = {...Types.readableStream<'r>}
 
 external make: (~blobParts: array<blobPart>=?, ~options: blobPropertyBag=?) => t = "Blob"
 

--- a/src/FileAPI/Blob.res
+++ b/src/FileAPI/Blob.res
@@ -1,22 +1,27 @@
-open FileTypes
+module Types = FileTypes
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob)
 */
 @new
-external make: (~blobParts: array<blobPart>=?, ~options: blobPropertyBag=?) => blob = "Blob"
+type t = Types.blob
+type blobPart = Types.blobPart
+type blobPropertyBag = Types.blobPropertyBag
+type readableStream<'r> = Types.readableStream<'r>
+
+external make: (~blobParts: array<blobPart>=?, ~options: blobPropertyBag=?) => t = "Blob"
 
 module Impl = (
   T: {
     type t
   },
 ) => {
-  external asBlob: T.t => blob = "%identity"
+  external asBlob: T.t => t = "%identity"
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob/slice)
 */
   @send
-  external slice: (T.t, ~start: int=?, ~end: int=?, ~contentType: string=?) => blob = "slice"
+  external slice: (T.t, ~start: int=?, ~end: int=?, ~contentType: string=?) => t = "slice"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob/stream)
@@ -43,4 +48,4 @@ module Impl = (
   external bytes: T.t => promise<array<int>> = "bytes"
 }
 
-include Impl({type t = blob})
+include Impl({type t = t})

--- a/src/FileAPI/File.res
+++ b/src/FileAPI/File.res
@@ -1,8 +1,8 @@
 module Types = FileTypes
 
-type t = Types.file
+type t = Types.file = {...Types.file}
 type blobPart = Types.blobPart
-type filePropertyBag = Types.filePropertyBag
+type filePropertyBag = Types.filePropertyBag = {...Types.filePropertyBag}
 
 include Blob.Impl({type t = t})
 

--- a/src/FileAPI/File.res
+++ b/src/FileAPI/File.res
@@ -1,6 +1,10 @@
-open FileTypes
+module Types = FileTypes
 
-include Blob.Impl({type t = file})
+type t = Types.file
+type blobPart = Types.blobPart
+type filePropertyBag = Types.filePropertyBag
+
+include Blob.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/File)
@@ -10,6 +14,6 @@ external make: (
   ~fileBits: array<blobPart>,
   ~fileName: string,
   ~options: filePropertyBag=?,
-) => file = "File"
+) => t = "File"
 
 let isInstanceOf = (_: 't): bool => %raw(`param instanceof File`)

--- a/src/FileAPI/File.res
+++ b/src/FileAPI/File.res
@@ -10,10 +10,7 @@ include Blob.Impl({type t = t})
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/File)
 */
 @new
-external make: (
-  ~fileBits: array<blobPart>,
-  ~fileName: string,
-  ~options: filePropertyBag=?,
-) => t = "File"
+external make: (~fileBits: array<blobPart>, ~fileName: string, ~options: filePropertyBag=?) => t =
+  "File"
 
 let isInstanceOf = (_: 't): bool => %raw(`param instanceof File`)

--- a/src/FileAPI/FileSystemDirectoryHandle.res
+++ b/src/FileAPI/FileSystemDirectoryHandle.res
@@ -1,18 +1,25 @@
-open FileTypes
+module Types = FileTypes
 
-external asFileSystemHandle: fileSystemDirectoryHandle => fileSystemHandle = "%identity"
+type t = Types.fileSystemDirectoryHandle
+type fileSystemHandle = Types.fileSystemHandle
+type fileSystemFileHandle = Types.fileSystemFileHandle
+type fileSystemGetFileOptions = Types.fileSystemGetFileOptions
+type fileSystemGetDirectoryOptions = Types.fileSystemGetDirectoryOptions
+type fileSystemRemoveOptions = Types.fileSystemRemoveOptions
+
+external asFileSystemHandle: t => fileSystemHandle = "%identity"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry)
 */
 @send
-external isSameEntry: (fileSystemDirectoryHandle, fileSystemHandle) => promise<bool> = "isSameEntry"
+external isSameEntry: (t, fileSystemHandle) => promise<bool> = "isSameEntry"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/getFileHandle)
 */
 @send
 external getFileHandle: (
-  fileSystemDirectoryHandle,
+  t,
   ~name: string,
   ~options: fileSystemGetFileOptions=?,
 ) => promise<fileSystemFileHandle> = "getFileHandle"
@@ -22,17 +29,17 @@ external getFileHandle: (
 */
 @send
 external getDirectoryHandle: (
-  fileSystemDirectoryHandle,
+  t,
   ~name: string,
   ~options: fileSystemGetDirectoryOptions=?,
-) => promise<fileSystemDirectoryHandle> = "getDirectoryHandle"
+) => promise<t> = "getDirectoryHandle"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/removeEntry)
 */
 @send
 external removeEntry: (
-  fileSystemDirectoryHandle,
+  t,
   ~name: string,
   ~options: fileSystemRemoveOptions=?,
 ) => promise<unit> = "removeEntry"
@@ -41,5 +48,5 @@ external removeEntry: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/resolve)
 */
 @send
-external resolve: (fileSystemDirectoryHandle, fileSystemHandle) => promise<array<string>> =
+external resolve: (t, fileSystemHandle) => promise<array<string>> =
   "resolve"

--- a/src/FileAPI/FileSystemDirectoryHandle.res
+++ b/src/FileAPI/FileSystemDirectoryHandle.res
@@ -1,11 +1,12 @@
 module Types = FileTypes
 
-type t = Types.fileSystemDirectoryHandle
-type fileSystemHandle = Types.fileSystemHandle
-type fileSystemFileHandle = Types.fileSystemFileHandle
-type fileSystemGetFileOptions = Types.fileSystemGetFileOptions
-type fileSystemGetDirectoryOptions = Types.fileSystemGetDirectoryOptions
-type fileSystemRemoveOptions = Types.fileSystemRemoveOptions
+type t = Types.fileSystemDirectoryHandle = {...Types.fileSystemDirectoryHandle}
+type fileSystemHandle = Types.fileSystemHandle = {...Types.fileSystemHandle}
+type fileSystemFileHandle = Types.fileSystemFileHandle = {...Types.fileSystemFileHandle}
+type fileSystemGetFileOptions = Types.fileSystemGetFileOptions = {...Types.fileSystemGetFileOptions}
+type fileSystemGetDirectoryOptions =
+  Types.fileSystemGetDirectoryOptions = {...Types.fileSystemGetDirectoryOptions}
+type fileSystemRemoveOptions = Types.fileSystemRemoveOptions = {...Types.fileSystemRemoveOptions}
 
 external asFileSystemHandle: t => fileSystemHandle = "%identity"
 /**

--- a/src/FileAPI/FileSystemDirectoryHandle.res
+++ b/src/FileAPI/FileSystemDirectoryHandle.res
@@ -4,8 +4,9 @@ type t = Types.fileSystemDirectoryHandle = {...Types.fileSystemDirectoryHandle}
 type fileSystemHandle = Types.fileSystemHandle = {...Types.fileSystemHandle}
 type fileSystemFileHandle = Types.fileSystemFileHandle = {...Types.fileSystemFileHandle}
 type fileSystemGetFileOptions = Types.fileSystemGetFileOptions = {...Types.fileSystemGetFileOptions}
-type fileSystemGetDirectoryOptions =
-  Types.fileSystemGetDirectoryOptions = {...Types.fileSystemGetDirectoryOptions}
+type fileSystemGetDirectoryOptions = Types.fileSystemGetDirectoryOptions = {
+  ...Types.fileSystemGetDirectoryOptions,
+}
 type fileSystemRemoveOptions = Types.fileSystemRemoveOptions = {...Types.fileSystemRemoveOptions}
 
 external asFileSystemHandle: t => fileSystemHandle = "%identity"
@@ -39,15 +40,11 @@ external getDirectoryHandle: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/removeEntry)
 */
 @send
-external removeEntry: (
-  t,
-  ~name: string,
-  ~options: fileSystemRemoveOptions=?,
-) => promise<unit> = "removeEntry"
+external removeEntry: (t, ~name: string, ~options: fileSystemRemoveOptions=?) => promise<unit> =
+  "removeEntry"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/resolve)
 */
 @send
-external resolve: (t, fileSystemHandle) => promise<array<string>> =
-  "resolve"
+external resolve: (t, fileSystemHandle) => promise<array<string>> = "resolve"

--- a/src/FileAPI/FileSystemFileHandle.res
+++ b/src/FileAPI/FileSystemFileHandle.res
@@ -3,10 +3,12 @@ module Types = FileTypes
 type t = Types.fileSystemFileHandle = {...Types.fileSystemFileHandle}
 type fileSystemHandle = Types.fileSystemHandle = {...Types.fileSystemHandle}
 type file = Types.file = {...Types.file}
-type fileSystemCreateWritableOptions =
-  Types.fileSystemCreateWritableOptions = {...Types.fileSystemCreateWritableOptions}
-type fileSystemWritableFileStream =
-  Types.fileSystemWritableFileStream = {...Types.fileSystemWritableFileStream}
+type fileSystemCreateWritableOptions = Types.fileSystemCreateWritableOptions = {
+  ...Types.fileSystemCreateWritableOptions,
+}
+type fileSystemWritableFileStream = Types.fileSystemWritableFileStream = {
+  ...Types.fileSystemWritableFileStream,
+}
 
 external asFileSystemHandle: t => fileSystemHandle = "%identity"
 /**

--- a/src/FileAPI/FileSystemFileHandle.res
+++ b/src/FileAPI/FileSystemFileHandle.res
@@ -1,23 +1,29 @@
-open FileTypes
+module Types = FileTypes
 
-external asFileSystemHandle: fileSystemFileHandle => fileSystemHandle = "%identity"
+type t = Types.fileSystemFileHandle
+type fileSystemHandle = Types.fileSystemHandle
+type file = Types.file
+type fileSystemCreateWritableOptions = Types.fileSystemCreateWritableOptions
+type fileSystemWritableFileStream = Types.fileSystemWritableFileStream
+
+external asFileSystemHandle: t => fileSystemHandle = "%identity"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry)
 */
 @send
-external isSameEntry: (fileSystemFileHandle, fileSystemHandle) => promise<bool> = "isSameEntry"
+external isSameEntry: (t, fileSystemHandle) => promise<bool> = "isSameEntry"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/getFile)
 */
 @send
-external getFile: fileSystemFileHandle => promise<file> = "getFile"
+external getFile: t => promise<file> = "getFile"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/createWritable)
 */
 @send
 external createWritable: (
-  fileSystemFileHandle,
+  t,
   ~options: fileSystemCreateWritableOptions=?,
 ) => promise<fileSystemWritableFileStream> = "createWritable"

--- a/src/FileAPI/FileSystemFileHandle.res
+++ b/src/FileAPI/FileSystemFileHandle.res
@@ -1,10 +1,12 @@
 module Types = FileTypes
 
-type t = Types.fileSystemFileHandle
-type fileSystemHandle = Types.fileSystemHandle
-type file = Types.file
-type fileSystemCreateWritableOptions = Types.fileSystemCreateWritableOptions
-type fileSystemWritableFileStream = Types.fileSystemWritableFileStream
+type t = Types.fileSystemFileHandle = {...Types.fileSystemFileHandle}
+type fileSystemHandle = Types.fileSystemHandle = {...Types.fileSystemHandle}
+type file = Types.file = {...Types.file}
+type fileSystemCreateWritableOptions =
+  Types.fileSystemCreateWritableOptions = {...Types.fileSystemCreateWritableOptions}
+type fileSystemWritableFileStream =
+  Types.fileSystemWritableFileStream = {...Types.fileSystemWritableFileStream}
 
 external asFileSystemHandle: t => fileSystemHandle = "%identity"
 /**

--- a/src/FileAPI/FileSystemHandle.res
+++ b/src/FileAPI/FileSystemHandle.res
@@ -1,7 +1,9 @@
-open FileTypes
+module Types = FileTypes
+
+type t = Types.fileSystemHandle
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry)
 */
 @send
-external isSameEntry: (fileSystemHandle, fileSystemHandle) => promise<bool> = "isSameEntry"
+external isSameEntry: (t, t) => promise<bool> = "isSameEntry"

--- a/src/FileAPI/FileSystemHandle.res
+++ b/src/FileAPI/FileSystemHandle.res
@@ -1,6 +1,6 @@
 module Types = FileTypes
 
-type t = Types.fileSystemHandle
+type t = Types.fileSystemHandle = {...Types.fileSystemHandle}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry)

--- a/src/FileAPI/ReadableStream.res
+++ b/src/FileAPI/ReadableStream.res
@@ -2,10 +2,12 @@ module Types = FileTypes
 
 type t<'r> = Types.readableStream<'r> = {...Types.readableStream<'r>}
 type readableStreamReaderMode = Types.readableStreamReaderMode
-type readableStreamGetReaderOptions =
-  Types.readableStreamGetReaderOptions = {...Types.readableStreamGetReaderOptions}
-type readableWritablePair<'r, 'w> =
-  Types.readableWritablePair<'r, 'w> = {...Types.readableWritablePair<'r, 'w>}
+type readableStreamGetReaderOptions = Types.readableStreamGetReaderOptions = {
+  ...Types.readableStreamGetReaderOptions,
+}
+type readableWritablePair<'r, 'w> = Types.readableWritablePair<'r, 'w> = {
+  ...Types.readableWritablePair<'r, 'w>,
+}
 type streamPipeOptions = Types.streamPipeOptions = {...Types.streamPipeOptions}
 
 /**

--- a/src/FileAPI/ReadableStream.res
+++ b/src/FileAPI/ReadableStream.res
@@ -1,10 +1,12 @@
 module Types = FileTypes
 
-type t<'r> = Types.readableStream<'r>
+type t<'r> = Types.readableStream<'r> = {...Types.readableStream<'r>}
 type readableStreamReaderMode = Types.readableStreamReaderMode
-type readableStreamGetReaderOptions = Types.readableStreamGetReaderOptions
-type readableWritablePair<'r, 'w> = Types.readableWritablePair<'r, 'w>
-type streamPipeOptions = Types.streamPipeOptions
+type readableStreamGetReaderOptions =
+  Types.readableStreamGetReaderOptions = {...Types.readableStreamGetReaderOptions}
+type readableWritablePair<'r, 'w> =
+  Types.readableWritablePair<'r, 'w> = {...Types.readableWritablePair<'r, 'w>}
+type streamPipeOptions = Types.streamPipeOptions = {...Types.streamPipeOptions}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)

--- a/src/FileAPI/ReadableStream.res
+++ b/src/FileAPI/ReadableStream.res
@@ -1,10 +1,16 @@
-open FileTypes
+module Types = FileTypes
+
+type t<'r> = Types.readableStream<'r>
+type readableStreamReaderMode = Types.readableStreamReaderMode
+type readableStreamGetReaderOptions = Types.readableStreamGetReaderOptions
+type readableWritablePair<'r, 'w> = Types.readableWritablePair<'r, 'w>
+type streamPipeOptions = Types.streamPipeOptions
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)
 */
 @new
-external make: unit => readableStream<array<int>> = "ReadableStream"
+external make: unit => t<array<int>> = "ReadableStream"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)
@@ -22,34 +28,34 @@ external make3: unit => unknown = "ReadableStream"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/cancel)
 */
 @send
-external cancel: (readableStream<'r>, ~reason: JSON.t=?) => promise<unit> = "cancel"
+external cancel: (t<'r>, ~reason: JSON.t=?) => promise<unit> = "cancel"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader)
 */
 @send
 external getReader: (
-  readableStream<'r>,
+  t<'r>,
   ~options: readableStreamGetReaderOptions=?,
-) => readableStreamReader<'r> = "getReader"
+) => Types.readableStreamReader<'r> = "getReader"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeThrough)
 */
 @send
 external pipeThrough: (
-  readableStream<'r>,
+  t<'r>,
   ~transform: readableWritablePair<'t, 'r>,
   ~options: streamPipeOptions=?,
-) => readableStream<'t> = "pipeThrough"
+) => t<'t> = "pipeThrough"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeTo)
 */
 @send
 external pipeTo: (
-  readableStream<'r>,
-  ~destination: writableStream<'r>,
+  t<'r>,
+  ~destination: WritableStream.t<'r>,
   ~options: streamPipeOptions=?,
 ) => promise<unit> = "pipeTo"
 
@@ -57,4 +63,4 @@ external pipeTo: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee)
 */
 @send
-external tee: readableStream<'r> => array<readableStream<unit>> = "tee"
+external tee: t<'r> => array<t<unit>> = "tee"

--- a/src/FileAPI/WritableStream.res
+++ b/src/FileAPI/WritableStream.res
@@ -1,6 +1,6 @@
 module Types = FileTypes
 
-type t<'w> = Types.writableStream<'w>
+type t<'w> = Types.writableStream<'w> = {...Types.writableStream<'w>}
 type queuingStrategy<'t> = Types.queuingStrategy<'t>
 type underlyingSink<'t> = Types.underlyingSink<'t>
 type writableStreamDefaultWriter<'t> = Types.writableStreamDefaultWriter<'t>

--- a/src/FileAPI/WritableStream.res
+++ b/src/FileAPI/WritableStream.res
@@ -1,4 +1,9 @@
-open FileTypes
+module Types = FileTypes
+
+type t<'w> = Types.writableStream<'w>
+type queuingStrategy<'t> = Types.queuingStrategy<'t>
+type underlyingSink<'t> = Types.underlyingSink<'t>
+type writableStreamDefaultWriter<'t> = Types.writableStreamDefaultWriter<'t>
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream)
@@ -7,22 +12,22 @@ open FileTypes
 external make: (
   ~underlyingSink: underlyingSink<'w>=?,
   ~strategy: queuingStrategy<'w>=?,
-) => writableStream<'w> = "WritableStream"
+) => t<'w> = "WritableStream"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/abort)
 */
 @send
-external abort: (writableStream<'w>, ~reason: JSON.t=?) => promise<unit> = "abort"
+external abort: (t<'w>, ~reason: JSON.t=?) => promise<unit> = "abort"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/close)
 */
 @send
-external close: writableStream<'w> => promise<unit> = "close"
+external close: t<'w> => promise<unit> = "close"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter)
 */
 @send
-external getWriter: writableStream<'w> => writableStreamDefaultWriter<'w> = "getWriter"
+external getWriter: t<'w> => writableStreamDefaultWriter<'w> = "getWriter"

--- a/src/FileAPI/WritableStream.res
+++ b/src/FileAPI/WritableStream.res
@@ -9,10 +9,8 @@ type writableStreamDefaultWriter<'t> = Types.writableStreamDefaultWriter<'t>
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream)
 */
 @new
-external make: (
-  ~underlyingSink: underlyingSink<'w>=?,
-  ~strategy: queuingStrategy<'w>=?,
-) => t<'w> = "WritableStream"
+external make: (~underlyingSink: underlyingSink<'w>=?, ~strategy: queuingStrategy<'w>=?) => t<'w> =
+  "WritableStream"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/abort)

--- a/src/FileAPI/WritableStreamDefaultController.res
+++ b/src/FileAPI/WritableStreamDefaultController.res
@@ -1,6 +1,6 @@
 module Types = FileTypes
 
-type t = Types.writableStreamDefaultController
+type t = Types.writableStreamDefaultController = {...Types.writableStreamDefaultController}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/error)

--- a/src/FileAPI/WritableStreamDefaultController.res
+++ b/src/FileAPI/WritableStreamDefaultController.res
@@ -1,7 +1,9 @@
-open FileTypes
+module Types = FileTypes
+
+type t = Types.writableStreamDefaultController
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/error)
 */
 @send
-external error: (writableStreamDefaultController, ~e: JSON.t=?) => unit = "error"
+external error: (t, ~e: JSON.t=?) => unit = "error"

--- a/src/URLAPI/URL.res
+++ b/src/URLAPI/URL.res
@@ -1,6 +1,6 @@
 module Types = URLTypes
 
-type t = Types.url
+type t = Types.url = {...Types.url}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL)

--- a/src/URLAPI/URL.res
+++ b/src/URLAPI/URL.res
@@ -1,16 +1,18 @@
-open URLTypes
+module Types = URLTypes
+
+type t = Types.url
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL)
 */
 @new
-external make: (~url: string, ~base: string=?) => url = "URL"
+external make: (~url: string, ~base: string=?) => t = "URL"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL/parse_static)
 */
 @scope("URL")
-external parse: (~url: string, ~base: string=?) => url = "parse"
+external parse: (~url: string, ~base: string=?) => t = "parse"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL/canParse_static)
@@ -22,7 +24,7 @@ external canParse: (~url: string, ~base: string=?) => bool = "canParse"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL/toJSON)
 */
 @send
-external toJSON: url => string = "toJSON"
+external toJSON: t => string = "toJSON"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static)

--- a/src/URLAPI/URLSearchParams.res
+++ b/src/URLAPI/URLSearchParams.res
@@ -1,6 +1,6 @@
 module Types = URLTypes
 
-type t = Types.urlSearchParams
+type t = Types.urlSearchParams = {...Types.urlSearchParams}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)

--- a/src/URLAPI/URLSearchParams.res
+++ b/src/URLAPI/URLSearchParams.res
@@ -1,101 +1,103 @@
-open URLTypes
+module Types = URLTypes
+
+type t = Types.urlSearchParams
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
 */
 @new
-external make: unit => urlSearchParams = "URLSearchParams"
+external make: unit => t = "URLSearchParams"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
 */
 @new
-external fromKeyValueArray: array<(string, string)> => urlSearchParams = "URLSearchParams"
+external fromKeyValueArray: array<(string, string)> => t = "URLSearchParams"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
 */
 @new
-external fromDict: dict<string> => urlSearchParams = "URLSearchParams"
+external fromDict: dict<string> => t = "URLSearchParams"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
 */
 @new
-external fromString: string => urlSearchParams = "URLSearchParams"
+external fromString: string => t = "URLSearchParams"
 
 /**
 Appends a specified key/value pair as a new search parameter.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/append)
 */
 @send
-external append: (urlSearchParams, ~name: string, ~value: string) => unit = "append"
+external append: (t, ~name: string, ~value: string) => unit = "append"
 
 /**
 Deletes the given search parameter, and its associated value, from the list of all search parameters.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/delete)
 */
 @send
-external delete: (urlSearchParams, ~name: string, ~value: string=?) => unit = "delete"
+external delete: (t, ~name: string, ~value: string=?) => unit = "delete"
 
 /**
 Returns key/value pairs in the same order as they appear in the query string.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/entries)
 */
 @send
-external entries: urlSearchParams => Iterator.t<(string, string)> = "entries"
+external entries: t => Iterator.t<(string, string)> = "entries"
 
 /**
 Returns the first value associated to the given search parameter.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/get)
 */
 @send
-external get: (urlSearchParams, string) => null<string> = "get"
+external get: (t, string) => null<string> = "get"
 
 /**
 Returns all the values association with a given search parameter.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll)
 */
 @send
-external getAll: (urlSearchParams, string) => array<string> = "getAll"
+external getAll: (t, string) => array<string> = "getAll"
 
 /**
 Returns a Boolean indicating if such a search parameter exists.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/has)
 */
 @send
-external has: (urlSearchParams, ~name: string, ~value: string=?) => bool = "has"
+external has: (t, ~name: string, ~value: string=?) => bool = "has"
 
 /**
 Returns an iterator allowing iteration through all keys contained in this object.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/keys)
 */
 @send
-external keys: urlSearchParams => Iterator.t<string> = "keys"
+external keys: t => Iterator.t<string> = "keys"
 
 /**
 Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/set)
 */
 @send
-external set: (urlSearchParams, ~name: string, ~value: string) => unit = "set"
+external set: (t, ~name: string, ~value: string) => unit = "set"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/sort)
 */
 @send
-external sort: urlSearchParams => unit = "sort"
+external sort: t => unit = "sort"
 
 /**
 Returns the query string suitable for use in a URL, without the question mark.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/toString)
 */
 @send
-external toString: urlSearchParams => string = "toString"
+external toString: t => string = "toString"
 
 /**
 Returns an iterator allowing iteration through all values contained in this object.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/values)
 */
 @send
-external values: urlSearchParams => Iterator.t<string> = "values"
+external values: t => Iterator.t<string> = "values"

--- a/src/WebSocketsAPI/CloseEvent.res
+++ b/src/WebSocketsAPI/CloseEvent.res
@@ -1,7 +1,7 @@
 module Types = WebSocketsTypes
 
-type t = Types.closeEvent
-type closeEventInit = Types.closeEventInit
+type t = Types.closeEvent = {...Types.closeEvent}
+type closeEventInit = Types.closeEventInit = {...Types.closeEventInit}
 
 include Event.Impl({type t = t})
 

--- a/src/WebSocketsAPI/CloseEvent.res
+++ b/src/WebSocketsAPI/CloseEvent.res
@@ -1,9 +1,12 @@
-open WebSocketsTypes
+module Types = WebSocketsTypes
 
-include Event.Impl({type t = closeEvent})
+type t = Types.closeEvent
+type closeEventInit = Types.closeEventInit
+
+include Event.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CloseEvent)
 */
 @new
-external make: (~type_: string, ~eventInitDict: closeEventInit=?) => closeEvent = "CloseEvent"
+external make: (~type_: string, ~eventInitDict: closeEventInit=?) => t = "CloseEvent"

--- a/src/WebSocketsAPI/MessageEvent.res
+++ b/src/WebSocketsAPI/MessageEvent.res
@@ -7,8 +7,7 @@ type messageEventInit<'t> = Types.messageEventInit<'t> = {...Types.messageEventI
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessageEvent)
 */
 @new
-external make: (~type_: string, ~eventInitDict: messageEventInit<'t>=?) => t<'t> =
-  "MessageEvent"
+external make: (~type_: string, ~eventInitDict: messageEventInit<'t>=?) => t<'t> = "MessageEvent"
 
 external asEvent: t<'t> => EventTypes.event = "%identity"
 /**

--- a/src/WebSocketsAPI/MessageEvent.res
+++ b/src/WebSocketsAPI/MessageEvent.res
@@ -1,7 +1,7 @@
 module Types = WebSocketsTypes
 
-type t<'t> = Types.messageEvent<'t>
-type messageEventInit<'t> = Types.messageEventInit<'t>
+type t<'t> = Types.messageEvent<'t> = {...Types.messageEvent<'t>}
+type messageEventInit<'t> = Types.messageEventInit<'t> = {...Types.messageEventInit<'t>}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessageEvent)

--- a/src/WebSocketsAPI/MessageEvent.res
+++ b/src/WebSocketsAPI/MessageEvent.res
@@ -1,38 +1,40 @@
-open EventTypes
-open WebSocketsTypes
+module Types = WebSocketsTypes
+
+type t<'t> = Types.messageEvent<'t>
+type messageEventInit<'t> = Types.messageEventInit<'t>
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessageEvent)
 */
 @new
-external make: (~type_: string, ~eventInitDict: messageEventInit<'t>=?) => messageEvent<'t> =
+external make: (~type_: string, ~eventInitDict: messageEventInit<'t>=?) => t<'t> =
   "MessageEvent"
 
-external asEvent: messageEvent<'t> => event = "%identity"
+external asEvent: t<'t> => EventTypes.event = "%identity"
 /**
 Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Event/composedPath)
 */
 @send
-external composedPath: messageEvent<'t> => array<eventTarget> = "composedPath"
+external composedPath: t<'t> => array<EventTypes.eventTarget> = "composedPath"
 
 /**
 When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Event/stopPropagation)
 */
 @send
-external stopPropagation: messageEvent<'t> => unit = "stopPropagation"
+external stopPropagation: t<'t> => unit = "stopPropagation"
 
 /**
 Invoking this method prevents event from reaching any registered event listeners after the current one finishes running and, when dispatched in a tree, also prevents event from reaching any other objects.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Event/stopImmediatePropagation)
 */
 @send
-external stopImmediatePropagation: messageEvent<'t> => unit = "stopImmediatePropagation"
+external stopImmediatePropagation: t<'t> => unit = "stopImmediatePropagation"
 
 /**
 If invoked when the cancelable attribute value is true, and while executing a listener for the event with passive set to false, signals to the operation that caused event to be dispatched that it needs to be canceled.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Event/preventDefault)
 */
 @send
-external preventDefault: messageEvent<'t> => unit = "preventDefault"
+external preventDefault: t<'t> => unit = "preventDefault"

--- a/src/WebSocketsAPI/WebSocket.res
+++ b/src/WebSocketsAPI/WebSocket.res
@@ -1,9 +1,9 @@
 module Types = WebSocketsTypes
 
-type t = Types.webSocket
+type t = Types.webSocket = {...Types.webSocket}
 type binaryType = Types.binaryType
-type messageEvent<'t> = Types.messageEvent<'t>
-type closeEvent = Types.closeEvent
+type messageEvent<'t> = Types.messageEvent<'t> = {...Types.messageEvent<'t>}
+type closeEvent = Types.closeEvent = {...Types.closeEvent}
 type messageEventSource = Types.messageEventSource
 
 /**

--- a/src/WebSocketsAPI/WebSocket.res
+++ b/src/WebSocketsAPI/WebSocket.res
@@ -1,51 +1,56 @@
-open WebSocketsTypes
-open FileTypes
+module Types = WebSocketsTypes
+
+type t = Types.webSocket
+type binaryType = Types.binaryType
+type messageEvent<'t> = Types.messageEvent<'t>
+type closeEvent = Types.closeEvent
+type messageEventSource = Types.messageEventSource
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket)
 */
 @new
-external make: (~url: string, ~protocols: string=?) => webSocket = "WebSocket"
+external make: (~url: string, ~protocols: string=?) => t = "WebSocket"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket)
 */
 @new
-external make2: (~url: string, ~protocols: array<string>=?) => webSocket = "WebSocket"
+external make2: (~url: string, ~protocols: array<string>=?) => t = "WebSocket"
 
-include EventTarget.Impl({type t = webSocket})
+include EventTarget.Impl({type t = t})
 
 /**
 Closes the WebSocket connection, optionally using code as the the WebSocket connection close code and reason as the the WebSocket connection close reason.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/close)
 */
 @send
-external close: (webSocket, ~code: int=?, ~reason: string=?) => unit = "close"
+external close: (t, ~code: int=?, ~reason: string=?) => unit = "close"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external send: (webSocket, DataView.t) => unit = "send"
+external send: (t, DataView.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external send2: (webSocket, ArrayBuffer.t) => unit = "send"
+external send2: (t, ArrayBuffer.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external send3: (webSocket, blob) => unit = "send"
+external send3: (t, FileTypes.blob) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external send4: (webSocket, string) => unit = "send"
+external send4: (t, string) => unit = "send"

--- a/tests/FetchAPI/FormData__test.res
+++ b/tests/FetchAPI/FormData__test.res
@@ -5,7 +5,7 @@ external myForm: DOMTypes.htmlFormElement = "myForm"
 let formData = FormData.make(~form=myForm)
 
 // Get a form field - returns formDataEntryValue which could be string or File
-let phoneEntry: null<FetchTypes.formDataEntryValue> = formData->FormData.get("phone")
+let phoneEntry: null<FormDataEntryValue.t> = formData->FormData.get("phone")
 
 // Decode the entry to handle both string and File cases
 let _ = switch phoneEntry->Null.toOption {
@@ -18,7 +18,7 @@ let _ = switch phoneEntry->Null.toOption {
 }
 
 // Get all values for a field (useful for multi-select or multiple file inputs)
-let allImages: array<FetchTypes.formDataEntryValue> = formData->FormData.getAll("images")
+let allImages: array<FormDataEntryValue.t> = formData->FormData.getAll("images")
 
 // Process all entries
 let _ = allImages->Array.forEach(entry => {
@@ -33,7 +33,7 @@ let stringEntry = FormDataEntryValue.fromString("test value")
 let fileEntry = FormDataEntryValue.fromFile(File.make(~fileBits=[], ~fileName="test.txt"))
 
 // Iterate over all entries in the FormData
-let entries: Iterator.t<(string, FetchTypes.formDataEntryValue)> = formData->FormData.entries
+let entries: Iterator.t<(string, FormDataEntryValue.t)> = formData->FormData.entries
 let _ = entries->Iterator.forEach(((key, value)) => {
   switch value->FormDataEntryValue.decode {
   | FormDataEntryValue.String(s) => Console.log(`${key}: ${s}`)

--- a/tests/FetchAPI/Request__test.res
+++ b/tests/FetchAPI/Request__test.res
@@ -1,10 +1,10 @@
-let req = Request.fromURL("https://example.com")
+let req: Request.t = Request.fromURL("https://example.com")
 
-let req1 = Request.fromURL(
+let req1: Request.t = Request.fromURL(
   "https://example.com/api",
   ~init={method: "POST", body: BodyInit.fromString("hello")},
 )
 
-let req2 = Request.fromRequest(req1)
+let req2: Request.t = Request.fromRequest(req1)
 
 Console.log(await req2->Request.text)

--- a/tests/FetchAPI/Response__test.res
+++ b/tests/FetchAPI/Response__test.res
@@ -1,6 +1,6 @@
-let response = Response.fromNull(~init={status: 204})
+let response: Response.t = Response.fromNull(~init={status: 204})
 
-let response1 = Response.fromString(
+let response1: Response.t = Response.fromString(
   "pong",
   ~init={status: 200, headers: HeadersInit.fromDict(dict{"X-Fruit": "Peach"})},
 )

--- a/tests/FetchAPI/URLSearchParams__test.res
+++ b/tests/FetchAPI/URLSearchParams__test.res
@@ -1,10 +1,10 @@
-let params1 = URLSearchParams.fromString("foo=1&bar=2")
+let params1: URLSearchParams.t = URLSearchParams.fromString("foo=1&bar=2")
 params1->URLSearchParams.keys->Iterator.toArray->Array.forEach(Console.log)
 
-let params2 = URLSearchParams.fromKeyValueArray([("foo", "1"), ("bar", "b")])
+let params2: URLSearchParams.t = URLSearchParams.fromKeyValueArray([("foo", "1"), ("bar", "b")])
 params2->URLSearchParams.values->Iterator.toArray->Array.forEach(Console.log)
 
-let params3 = URLSearchParams.fromDict(dict{"foo": "1", "bar": "b"})
+let params3: URLSearchParams.t = URLSearchParams.fromDict(dict{"foo": "1", "bar": "b"})
 params3
 ->URLSearchParams.entries
 ->Iterator.toArray

--- a/tests/URLAPI/URL__test.res
+++ b/tests/URLAPI/URL__test.res
@@ -1,3 +1,3 @@
 open WebAPI
 
-let url = URL.make(~url="/foo", ~base="https://bar.com")
+let url: URL.t = URL.make(~url="/foo", ~base="https://bar.com")


### PR DESCRIPTION
## Summary
- add `type t` aliases and selective helper re-exports across Fetch,
  File, Canvas, URL, ChannelMessaging, CSSFontLoading, and WebSockets concrete modules
-
  replace broad `open` usage with qualified references or local owner-module re-exports where
  the surface allows it
- update fetch and URL tests to use concrete module aliases such as
  `Request.t`, `Response.t`, `URL.t`, and `URLSearchParams.t`

## Validation
- `npm run
  build`
- `npm test`

## Related
- Refs #240