### PR TITLE
refactor: move runtime capability access away from Global window and navigator

### DIFF
--- a/src/ClipboardAPI/Clipboard.res
+++ b/src/ClipboardAPI/Clipboard.res
@@ -1,27 +1,31 @@
 open ClipboardTypes
 
-include EventTarget.Impl({type t = clipboard})
+type t = ClipboardTypes.clipboard = {...ClipboardTypes.clipboard}
+
+external current: t = "clipboard"
+
+include EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clipboard/read)
 */
 @send
-external read: clipboard => promise<array<clipboardItem>> = "read"
+external read: t => promise<array<clipboardItem>> = "read"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clipboard/readText)
 */
 @send
-external readText: clipboard => promise<string> = "readText"
+external readText: t => promise<string> = "readText"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clipboard/write)
 */
 @send
-external write: (clipboard, array<clipboardItem>) => promise<unit> = "write"
+external write: (t, array<clipboardItem>) => promise<unit> = "write"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clipboard/writeText)
 */
 @send
-external writeText: (clipboard, string) => promise<unit> = "writeText"
+external writeText: (t, string) => promise<unit> = "writeText"

--- a/src/CredentialManagementAPI/CredentialsContainer.res
+++ b/src/CredentialManagementAPI/CredentialsContainer.res
@@ -1,24 +1,28 @@
 open CredentialManagementTypes
 
+type t = CredentialManagementTypes.credentialsContainer = {}
+
+external current: t = "credentials"
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/get)
 */
 @send
-external get: (credentialsContainer, ~options: credentialRequestOptions=?) => promise<credential> =
+external get: (t, ~options: credentialRequestOptions=?) => promise<credential> =
   "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/store)
 */
 @send
-external store: (credentialsContainer, credential) => promise<unit> = "store"
+external store: (t, credential) => promise<unit> = "store"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/create)
 */
 @send
 external create: (
-  credentialsContainer,
+  t,
   ~options: credentialCreationOptions=?,
 ) => promise<credential> = "create"
 
@@ -26,4 +30,4 @@ external create: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/preventSilentAccess)
 */
 @send
-external preventSilentAccess: credentialsContainer => promise<unit> = "preventSilentAccess"
+external preventSilentAccess: t => promise<unit> = "preventSilentAccess"

--- a/src/CredentialManagementAPI/CredentialsContainer.res
+++ b/src/CredentialManagementAPI/CredentialsContainer.res
@@ -1,6 +1,9 @@
 open CredentialManagementTypes
 
-type t = CredentialManagementTypes.credentialsContainer = {}
+type t =
+  CredentialManagementTypes.credentialsContainer = {
+    ...CredentialManagementTypes.credentialsContainer,
+  }
 
 external current: t = "credentials"
 

--- a/src/CredentialManagementAPI/CredentialsContainer.res
+++ b/src/CredentialManagementAPI/CredentialsContainer.res
@@ -1,9 +1,8 @@
 open CredentialManagementTypes
 
-type t =
-  CredentialManagementTypes.credentialsContainer = {
-    ...CredentialManagementTypes.credentialsContainer,
-  }
+type t = CredentialManagementTypes.credentialsContainer = {
+  ...CredentialManagementTypes.credentialsContainer,
+}
 
 external current: t = "credentials"
 
@@ -11,8 +10,7 @@ external current: t = "credentials"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/get)
 */
 @send
-external get: (t, ~options: credentialRequestOptions=?) => promise<credential> =
-  "get"
+external get: (t, ~options: credentialRequestOptions=?) => promise<credential> = "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/store)
@@ -24,10 +22,7 @@ external store: (t, credential) => promise<unit> = "store"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/create)
 */
 @send
-external create: (
-  t,
-  ~options: credentialCreationOptions=?,
-) => promise<credential> = "create"
+external create: (t, ~options: credentialCreationOptions=?) => promise<credential> = "create"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/preventSilentAccess)

--- a/src/Global.res
+++ b/src/Global.res
@@ -14,11 +14,6 @@ open FetchTypes
 open EventTypes
 
 /**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/window)
-*/
-external window: window = "window"
-
-/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/self)
 */
 external self: window = "self"
@@ -123,11 +118,6 @@ external parent: window = "parent"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/frameElement)
 */
 external frameElement: element = "frameElement"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/navigator)
-*/
-external navigator: navigator = "navigator"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/screen)

--- a/src/HistoryAPI/History.res
+++ b/src/HistoryAPI/History.res
@@ -32,5 +32,4 @@ external pushState: (t, ~data: JSON.t, ~unused: string, ~url: string=?) => unit 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/replaceState)
 */
 @send
-external replaceState: (t, ~data: JSON.t, ~unused: string, ~url: string=?) => unit =
-  "replaceState"
+external replaceState: (t, ~data: JSON.t, ~unused: string, ~url: string=?) => unit = "replaceState"

--- a/src/HistoryAPI/History.res
+++ b/src/HistoryAPI/History.res
@@ -1,32 +1,36 @@
 open HistoryTypes
 
+type t = HistoryTypes.history = {...HistoryTypes.history}
+
+external current: t = "history"
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/go)
 */
 @send
-external go: (history, ~delta: int=?) => unit = "go"
+external go: (t, ~delta: int=?) => unit = "go"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/back)
 */
 @send
-external back: history => unit = "back"
+external back: t => unit = "back"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/forward)
 */
 @send
-external forward: history => unit = "forward"
+external forward: t => unit = "forward"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/pushState)
 */
 @send
-external pushState: (history, ~data: JSON.t, ~unused: string, ~url: string=?) => unit = "pushState"
+external pushState: (t, ~data: JSON.t, ~unused: string, ~url: string=?) => unit = "pushState"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/replaceState)
 */
 @send
-external replaceState: (history, ~data: JSON.t, ~unused: string, ~url: string=?) => unit =
+external replaceState: (t, ~data: JSON.t, ~unused: string, ~url: string=?) => unit =
   "replaceState"

--- a/src/IndexedDBAPI/IDBFactory.res
+++ b/src/IndexedDBAPI/IDBFactory.res
@@ -1,24 +1,28 @@
 open IndexedDBTypes
 
+type t = IndexedDBTypes.idbFactory = {}
+
+external current: t = "indexedDB"
+
 /**
 Attempts to open a connection to the named database with the current version, or 1 if it does not already exist. If the request is successful request's result will be the connection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBFactory/open)
 */
 @send
-external open_: (idbFactory, ~name: string, ~version: int=?) => idbOpenDBRequest = "open"
+external open_: (t, ~name: string, ~version: int=?) => idbOpenDBRequest = "open"
 
 /**
 Attempts to delete the named database. If the database already exists and there are open connections that don't close in response to a versionchange event, the request will be blocked until all they close. If the request is successful request's result will be null.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBFactory/deleteDatabase)
 */
 @send
-external deleteDatabase: (idbFactory, string) => idbOpenDBRequest = "deleteDatabase"
+external deleteDatabase: (t, string) => idbOpenDBRequest = "deleteDatabase"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBFactory/databases)
 */
 @send
-external databases: idbFactory => promise<array<idbDatabaseInfo>> = "databases"
+external databases: t => promise<array<idbDatabaseInfo>> = "databases"
 
 /**
 Compares two values as keys. Returns -1 if key1 precedes key2, 1 if key2 precedes key1, and 0 if the keys are equal.
@@ -27,4 +31,4 @@ Throws a "DataError" DOMException if either input is not a valid key.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBFactory/cmp)
 */
 @send
-external cmp: (idbFactory, ~first: JSON.t, ~second: JSON.t) => int = "cmp"
+external cmp: (t, ~first: JSON.t, ~second: JSON.t) => int = "cmp"

--- a/src/IndexedDBAPI/IDBFactory.res
+++ b/src/IndexedDBAPI/IDBFactory.res
@@ -1,6 +1,6 @@
 open IndexedDBTypes
 
-type t = IndexedDBTypes.idbFactory = {}
+type t = IndexedDBTypes.idbFactory = {...IndexedDBTypes.idbFactory}
 
 external current: t = "indexedDB"
 

--- a/src/PerformanceAPI/Performance.res
+++ b/src/PerformanceAPI/Performance.res
@@ -1,56 +1,60 @@
 open PerformanceTypes
 
-include EventTarget.Impl({type t = performance})
+type t = PerformanceTypes.performance = {...PerformanceTypes.performance}
+
+external current: t = "performance"
+
+include EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/now)
 */
 @send
-external now: performance => float = "now"
+external now: t => float = "now"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/toJSON)
 */
 @send
-external toJSON: performance => Dict.t<string> = "toJSON"
+external toJSON: t => Dict.t<string> = "toJSON"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/getEntries)
 */
 @send
-external getEntries: performance => performanceEntryList = "getEntries"
+external getEntries: t => performanceEntryList = "getEntries"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByType)
 */
 @send
-external getEntriesByType: (performance, string) => performanceEntryList = "getEntriesByType"
+external getEntriesByType: (t, string) => performanceEntryList = "getEntriesByType"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/getEntriesByName)
 */
 @send
-external getEntriesByName: (performance, ~name: string, ~type_: string=?) => performanceEntryList =
+external getEntriesByName: (t, ~name: string, ~type_: string=?) => performanceEntryList =
   "getEntriesByName"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/clearResourceTimings)
 */
 @send
-external clearResourceTimings: performance => unit = "clearResourceTimings"
+external clearResourceTimings: t => unit = "clearResourceTimings"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/setResourceTimingBufferSize)
 */
 @send
-external setResourceTimingBufferSize: (performance, int) => unit = "setResourceTimingBufferSize"
+external setResourceTimingBufferSize: (t, int) => unit = "setResourceTimingBufferSize"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/mark)
 */
 @send
 external mark: (
-  performance,
+  t,
   ~markName: string,
   ~markOptions: performanceMarkOptions=?,
 ) => performanceMark = "mark"
@@ -59,14 +63,14 @@ external mark: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/clearMarks)
 */
 @send
-external clearMarks: (performance, ~markName: string=?) => unit = "clearMarks"
+external clearMarks: (t, ~markName: string=?) => unit = "clearMarks"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/measure)
 */
 @send
 external measure: (
-  performance,
+  t,
   ~measureName: string,
   ~startOrMeasureOptions: string=?,
   ~endMark: string=?,
@@ -77,7 +81,7 @@ external measure: (
 */
 @send
 external measure2: (
-  performance,
+  t,
   ~measureName: string,
   ~startOrMeasureOptions: performanceMeasureOptions=?,
   ~endMark: string=?,
@@ -87,4 +91,4 @@ external measure2: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/clearMeasures)
 */
 @send
-external clearMeasures: (performance, ~measureName: string=?) => unit = "clearMeasures"
+external clearMeasures: (t, ~measureName: string=?) => unit = "clearMeasures"

--- a/src/PerformanceAPI/Performance.res
+++ b/src/PerformanceAPI/Performance.res
@@ -53,11 +53,8 @@ external setResourceTimingBufferSize: (t, int) => unit = "setResourceTimingBuffe
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/mark)
 */
 @send
-external mark: (
-  t,
-  ~markName: string,
-  ~markOptions: performanceMarkOptions=?,
-) => performanceMark = "mark"
+external mark: (t, ~markName: string, ~markOptions: performanceMarkOptions=?) => performanceMark =
+  "mark"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/clearMarks)

--- a/src/PermissionsAPI/Permissions.res
+++ b/src/PermissionsAPI/Permissions.res
@@ -1,6 +1,6 @@
 open PermissionsTypes
 
-type t = PermissionsTypes.permissions = {}
+type t = PermissionsTypes.permissions = {...PermissionsTypes.permissions}
 
 external current: t = "permissions"
 

--- a/src/PermissionsAPI/Permissions.res
+++ b/src/PermissionsAPI/Permissions.res
@@ -1,7 +1,11 @@
 open PermissionsTypes
 
+type t = PermissionsTypes.permissions = {}
+
+external current: t = "permissions"
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Permissions/query)
 */
 @send
-external query: (permissions, permissionDescriptor) => promise<permissionStatus> = "query"
+external query: (t, permissionDescriptor) => promise<permissionStatus> = "query"

--- a/src/ScreenWakeLockAPI/WakeLock.res
+++ b/src/ScreenWakeLockAPI/WakeLock.res
@@ -1,6 +1,6 @@
 open ScreenWakeLockTypes
 
-type t = ScreenWakeLockTypes.wakeLock = {}
+type t = ScreenWakeLockTypes.wakeLock = {...ScreenWakeLockTypes.wakeLock}
 
 external current: t = "wakeLock"
 

--- a/src/ScreenWakeLockAPI/WakeLock.res
+++ b/src/ScreenWakeLockAPI/WakeLock.res
@@ -1,7 +1,11 @@
 open ScreenWakeLockTypes
 
+type t = ScreenWakeLockTypes.wakeLock = {}
+
+external current: t = "wakeLock"
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WakeLock/request)
 */
 @send
-external request: (wakeLock, ~type_: wakeLockType=?) => promise<wakeLockSentinel> = "request"
+external request: (t, ~type_: wakeLockType=?) => promise<wakeLockSentinel> = "request"

--- a/src/ServiceWorkerAPI/ServiceWorkerContainer.res
+++ b/src/ServiceWorkerAPI/ServiceWorkerContainer.res
@@ -20,17 +20,14 @@ external register: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/getRegistration)
 */
 @send
-external getRegistration: (
-  t,
-  ~clientURL: string=?,
-) => Nullable.t<serviceWorkerRegistration> = "getRegistration"
+external getRegistration: (t, ~clientURL: string=?) => Nullable.t<serviceWorkerRegistration> =
+  "getRegistration"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/getRegistrations)
 */
 @send
-external getRegistrations: t => promise<array<serviceWorkerRegistration>> =
-  "getRegistrations"
+external getRegistrations: t => promise<array<serviceWorkerRegistration>> = "getRegistrations"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/startMessages)

--- a/src/ServiceWorkerAPI/ServiceWorkerContainer.res
+++ b/src/ServiceWorkerAPI/ServiceWorkerContainer.res
@@ -1,13 +1,17 @@
 open ServiceWorkerTypes
 
-include EventTarget.Impl({type t = serviceWorkerContainer})
+type t = ServiceWorkerTypes.serviceWorkerContainer = {...ServiceWorkerTypes.serviceWorkerContainer}
+
+external current: t = "serviceWorker"
+
+include EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/register)
 */
 @send
 external register: (
-  serviceWorkerContainer,
+  t,
   string,
   ~options: registrationOptions=?,
 ) => promise<serviceWorkerRegistration> = "register"
@@ -17,7 +21,7 @@ external register: (
 */
 @send
 external getRegistration: (
-  serviceWorkerContainer,
+  t,
   ~clientURL: string=?,
 ) => Nullable.t<serviceWorkerRegistration> = "getRegistration"
 
@@ -25,11 +29,11 @@ external getRegistration: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/getRegistrations)
 */
 @send
-external getRegistrations: serviceWorkerContainer => promise<array<serviceWorkerRegistration>> =
+external getRegistrations: t => promise<array<serviceWorkerRegistration>> =
   "getRegistrations"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/startMessages)
 */
 @send
-external startMessages: serviceWorkerContainer => unit = "startMessages"
+external startMessages: t => unit = "startMessages"

--- a/src/ServiceWorkerAPI/ServiceWorkerGlobalScope.res
+++ b/src/ServiceWorkerAPI/ServiceWorkerGlobalScope.res
@@ -1,10 +1,12 @@
 open ServiceWorkerTypes
 
-include WorkerGlobalScope.Impl({type t = serviceWorkerGlobalScope})
+type t = ServiceWorkerTypes.serviceWorkerGlobalScope = {...ServiceWorkerTypes.serviceWorkerGlobalScope}
+
+include WorkerGlobalScope.Impl({type t = t})
 
 /**
 Forces the waiting service worker to become the active service worker.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/skipWaiting)
 */
 @send
-external skipWaiting: serviceWorkerGlobalScope => promise<unit> = "skipWaiting"
+external skipWaiting: t => promise<unit> = "skipWaiting"

--- a/src/ServiceWorkerAPI/ServiceWorkerGlobalScope.res
+++ b/src/ServiceWorkerAPI/ServiceWorkerGlobalScope.res
@@ -1,6 +1,8 @@
 open ServiceWorkerTypes
 
-type t = ServiceWorkerTypes.serviceWorkerGlobalScope = {...ServiceWorkerTypes.serviceWorkerGlobalScope}
+type t = ServiceWorkerTypes.serviceWorkerGlobalScope = {
+  ...ServiceWorkerTypes.serviceWorkerGlobalScope,
+}
 
 include WorkerGlobalScope.Impl({type t = t})
 

--- a/src/StorageAPI/StorageManager.res
+++ b/src/StorageAPI/StorageManager.res
@@ -1,7 +1,7 @@
 open StorageTypes
 open FileTypes
 
-type t = StorageTypes.storageManager = {}
+type t = StorageTypes.storageManager = {...StorageTypes.storageManager}
 
 external current: t = "storage"
 

--- a/src/StorageAPI/StorageManager.res
+++ b/src/StorageAPI/StorageManager.res
@@ -1,26 +1,30 @@
 open StorageTypes
 open FileTypes
 
+type t = StorageTypes.storageManager = {}
+
+external current: t = "storage"
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StorageManager/persisted)
 */
 @send
-external persisted: storageManager => promise<bool> = "persisted"
+external persisted: t => promise<bool> = "persisted"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StorageManager/persist)
 */
 @send
-external persist: storageManager => promise<bool> = "persist"
+external persist: t => promise<bool> = "persist"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StorageManager/estimate)
 */
 @send
-external estimate: storageManager => promise<storageEstimate> = "estimate"
+external estimate: t => promise<storageEstimate> = "estimate"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StorageManager/getDirectory)
 */
 @send
-external getDirectory: storageManager => promise<fileSystemDirectoryHandle> = "getDirectory"
+external getDirectory: t => promise<fileSystemDirectoryHandle> = "getDirectory"

--- a/src/WebCryptoAPI/Crypto.res
+++ b/src/WebCryptoAPI/Crypto.res
@@ -1,13 +1,17 @@
 open WebCryptoTypes
 
+type t = WebCryptoTypes.crypto = {...WebCryptoTypes.crypto}
+
+external current: t = "crypto"
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Crypto/getRandomValues)
 */
 @send
-external getRandomValues: (crypto, 't) => 't = "getRandomValues"
+external getRandomValues: (t, 't) => 't = "getRandomValues"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
 */
 @send
-external randomUUID: crypto => string = "randomUUID"
+external randomUUID: t => string = "randomUUID"

--- a/src/WebLocksAPI/LockManager.res
+++ b/src/WebLocksAPI/LockManager.res
@@ -1,10 +1,14 @@
 open WebLocksTypes
 
+type t = WebLocksTypes.lockManager = {}
+
+external current: t = "locks"
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/LockManager/request)
 */
 @send
-external request: (lockManager, ~name: string, ~callback: lockGrantedCallback) => promise<JSON.t> =
+external request: (t, ~name: string, ~callback: lockGrantedCallback) => promise<JSON.t> =
   "request"
 
 /**
@@ -12,7 +16,7 @@ external request: (lockManager, ~name: string, ~callback: lockGrantedCallback) =
 */
 @send
 external request2: (
-  lockManager,
+  t,
   ~name: string,
   ~options: lockOptions,
   ~callback: lockGrantedCallback,
@@ -22,4 +26,4 @@ external request2: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/LockManager/query)
 */
 @send
-external query: lockManager => promise<lockManagerSnapshot> = "query"
+external query: t => promise<lockManagerSnapshot> = "query"

--- a/src/WebLocksAPI/LockManager.res
+++ b/src/WebLocksAPI/LockManager.res
@@ -1,6 +1,6 @@
 open WebLocksTypes
 
-type t = WebLocksTypes.lockManager = {}
+type t = WebLocksTypes.lockManager = {...WebLocksTypes.lockManager}
 
 external current: t = "locks"
 

--- a/src/WebLocksAPI/LockManager.res
+++ b/src/WebLocksAPI/LockManager.res
@@ -8,8 +8,7 @@ external current: t = "locks"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/LockManager/request)
 */
 @send
-external request: (t, ~name: string, ~callback: lockGrantedCallback) => promise<JSON.t> =
-  "request"
+external request: (t, ~name: string, ~callback: lockGrantedCallback) => promise<JSON.t> = "request"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/LockManager/request)

--- a/src/WebStorageAPI/Storage.res
+++ b/src/WebStorageAPI/Storage.res
@@ -1,18 +1,24 @@
 open WebStorageTypes
 
+type t = WebStorageTypes.storage = {...WebStorageTypes.storage}
+
+external local: t = "localStorage"
+
+external session: t = "sessionStorage"
+
 /**
 Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Storage/key)
 */
 @send
-external key: (storage, int) => Null.t<string> = "key"
+external key: (t, int) => Null.t<string> = "key"
 
 /**
 Returns the current value associated with the given key, or null if the given key does not exist.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Storage/getItem)
 */
 @send
-external getItem: (storage, string) => Null.t<string> = "getItem"
+external getItem: (t, string) => Null.t<string> = "getItem"
 
 /**
 Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
@@ -23,7 +29,7 @@ Dispatches a storage event on Window objects holding an equivalent Storage objec
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
 */
 @send
-external setItem: (storage, ~key: string, ~value: string) => unit = "setItem"
+external setItem: (t, ~key: string, ~value: string) => unit = "setItem"
 
 /**
 Removes the key/value pair with the given key, if a key/value pair with the given key exists.
@@ -32,7 +38,7 @@ Dispatches a storage event on Window objects holding an equivalent Storage objec
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Storage/removeItem)
 */
 @send
-external removeItem: (storage, string) => unit = "removeItem"
+external removeItem: (t, string) => unit = "removeItem"
 
 /**
 Removes all key/value pairs, if there are any.
@@ -41,4 +47,4 @@ Dispatches a storage event on Window objects holding an equivalent Storage objec
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Storage/clear)
 */
 @send
-external clear: storage => unit = "clear"
+external clear: t => unit = "clear"

--- a/src/WebWorkersAPI/SharedWorkerGlobalScope.res
+++ b/src/WebWorkersAPI/SharedWorkerGlobalScope.res
@@ -1,5 +1,7 @@
 open WebWorkersTypes
 
+type t = WebWorkersTypes.sharedWorkerGlobalScope = {...WebWorkersTypes.sharedWorkerGlobalScope}
+
 module Impl = (
   T: {
     type t
@@ -24,4 +26,4 @@ self -> SharedWorkerGlobalScope.close
   external close: T.t => unit = "close"
 }
 
-include Impl({type t = sharedWorkerGlobalScope})
+include Impl({type t = t})

--- a/src/WebWorkersAPI/WorkerGlobalScope.res
+++ b/src/WebWorkersAPI/WorkerGlobalScope.res
@@ -1,12 +1,16 @@
 open WebWorkersTypes
 open FetchTypes
 
+type t = WebWorkersTypes.workerGlobalScope = {...WebWorkersTypes.workerGlobalScope}
+
 module Impl = (
   T: {
     type t
   },
 ) => {
   include EventTarget.Impl({type t = T.t})
+
+  external current: T.t = "self"
 
   /**
 `fetch(workerGlobalScope, string, init)`
@@ -38,4 +42,4 @@ let response = await self->WorkerGlobalScope.fetch(myRequest)
   external fetchWithRequest: (T.t, request, ~init: requestInit=?) => promise<response> = "fetch"
 }
 
-include Impl({type t = workerGlobalScope})
+include Impl({type t = t})

--- a/tests/DOMAPI/Location__test.res
+++ b/tests/DOMAPI/Location__test.res
@@ -1,7 +1,4 @@
-open Global
-
-// Note that this only works when you added the `-open Global` bsc flag.
-let location = window.location
+let location = Window.current.location
 
 // Access properties using `.`
 let href = location.href

--- a/tests/Global__test.res
+++ b/tests/Global__test.res
@@ -41,7 +41,9 @@ let _wakeLock = WakeLock.current
 let _locks = LockManager.current
 let _storageManager = StorageManager.current
 
-let registrationResult = await ServiceWorkerContainer.current->ServiceWorkerContainer.register("/sw.js")
+let registrationResult = await ServiceWorkerContainer.current->ServiceWorkerContainer.register(
+  "/sw.js",
+)
 let subscription = await registrationResult.pushManager->PushManager.subscribe(
   ~options={
     userVisibleOnly: true,

--- a/tests/Global__test.res
+++ b/tests/Global__test.res
@@ -30,7 +30,18 @@ let response3 = await fetchWithRequest(
 
 removeEventListener(Mousedown, MouseEvent.preventDefault, ~options={capture: false})
 
-let registrationResult = await navigator.serviceWorker->ServiceWorkerContainer.register("/sw.js")
+let _history = History.current
+let _performance = Performance.current
+let _crypto = Crypto.current
+let _indexedDB = IDBFactory.current
+let _clipboard = Clipboard.current
+let _permissions = Permissions.current
+let _credentials = CredentialsContainer.current
+let _wakeLock = WakeLock.current
+let _locks = LockManager.current
+let _storageManager = StorageManager.current
+
+let registrationResult = await ServiceWorkerContainer.current->ServiceWorkerContainer.register("/sw.js")
 let subscription = await registrationResult.pushManager->PushManager.subscribe(
   ~options={
     userVisibleOnly: true,

--- a/tests/ServiceWorkerAPI/ServiceWorker__test.res
+++ b/tests/ServiceWorkerAPI/ServiceWorker__test.res
@@ -1,6 +1,6 @@
 open WebAPI.ServiceWorkerTypes
 
-external self: serviceWorkerGlobalScope = "self"
+let self = ServiceWorkerGlobalScope.current
 
 self->ServiceWorkerGlobalScope.addEventListener(EventTypes.Push, (event: PushTypes.pushEvent) => {
   Console.log("received push event")

--- a/tests/WebStorageAPI/Storage__test.res
+++ b/tests/WebStorageAPI/Storage__test.res
@@ -1,8 +1,14 @@
-open Global
 open WebAPI.Storage
+
+let localStorage = Storage.local
+let sessionStorage = Storage.session
 
 for i in 0 to localStorage.length - 1 {
   localStorage->key(i)->Null.getOr("nothing")->Console.log
+}
+
+for i in 0 to sessionStorage.length - 1 {
+  sessionStorage->key(i)->Null.getOr("nothing")->Console.log
 }
 
 let item1 = localStorage->getItem("foo")->Null.getOr("nothing")
@@ -12,3 +18,5 @@ localStorage->setItem(~key="bar", ~value="...")
 localStorage->removeItem("bar")
 
 localStorage->clear
+
+sessionStorage->clear

--- a/tests/WebWorkersAPI/SharedWorkerGlobalScope__test.res
+++ b/tests/WebWorkersAPI/SharedWorkerGlobalScope__test.res
@@ -1,7 +1,5 @@
 open WebAPI.WebWorkersTypes
 
-external getSelf: unit => sharedWorkerGlobalScope = "self"
-
-let self = getSelf()
+let self = SharedWorkerGlobalScope.current
 
 self->SharedWorkerGlobalScope.close

--- a/tests/WebWorkersAPI/SharedWorker__test.res
+++ b/tests/WebWorkersAPI/SharedWorker__test.res
@@ -14,8 +14,6 @@ let shared3: sharedWorker = SharedWorker.makeWithOptions(
 
 let port: WebAPI.ChannelMessagingTypes.messagePort = SharedWorker.port(shared1)
 
-external getSelf: unit => sharedWorkerGlobalScope = "self"
-
-let self = getSelf()
+let self = SharedWorkerGlobalScope.current
 
 self->SharedWorkerGlobalScope.close


### PR DESCRIPTION
## Summary
- remove `Global.window` and `Global.navigator` from the public
  runtime access path
- add owner-module entrypoints such as `History.current`,
  `Storage.local`, `Storage.session`, `Performance.current`, `Crypto.current`, and worker/
  service-worker `current` accessors
- update runtime-facing tests to use the owner modules
  instead of `Global.window` and `Global.navigator`

## Validation
- `npm run build`
-
  `npm test`

## Related
- Refs #241