### PR TITLE
refactor: simplify media and device module surfaces

### DIFF
--- a/src/NotificationAPI/Notification.res
+++ b/src/NotificationAPI/Notification.res
@@ -4,11 +4,19 @@ type t = notification = {...notification}
 
 type notificationDirection = NotificationTypes.notificationDirection
 type notificationPermission = NotificationTypes.notificationPermission
-type notificationAction = NotificationTypes.notificationAction
-type notificationOptions = NotificationTypes.notificationOptions
-type getNotificationOptions = NotificationTypes.getNotificationOptions
+type notificationAction = NotificationTypes.notificationAction = {
+  ...NotificationTypes.notificationAction,
+}
+type notificationOptions = NotificationTypes.notificationOptions = {
+  ...NotificationTypes.notificationOptions,
+}
+type getNotificationOptions = NotificationTypes.getNotificationOptions = {
+  ...NotificationTypes.getNotificationOptions,
+}
 type notificationPermissionCallback = NotificationTypes.notificationPermissionCallback
-type notificationEvent = NotificationTypes.notificationEvent
+type notificationEvent = NotificationTypes.notificationEvent = {
+  ...NotificationTypes.notificationEvent,
+}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Notification)

--- a/src/NotificationAPI/Notification.res
+++ b/src/NotificationAPI/Notification.res
@@ -1,12 +1,22 @@
 open NotificationTypes
 
+type t = notification = {...notification}
+
+type notificationDirection = NotificationTypes.notificationDirection
+type notificationPermission = NotificationTypes.notificationPermission
+type notificationAction = NotificationTypes.notificationAction
+type notificationOptions = NotificationTypes.notificationOptions
+type getNotificationOptions = NotificationTypes.getNotificationOptions
+type notificationPermissionCallback = NotificationTypes.notificationPermissionCallback
+type notificationEvent = NotificationTypes.notificationEvent
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Notification)
 */
 @new
-external make: (~title: string, ~options: notificationOptions=?) => notification = "Notification"
+external make: (~title: string, ~options: notificationOptions=?) => t = "Notification"
 
-include EventTarget.Impl({type t = notification})
+include EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Notification/requestPermission_static)
@@ -20,7 +30,7 @@ external requestPermission: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Notification/close)
 */
 @send
-external close: notification => unit = "close"
+external close: t => unit = "close"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Notification/permission_static)

--- a/src/PictureInPicture.res
+++ b/src/PictureInPicture.res
@@ -1,0 +1,5 @@
+open PictureInPictureTypes
+
+type t = pictureInPictureWindow = {...pictureInPictureWindow}
+
+include EventTarget.Impl({type t = t})

--- a/src/WebAudioAPI/AudioContext.res
+++ b/src/WebAudioAPI/AudioContext.res
@@ -3,9 +3,9 @@ open DOMTypes
 open MediaCaptureAndStreamsTypes
 
 type t = audioContext = {...audioContext}
-type baseAudioContext = WebAudioTypes.baseAudioContext
-type audioContextOptions = WebAudioTypes.audioContextOptions
-type audioTimestamp = WebAudioTypes.audioTimestamp
+type baseAudioContext = WebAudioTypes.baseAudioContext = {...WebAudioTypes.baseAudioContext}
+type audioContextOptions = WebAudioTypes.audioContextOptions = {...WebAudioTypes.audioContextOptions}
+type audioTimestamp = WebAudioTypes.audioTimestamp = {...WebAudioTypes.audioTimestamp}
 
 include BaseAudioContext.Impl({type t = t})
 

--- a/src/WebAudioAPI/AudioContext.res
+++ b/src/WebAudioAPI/AudioContext.res
@@ -4,7 +4,9 @@ open MediaCaptureAndStreamsTypes
 
 type t = audioContext = {...audioContext}
 type baseAudioContext = WebAudioTypes.baseAudioContext = {...WebAudioTypes.baseAudioContext}
-type audioContextOptions = WebAudioTypes.audioContextOptions = {...WebAudioTypes.audioContextOptions}
+type audioContextOptions = WebAudioTypes.audioContextOptions = {
+  ...WebAudioTypes.audioContextOptions,
+}
 type audioTimestamp = WebAudioTypes.audioTimestamp = {...WebAudioTypes.audioTimestamp}
 
 include BaseAudioContext.Impl({type t = t})

--- a/src/WebAudioAPI/AudioContext.res
+++ b/src/WebAudioAPI/AudioContext.res
@@ -2,55 +2,60 @@ open WebAudioTypes
 open DOMTypes
 open MediaCaptureAndStreamsTypes
 
-include BaseAudioContext.Impl({type t = audioContext})
+type t = audioContext = {...audioContext}
+type baseAudioContext = WebAudioTypes.baseAudioContext
+type audioContextOptions = WebAudioTypes.audioContextOptions
+type audioTimestamp = WebAudioTypes.audioTimestamp
+
+include BaseAudioContext.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext)
 */
 @new
-external make: (~contextOptions: audioContextOptions=?) => audioContext = "AudioContext"
+external make: (~contextOptions: audioContextOptions=?) => t = "AudioContext"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/getOutputTimestamp)
 */
 @send
-external getOutputTimestamp: audioContext => audioTimestamp = "getOutputTimestamp"
+external getOutputTimestamp: t => audioTimestamp = "getOutputTimestamp"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/resume)
 */
 @send
-external resume: audioContext => promise<unit> = "resume"
+external resume: t => promise<unit> = "resume"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/suspend)
 */
 @send
-external suspend: audioContext => promise<unit> = "suspend"
+external suspend: t => promise<unit> = "suspend"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/close)
 */
 @send
-external close: audioContext => promise<unit> = "close"
+external close: t => promise<unit> = "close"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaElementSource)
 */
 @send
-external createMediaElementSource: (audioContext, htmlMediaElement) => mediaElementAudioSourceNode =
+external createMediaElementSource: (t, htmlMediaElement) => mediaElementAudioSourceNode =
   "createMediaElementSource"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaStreamSource)
 */
 @send
-external createMediaStreamSource: (audioContext, mediaStream) => mediaStreamAudioSourceNode =
+external createMediaStreamSource: (t, mediaStream) => mediaStreamAudioSourceNode =
   "createMediaStreamSource"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaStreamDestination)
 */
 @send
-external createMediaStreamDestination: audioContext => mediaStreamAudioDestinationNode =
+external createMediaStreamDestination: t => mediaStreamAudioDestinationNode =
   "createMediaStreamDestination"

--- a/src/WebAudioAPI/AudioDestinationNode.res
+++ b/src/WebAudioAPI/AudioDestinationNode.res
@@ -1,3 +1,5 @@
 open WebAudioTypes
 
-include AudioNode.Impl({type t = audioDestinationNode})
+type t = audioDestinationNode = {...audioDestinationNode}
+
+include AudioNode.Impl({type t = t})

--- a/src/WebAudioAPI/AudioNode.res
+++ b/src/WebAudioAPI/AudioNode.res
@@ -1,5 +1,7 @@
 open WebAudioTypes
 
+type t = audioNode = {...audioNode}
+
 module Impl = (
   T: {
     type t
@@ -65,3 +67,5 @@ module Impl = (
   @send
   external disconnect7: (T.t, ~destinationParam: audioParam, ~output: int) => unit = "disconnect"
 }
+
+include Impl({type t = t})

--- a/src/WebAudioAPI/AudioScheduledSourceNode.res
+++ b/src/WebAudioAPI/AudioScheduledSourceNode.res
@@ -1,5 +1,7 @@
 open WebAudioTypes
 
+type t = audioScheduledSourceNode = {...audioScheduledSourceNode}
+
 module Impl = (
   T: {
     type t
@@ -22,4 +24,4 @@ module Impl = (
   external stop: (T.t, ~when_: float=?) => unit = "stop"
 }
 
-include Impl({type t = audioScheduledSourceNode})
+include Impl({type t = t})

--- a/src/WebAudioAPI/GainNode.res
+++ b/src/WebAudioAPI/GainNode.res
@@ -1,9 +1,12 @@
 open WebAudioTypes
 
-include AudioNode.Impl({type t = gainNode})
+type t = gainNode = {...gainNode}
+type gainOptions = WebAudioTypes.gainOptions
+
+include AudioNode.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/GainNode)
 */
 @new
-external make: (~context: baseAudioContext, ~options: gainOptions=?) => gainNode = "GainNode"
+external make: (~context: baseAudioContext, ~options: gainOptions=?) => t = "GainNode"

--- a/src/WebAudioAPI/GainNode.res
+++ b/src/WebAudioAPI/GainNode.res
@@ -1,7 +1,7 @@
 open WebAudioTypes
 
 type t = gainNode = {...gainNode}
-type gainOptions = WebAudioTypes.gainOptions
+type gainOptions = WebAudioTypes.gainOptions = {...WebAudioTypes.gainOptions}
 
 include AudioNode.Impl({type t = t})
 

--- a/src/WebAudioAPI/OscillatorNode.res
+++ b/src/WebAudioAPI/OscillatorNode.res
@@ -1,16 +1,21 @@
 open WebAudioTypes
 
-include AudioScheduledSourceNode.Impl({type t = oscillatorNode})
+type t = oscillatorNode = {...oscillatorNode}
+type oscillatorOptions = WebAudioTypes.oscillatorOptions
+type oscillatorType = WebAudioTypes.oscillatorType
+type periodicWave = WebAudioTypes.periodicWave
+
+include AudioScheduledSourceNode.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OscillatorNode)
 */
 @new
-external make: (~context: baseAudioContext, ~options: oscillatorOptions=?) => oscillatorNode =
+external make: (~context: baseAudioContext, ~options: oscillatorOptions=?) => t =
   "OscillatorNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OscillatorNode/setPeriodicWave)
 */
 @send
-external setPeriodicWave: (oscillatorNode, periodicWave) => unit = "setPeriodicWave"
+external setPeriodicWave: (t, periodicWave) => unit = "setPeriodicWave"

--- a/src/WebAudioAPI/OscillatorNode.res
+++ b/src/WebAudioAPI/OscillatorNode.res
@@ -1,9 +1,9 @@
 open WebAudioTypes
 
 type t = oscillatorNode = {...oscillatorNode}
-type oscillatorOptions = WebAudioTypes.oscillatorOptions
+type oscillatorOptions = WebAudioTypes.oscillatorOptions = {...WebAudioTypes.oscillatorOptions}
 type oscillatorType = WebAudioTypes.oscillatorType
-type periodicWave = WebAudioTypes.periodicWave
+type periodicWave = WebAudioTypes.periodicWave = {...WebAudioTypes.periodicWave}
 
 include AudioScheduledSourceNode.Impl({type t = t})
 

--- a/src/WebAudioAPI/OscillatorNode.res
+++ b/src/WebAudioAPI/OscillatorNode.res
@@ -11,8 +11,7 @@ include AudioScheduledSourceNode.Impl({type t = t})
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OscillatorNode)
 */
 @new
-external make: (~context: baseAudioContext, ~options: oscillatorOptions=?) => t =
-  "OscillatorNode"
+external make: (~context: baseAudioContext, ~options: oscillatorOptions=?) => t = "OscillatorNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OscillatorNode/setPeriodicWave)

--- a/src/WebMIDI.res
+++ b/src/WebMIDI.res
@@ -1,0 +1,4 @@
+open WebMIDITypes
+
+type t = midiAccess = {...midiAccess}
+type midiOptions = WebMIDITypes.midiOptions

--- a/src/WebMIDI.res
+++ b/src/WebMIDI.res
@@ -1,4 +1,4 @@
 open WebMIDITypes
 
 type t = midiAccess = {...midiAccess}
-type midiOptions = WebMIDITypes.midiOptions
+type midiOptions = WebMIDITypes.midiOptions = {...WebMIDITypes.midiOptions}

--- a/tests/NotificationsAPI/Notification__test.res
+++ b/tests/NotificationsAPI/Notification__test.res
@@ -1,9 +1,9 @@
-open WebAPI.NotificationTypes
+let current: Notification.notificationPermission = Notification.permission
 
-let current = Notification.permission
+let _notification: Notification.t = Notification.make(~title="Testing notifications")
 
 Notification.requestPermission()
-->Promise.thenResolve(notificationPermission => {
+->Promise.thenResolve((notificationPermission: Notification.notificationPermission) => {
   switch notificationPermission {
   | Granted => Console.log("Permission granted")
   | Denied => Console.log("Permission denied")

--- a/tests/WebAudioAPI/AudioDestinationNode__.test.res
+++ b/tests/WebAudioAPI/AudioDestinationNode__.test.res
@@ -1,27 +1,24 @@
-open WebAudioTypes
+let ctx: AudioContext.t = AudioContext.make()
 
-let ctx = AudioContext.make()
+let destinationNode: AudioNode.t = ctx.destination->AudioDestinationNode.asAudioNode
+let context: AudioContext.baseAudioContext = AudioContext.asBaseAudioContext(ctx)
 
-let destinationNode = ctx.destination->AudioDestinationNode.asAudioNode
-let context = AudioContext.asBaseAudioContext(ctx)
+let oscillatorOptions: OscillatorNode.oscillatorOptions = {
+  type_: Sine,
+  frequency: 440.0,
+}
+let osc: OscillatorNode.t = OscillatorNode.make(~context, ~options=oscillatorOptions)
 
-let osc = OscillatorNode.make(
-  ~context,
-  ~options={
-    type_: Sine,
-    frequency: 440.0,
-  },
-)
-let gain = GainNode.make(
-  ~context,
-  ~options={
-    gain: 0.3,
-  },
-)
+let gainOptions: GainNode.gainOptions = {
+  gain: 0.3,
+}
+let gain: GainNode.t = GainNode.make(~context, ~options=gainOptions)
+
 let _ = gain->GainNode.connect(~destinationNode)
+let _scheduledSource: AudioScheduledSourceNode.t =
+  osc->OscillatorNode.asAudioScheduledSourceNode
 let _ =
-  osc
-  ->OscillatorNode.asAudioScheduledSourceNode
+  _scheduledSource
   ->AudioScheduledSourceNode.connect(~destinationNode=gain->GainNode.asAudioNode)
 
 osc->OscillatorNode.start

--- a/tests/WebAudioAPI/AudioDestinationNode__.test.res
+++ b/tests/WebAudioAPI/AudioDestinationNode__.test.res
@@ -15,10 +15,8 @@ let gainOptions: GainNode.gainOptions = {
 let gain: GainNode.t = GainNode.make(~context, ~options=gainOptions)
 
 let _ = gain->GainNode.connect(~destinationNode)
-let _scheduledSource: AudioScheduledSourceNode.t =
-  osc->OscillatorNode.asAudioScheduledSourceNode
+let _scheduledSource: AudioScheduledSourceNode.t = osc->OscillatorNode.asAudioScheduledSourceNode
 let _ =
-  _scheduledSource
-  ->AudioScheduledSourceNode.connect(~destinationNode=gain->GainNode.asAudioNode)
+  _scheduledSource->AudioScheduledSourceNode.connect(~destinationNode=gain->GainNode.asAudioNode)
 
 osc->OscillatorNode.start


### PR DESCRIPTION
## Summary
- add concrete-module `t` aliases and targeted helper type re-exports for the
  Notification and Web Audio surface touched in this pass
- introduce owner modules for `PictureInPicture` and
  `WebMIDI`
- update the media-facing tests to use the concrete module APIs instead of opening raw `...Types`
  modules directly

## Validation
- `npm run build`
- `npm test`

## Related
- Refs #243