### PR TITLE
refactor: complete final integration cleanup

### DIFF
--- a/src/CanvasAPI/CanvasPattern.res
+++ b/src/CanvasAPI/CanvasPattern.res
@@ -1,12 +1,13 @@
 module Types = CanvasTypes
 
 type t = Types.canvasPattern = {...Types.canvasPattern}
+type domMatrix2DInit = DOMTypes.domMatrix2DInit = {...DOMTypes.domMatrix2DInit}
 
 /**
 Sets the transformation matrix that will be used when rendering the pattern during a fill or stroke painting operation.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasPattern/setTransform)
 */
 @send
-external setTransform: (t, ~transform: DOMTypes.domMatrix2DInit=?) => unit = "setTransform"
+external setTransform: (t, ~transform: domMatrix2DInit=?) => unit = "setTransform"
 
 let isInstanceOf = (_: 't): bool => %raw(`param instanceof CanvasPattern`)

--- a/src/CanvasAPI/OffscreenCanvas.res
+++ b/src/CanvasAPI/OffscreenCanvas.res
@@ -95,5 +95,4 @@ The argument, if provided, is a dictionary that controls the encoding options of
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/convertToBlob)
 */
 @send
-external convertToBlob: (t, ~options: imageEncodeOptions=?) => promise<FileTypes.blob> =
-  "convertToBlob"
+external convertToBlob: (t, ~options: imageEncodeOptions=?) => promise<Blob.t> = "convertToBlob"

--- a/src/CanvasAPI/Path2D.res
+++ b/src/CanvasAPI/Path2D.res
@@ -1,6 +1,7 @@
 module Types = CanvasTypes
 
 type t = Types.path2D = {...Types.path2D}
+type domMatrix2DInit = DOMTypes.domMatrix2DInit = {...DOMTypes.domMatrix2DInit}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Path2D)
@@ -114,4 +115,4 @@ Adds to the path the path given by the argument.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Path2D/addPath)
 */
 @send
-external addPath: (t, ~path: t, ~transform: DOMTypes.domMatrix2DInit=?) => unit = "addPath"
+external addPath: (t, ~path: t, ~transform: domMatrix2DInit=?) => unit = "addPath"

--- a/src/DOMAPI/HTMLFormElement.res
+++ b/src/DOMAPI/HTMLFormElement.res
@@ -1,5 +1,7 @@
 open DOMTypes
 
+type t = htmlFormElement = {...htmlFormElement}
+
 include HTMLElement.Impl({type t = htmlFormElement})
 
 /**

--- a/src/FetchAPI/BodyInit.res
+++ b/src/FetchAPI/BodyInit.res
@@ -25,24 +25,24 @@ external fromDataView: DataView.t => t = "%identity"
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromBlob: FileTypes.blob => t = "%identity"
+external fromBlob: Blob.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromFile: FileTypes.file => t = "%identity"
+external fromFile: File.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromURLSearchParams: URLTypes.urlSearchParams => t = "%identity"
+external fromURLSearchParams: URLSearchParams.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromFormData: Types.formData => t = "%identity"
+external fromFormData: FormData.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromReadableStream: FileTypes.readableStream<'t> => t = "%identity"
+external fromReadableStream: ReadableStream.t<'t> => t = "%identity"

--- a/src/FetchAPI/FormData.res
+++ b/src/FetchAPI/FormData.res
@@ -5,10 +5,11 @@ module Types = FetchTypes
  */
 @new
 type t = Types.formData = {...Types.formData}
-type formDataEntryValue = Types.formDataEntryValue
+type formDataEntryValue = FormDataEntryValue.t
+type htmlFormElement = HTMLFormElement.t
+type htmlElement = HTMLElement.t
 
-external make: (~form: DOMTypes.htmlFormElement=?, ~submitter: DOMTypes.htmlElement=?) => t =
-  "FormData"
+external make: (~form: htmlFormElement=?, ~submitter: htmlElement=?) => t = "FormData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/append)
@@ -20,8 +21,7 @@ external append: (t, ~name: string, ~value: string) => unit = "append"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/append)
 */
 @send
-external appendBlob: (t, ~name: string, ~blobValue: FileTypes.blob, ~filename: string=?) => unit =
-  "append"
+external appendBlob: (t, ~name: string, ~blobValue: Blob.t, ~filename: string=?) => unit = "append"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/delete)
@@ -69,5 +69,4 @@ external set: (t, ~name: string, ~value: string) => unit = "set"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/set)
 */
 @send
-external setBlob: (t, ~name: string, ~blobValue: FileTypes.blob, ~filename: string=?) => unit =
-  "set"
+external setBlob: (t, ~name: string, ~blobValue: Blob.t, ~filename: string=?) => unit = "set"

--- a/src/FetchAPI/FormDataEntryValue.res
+++ b/src/FetchAPI/FormDataEntryValue.res
@@ -5,7 +5,7 @@ module Types = FetchTypes
 type t = Types.formDataEntryValue
 
 external fromString: string => t = "%identity"
-external fromFile: FileTypes.file => t = "%identity"
+external fromFile: File.t => t = "%identity"
 
 /**
 Represents a decoded version of the abstract `formDataEntryValue` type.
@@ -13,7 +13,7 @@ A FormData entry value is either a string or a File.
 */
 type decoded =
   | String(string)
-  | File(FileTypes.file)
+  | File(File.t)
 
 let decode = (value: t): decoded => {
   if File.isInstanceOf(value) {

--- a/src/FetchAPI/Request.res
+++ b/src/FetchAPI/Request.res
@@ -2,8 +2,8 @@ module Types = FetchTypes
 
 type t = Types.request = {...Types.request}
 type requestInit = Types.requestInit = {...Types.requestInit}
-type bodyInit = Types.bodyInit
-type headersInit = Types.headersInit
+type bodyInit = BodyInit.t
+type headersInit = HeadersInit.t
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
@@ -27,7 +27,7 @@ external arrayBuffer: t => promise<ArrayBuffer.t> = "arrayBuffer"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/blob)
 */
 @send
-external blob: t => promise<FileTypes.blob> = "blob"
+external blob: t => promise<Blob.t> = "blob"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/bytes)
@@ -39,7 +39,7 @@ external bytes: t => promise<array<int>> = "bytes"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/formData)
 */
 @send
-external formData: t => promise<Types.formData> = "formData"
+external formData: t => promise<FormData.t> = "formData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/json)

--- a/src/FetchAPI/Response.res
+++ b/src/FetchAPI/Response.res
@@ -2,8 +2,8 @@ module Types = FetchTypes
 
 type t = Types.response = {...Types.response}
 type responseInit = Types.responseInit = {...Types.responseInit}
-type bodyInit = Types.bodyInit
-type headersInit = Types.headersInit
+type bodyInit = BodyInit.t
+type headersInit = HeadersInit.t
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
@@ -39,31 +39,31 @@ external fromDataView: (DataView.t, ~init: responseInit=?) => t = "Response"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromBlob: (FileTypes.blob, ~init: responseInit=?) => t = "Response"
+external fromBlob: (Blob.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromFile: (FileTypes.file, ~init: responseInit=?) => t = "Response"
+external fromFile: (File.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromURLSearchParams: (URLTypes.urlSearchParams, ~init: responseInit=?) => t = "Response"
+external fromURLSearchParams: (URLSearchParams.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromFormData: (Types.formData, ~init: responseInit=?) => t = "Response"
+external fromFormData: (FormData.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromReadableStream: (FileTypes.readableStream<'t>, ~init: responseInit=?) => t = "Response"
+external fromReadableStream: (ReadableStream.t<'t>, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer)
@@ -75,7 +75,7 @@ external arrayBuffer: t => promise<ArrayBuffer.t> = "arrayBuffer"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/blob)
 */
 @send
-external blob: t => promise<FileTypes.blob> = "blob"
+external blob: t => promise<Blob.t> = "blob"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/bytes)
@@ -87,7 +87,7 @@ external bytes: t => promise<array<int>> = "bytes"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/formData)
 */
 @send
-external formData: t => promise<Types.formData> = "formData"
+external formData: t => promise<FormData.t> = "formData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/json)

--- a/src/PushAPI/PushEvent.res
+++ b/src/PushAPI/PushEvent.res
@@ -1,3 +1,5 @@
 open PushTypes
 
-include ExtendableEvent.Impl({type t = pushEvent})
+type t = pushEvent = {...pushEvent}
+
+include ExtendableEvent.Impl({type t = t})

--- a/src/PushAPI/PushMessageData.res
+++ b/src/PushAPI/PushMessageData.res
@@ -1,15 +1,17 @@
 open PushTypes
 
+type t = pushMessageData
+
 /**
 The json() method of the PushMessageData interface extracts push message data by parsing it as a JSON string and returning the result.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushMessageData/json)
 */
 @send
-external json: pushMessageData => JSON.t = "json"
+external json: t => JSON.t = "json"
 
 /**
 The text() method of the PushMessageData interface extracts push message data as a plain text string.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushMessageData/text)
 */
 @send
-external text: pushMessageData => string = "text"
+external text: t => string = "text"

--- a/src/ServiceWorkerAPI/ServiceWorker.res
+++ b/src/ServiceWorkerAPI/ServiceWorker.res
@@ -1,13 +1,14 @@
 open ServiceWorkerTypes
-open ChannelMessagingTypes
 
-include EventTarget.Impl({type t = serviceWorker})
+type t = serviceWorker = {...serviceWorker}
+
+include EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorker/postMessage)
 */
 @send
-external postMessage: (serviceWorker, ~message: JSON.t, ~transfer: array<Dict.t<string>>) => unit =
+external postMessage: (t, ~message: JSON.t, ~transfer: array<Dict.t<string>>) => unit =
   "postMessage"
 
 /**
@@ -15,7 +16,7 @@ external postMessage: (serviceWorker, ~message: JSON.t, ~transfer: array<Dict.t<
 */
 @send
 external postMessageWithOptions: (
-  serviceWorker,
+  t,
   ~message: JSON.t,
-  ~options: structuredSerializeOptions=?,
+  ~options: MessagePort.structuredSerializeOptions=?,
 ) => unit = "postMessage"

--- a/src/WebSocketsAPI/MessageEvent.res
+++ b/src/WebSocketsAPI/MessageEvent.res
@@ -9,13 +9,13 @@ type messageEventInit<'t> = Types.messageEventInit<'t> = {...Types.messageEventI
 @new
 external make: (~type_: string, ~eventInitDict: messageEventInit<'t>=?) => t<'t> = "MessageEvent"
 
-external asEvent: t<'t> => EventTypes.event = "%identity"
+external asEvent: t<'t> => Event.t = "%identity"
 /**
 Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Event/composedPath)
 */
 @send
-external composedPath: t<'t> => array<EventTypes.eventTarget> = "composedPath"
+external composedPath: t<'t> => array<EventTarget.t> = "composedPath"
 
 /**
 When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object.

--- a/src/WebSocketsAPI/WebSocket.res
+++ b/src/WebSocketsAPI/WebSocket.res
@@ -46,7 +46,7 @@ Transmits data using the WebSocket connection. data can be a string, a Blob, an 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external sendBlob: (t, FileTypes.blob) => unit = "send"
+external sendBlob: (t, Blob.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.

--- a/src/WebWorkersAPI/SharedWorker.res
+++ b/src/WebWorkersAPI/SharedWorker.res
@@ -1,7 +1,10 @@
-open ChannelMessagingTypes
 open WebWorkersTypes
 
-include EventTarget.Impl({type t = sharedWorker})
+type t = sharedWorker
+type workerType = WebWorkersTypes.workerType
+type workerOptions = WebWorkersTypes.workerOptions = {...WebWorkersTypes.workerOptions}
+
+include EventTarget.Impl({type t = t})
 
 /**
 `make(string)`
@@ -10,13 +13,13 @@ The SharedWorker() constructor creates a SharedWorker object that executes the
 script at the specified URL. This script must obey the same-origin policy.
 
 ```res
-let shared: sharedWorker = SharedWorker.make("sharedworker.js")
+let shared: SharedWorker.t = SharedWorker.make("sharedworker.js")
 ```
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
 @new
-external make: string => sharedWorker = "SharedWorker"
+external make: string => t = "SharedWorker"
 
 /**
 `makeWithName(string, string)`
@@ -25,13 +28,13 @@ The SharedWorker() constructor creates a SharedWorker object that executes the
 script at the specified URL. This script must obey the same-origin policy.
 
 ```res
-let shared: sharedWorker = SharedWorker.make("sharedworker.js", "name")
+let shared: SharedWorker.t = SharedWorker.makeWithName("sharedworker.js", "name")
 ```
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
 @new
-external makeWithName: (string, string) => sharedWorker = "SharedWorker"
+external makeWithName: (string, string) => t = "SharedWorker"
 
 /**
 `makeWithOptions(string, workerOptions)`
@@ -40,16 +43,15 @@ The SharedWorker() constructor creates a SharedWorker object that executes the
 script at the specified URL. This script must obey the same-origin policy.
 
 ```res
-let shared: sharedWorker = SharedWorker.makeWithOptions("sharedworker.js", {
+let shared: SharedWorker.t = SharedWorker.makeWithOptions("sharedworker.js", {
   name: "workerName",
-  type_: Module
 })
 ```
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
 @new
-external makeWithOptions: (string, workerOptions) => sharedWorker = "SharedWorker"
+external makeWithOptions: (string, workerOptions) => t = "SharedWorker"
 
 /**
 `port(sharedWorker)`
@@ -58,10 +60,10 @@ The port property of the SharedWorker interface returns a MessagePort object
 used to communicate and control the shared worker.
 
 ```res
-let port: WebAPI.ChannelMessagingTypes.messagePort = SharedWorker.port(myWorker)
+let port: MessagePort.t = SharedWorker.port(myWorker)
 ```
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/port)
 */
 @get
-external port: sharedWorker => messagePort = "port"
+external port: t => MessagePort.t = "port"

--- a/tests/FetchAPI/FormData__test.res
+++ b/tests/FetchAPI/FormData__test.res
@@ -1,6 +1,6 @@
 /* This works when your form has an id of "myForm" */
 @scope(("document", "forms"))
-external myForm: DOMTypes.htmlFormElement = "myForm"
+external myForm: HTMLFormElement.t = "myForm"
 
 let formData = FormData.make(~form=myForm)
 

--- a/tests/ServiceWorkerAPI/ServiceWorker__test.res
+++ b/tests/ServiceWorkerAPI/ServiceWorker__test.res
@@ -1,8 +1,8 @@
-open WebAPI.ServiceWorkerTypes
+open WebAPI
 
 let self = ServiceWorkerGlobalScope.current
 
-self->ServiceWorkerGlobalScope.addEventListener(EventTypes.Push, (event: PushTypes.pushEvent) => {
+self->ServiceWorkerGlobalScope.addEventListener(EventTypes.Push, (event: PushEvent.t) => {
   Console.log("received push event")
 
   // Extract data
@@ -35,7 +35,7 @@ self->ServiceWorkerGlobalScope.addEventListener(EventTypes.Push, (event: PushTyp
 })
 
 self->ServiceWorkerGlobalScope.addEventListener(EventTypes.NotificationClick, (
-  event: NotificationTypes.notificationEvent,
+  event: Notification.notificationEvent,
 ) => {
   Console.log(`notification clicked: ${event.action}`)
   // Close the notification

--- a/tests/WebWorkersAPI/SharedWorkerGlobalScope__test.res
+++ b/tests/WebWorkersAPI/SharedWorkerGlobalScope__test.res
@@ -1,4 +1,4 @@
-open WebAPI.WebWorkersTypes
+open WebAPI
 
 let self = SharedWorkerGlobalScope.current
 

--- a/tests/WebWorkersAPI/SharedWorker__test.res
+++ b/tests/WebWorkersAPI/SharedWorker__test.res
@@ -1,18 +1,17 @@
-open WebAPI.WebWorkersTypes
+open WebAPI
 
-let shared1: sharedWorker = SharedWorker.make("sharedworker.js")
+let shared1: SharedWorker.t = SharedWorker.make("sharedworker.js")
 
-let shared2: sharedWorker = SharedWorker.makeWithName("sharedworker.js", "name")
+let shared2: SharedWorker.t = SharedWorker.makeWithName("sharedworker.js", "name")
 
-let shared3: sharedWorker = SharedWorker.makeWithOptions(
+let shared3: SharedWorker.t = SharedWorker.makeWithOptions(
   "sharedworker.js",
   {
     name: "workerName",
-    type_: Module,
   },
 )
 
-let port: WebAPI.ChannelMessagingTypes.messagePort = SharedWorker.port(shared1)
+let port: MessagePort.t = SharedWorker.port(shared1)
 
 let self = SharedWorkerGlobalScope.current
 


### PR DESCRIPTION
## Summary
- complete the final integration pass after the parallel refactors
- remove the remaining raw type-holder leaks from
  concrete module surfaces and tests
- add the missing root aliases while keeping the final diff free of new include directives

##
  Validation
- `npm run build`
- `npm test`

## Related
- Completes #242
- Refs #237
- Refs #238
- Refs #240
- Refs #241
- Refs #243