### PR TITLE
refactor: carry over post-monorepo pre-alpha cleanup

### DIFF
--- a/packages/Canvas/src/CanvasPattern.res
+++ b/packages/Canvas/src/CanvasPattern.res
@@ -1,9 +1,11 @@
+type domMatrix2DInit = WebApiDOM.Types.domMatrix2DInit
+
 /**
 Sets the transformation matrix that will be used when rendering the pattern during a fill or stroke painting operation.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasPattern/setTransform)
 */
 @send
-external setTransform: (Types.canvasPattern, ~transform: WebApiDOM.Types.domMatrix2DInit=?) => unit =
+external setTransform: (Types.canvasPattern, ~transform: domMatrix2DInit=?) => unit =
   "setTransform"
 
 let isInstanceOf = (_: 't): bool => %raw(`param instanceof CanvasPattern`)

--- a/packages/Canvas/src/OffscreenCanvas.res
+++ b/packages/Canvas/src/OffscreenCanvas.res
@@ -83,4 +83,4 @@ The argument, if provided, is a dictionary that controls the encoding options of
 external convertToBlob: (
   Types.offscreenCanvas,
   ~options: Types.imageEncodeOptions=?,
-) => promise<WebApiFile.Types.blob> = "convertToBlob"
+) => promise<WebApiFile.Blob.t> = "convertToBlob"

--- a/packages/Canvas/src/Path2D.res
+++ b/packages/Canvas/src/Path2D.res
@@ -1,3 +1,5 @@
+type domMatrix2DInit = WebApiDOM.Types.domMatrix2DInit
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Path2D)
 */
@@ -145,5 +147,5 @@ Adds to the path the path given by the argument.
 external addPath: (
   Types.path2D,
   ~path: Types.path2D,
-  ~transform: WebApiDOM.Types.domMatrix2DInit=?,
+  ~transform: domMatrix2DInit=?,
 ) => unit = "addPath"

--- a/packages/ChannelMessaging/src/MessagePort.res
+++ b/packages/ChannelMessaging/src/MessagePort.res
@@ -1,4 +1,7 @@
-include WebApiEvent.EventTarget.Impl({type t = Types.messagePort})
+type t = Types.messagePort
+type structuredSerializeOptions = Types.structuredSerializeOptions
+
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 Posts a message through the channel. Objects listed in transfer are transferred, not just cloned, meaning that they are no longer usable on the sending side.
@@ -8,7 +11,7 @@ Throws a "DataCloneError" DOMException if transfer contains duplicate objects or
 */
 @send
 external postMessage: (
-  Types.messagePort,
+  t,
   ~message: JSON.t,
   ~transfer: array<Dict.t<string>>,
 ) => unit = "postMessage"
@@ -21,9 +24,9 @@ Throws a "DataCloneError" DOMException if transfer contains duplicate objects or
 */
 @send
 external postMessage2: (
-  Types.messagePort,
+  t,
   ~message: JSON.t,
-  ~options: Types.structuredSerializeOptions=?,
+  ~options: structuredSerializeOptions=?,
 ) => unit = "postMessage"
 
 /**
@@ -31,11 +34,11 @@ Begins dispatching messages received on the port.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessagePort/start)
 */
 @send
-external start: Types.messagePort => unit = "start"
+external start: t => unit = "start"
 
 /**
 Disconnects the port, so that it is no longer active.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessagePort/close)
 */
 @send
-external close: Types.messagePort => unit = "close"
+external close: t => unit = "close"

--- a/packages/DOM/src/HTMLElement.res
+++ b/packages/DOM/src/HTMLElement.res
@@ -1,3 +1,5 @@
+type t = Types.htmlElement
+
 module Impl = (
   T: {
     type t
@@ -5,7 +7,7 @@ module Impl = (
 ) => {
   include Element.Impl({type t = T.t})
 
-  external asHTMLElement: T.t => Types.htmlElement = "%identity"
+  external asHTMLElement: T.t => t = "%identity"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/attachInternals)
@@ -50,4 +52,4 @@ module Impl = (
   external togglePopover: (T.t, ~force: bool=?) => bool = "togglePopover"
 }
 
-include Impl({type t = Types.htmlElement})
+include Impl({type t = t})

--- a/packages/DOM/src/HTMLFormElement.res
+++ b/packages/DOM/src/HTMLFormElement.res
@@ -1,17 +1,19 @@
-include HTMLElement.Impl({type t = Types.htmlFormElement})
+type t = Types.htmlFormElement
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Fires when a FORM is about to be submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/submit)
 */
 @send
-external submit: Types.htmlFormElement => unit = "submit"
+external submit: t => unit = "submit"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/requestSubmit)
 */
 @send
-external requestSubmit: (Types.htmlFormElement, ~submitter: Types.htmlElement=?) => unit =
+external requestSubmit: (t, ~submitter: WebApiDOM.HTMLElement.t=?) => unit =
   "requestSubmit"
 
 /**
@@ -19,17 +21,17 @@ Fires when the user resets a form.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reset)
 */
 @send
-external reset: Types.htmlFormElement => unit = "reset"
+external reset: t => unit = "reset"
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/checkValidity)
 */
 @send
-external checkValidity: Types.htmlFormElement => bool = "checkValidity"
+external checkValidity: t => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reportValidity)
 */
 @send
-external reportValidity: Types.htmlFormElement => bool = "reportValidity"
+external reportValidity: t => bool = "reportValidity"

--- a/packages/DOM/src/Window.res
+++ b/packages/DOM/src/Window.res
@@ -1,5 +1,7 @@
 include WebApiEvent.EventTarget.Impl({type t = Types.window})
 
+external current: Types.window = "window"
+
 /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/window)
     */
@@ -325,6 +327,16 @@ external setInterval2: (Types.window, ~handler: unit => unit, ~timeout: int=?) =
   "setInterval"
 
 /**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setInterval)
+*/
+@send
+external setIntervalWithCallback: (
+  Types.window,
+  ~handler: unit => unit,
+  ~timeout: int=?,
+) => int = "setInterval"
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/clearInterval)
 */
 @send
@@ -403,6 +415,12 @@ external alert: Types.window => unit = "alert"
 external alert2: (Types.window, string) => unit = "alert"
 
 /**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/alert)
+*/
+@send
+external alertWithMessage: (Types.window, string) => unit = "alert"
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/confirm)
 */
 @send
@@ -460,6 +478,25 @@ external postMessage2: (
 ) => unit = "postMessage"
 
 /**
+Posts a message to the given window. Messages can be structured objects, e.g. nested objects and arrays, can contain JavaScript values (strings, numbers, Date objects, etc), and can contain certain data objects such as WebApiFile Blob, FileList, and ArrayBuffer objects.
+
+Objects listed in the transfer member of options are transferred, not just cloned, meaning that they are no longer usable on the sending side.
+
+A target origin can be specified using the targetOrigin member of options. If not provided, it defaults to "/". This default restricts the message to same-origin targets only.
+
+If the origin of the target window doesn't match the given target origin, the message is discarded, to avoid information leakage. To send the message to the target regardless of origin, set the target origin to "*".
+
+Throws a "DataCloneError" DOMException if transfer array contains duplicate objects or if message could not be cloned.
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
+*/
+@send
+external postMessageWithOptions: (
+  Types.window,
+  ~message: JSON.t,
+  ~options: Types.windowPostMessageOptions=?,
+) => unit = "postMessage"
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/matchMedia)
 */
 @send
@@ -502,6 +539,12 @@ external scroll: (Types.window, ~options: Types.scrollToOptions=?) => unit = "sc
 external scroll2: (Types.window, ~x: float, ~y: float) => unit = "scroll"
 
 /**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scroll)
+*/
+@send
+external scrollXY: (Types.window, ~x: float, ~y: float) => unit = "scroll"
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollTo)
 */
 @send
@@ -514,6 +557,12 @@ external scrollTo: (Types.window, ~options: Types.scrollToOptions=?) => unit = "
 external scrollTo2: (Types.window, ~x: float, ~y: float) => unit = "scrollTo"
 
 /**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollTo)
+*/
+@send
+external scrollToXY: (Types.window, ~x: float, ~y: float) => unit = "scrollTo"
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollBy)
 */
 @send
@@ -524,6 +573,12 @@ external scrollBy: (Types.window, ~options: Types.scrollToOptions=?) => unit = "
 */
 @send
 external scrollBy2: (Types.window, ~x: float, ~y: float) => unit = "scrollBy"
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollBy)
+*/
+@send
+external scrollByXY: (Types.window, ~x: float, ~y: float) => unit = "scrollBy"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)

--- a/packages/DOM/src/Window.res
+++ b/packages/DOM/src/Window.res
@@ -412,12 +412,6 @@ external alert: Types.window => unit = "alert"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/alert)
 */
 @send
-external alert2: (Types.window, string) => unit = "alert"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/alert)
-*/
-@send
 external alertWithMessage: (Types.window, string) => unit = "alert"
 
 /**
@@ -536,12 +530,6 @@ external scroll: (Types.window, ~options: Types.scrollToOptions=?) => unit = "sc
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scroll)
 */
 @send
-external scroll2: (Types.window, ~x: float, ~y: float) => unit = "scroll"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scroll)
-*/
-@send
 external scrollXY: (Types.window, ~x: float, ~y: float) => unit = "scroll"
 
 /**
@@ -554,12 +542,6 @@ external scrollTo: (Types.window, ~options: Types.scrollToOptions=?) => unit = "
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollTo)
 */
 @send
-external scrollTo2: (Types.window, ~x: float, ~y: float) => unit = "scrollTo"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollTo)
-*/
-@send
 external scrollToXY: (Types.window, ~x: float, ~y: float) => unit = "scrollTo"
 
 /**
@@ -567,12 +549,6 @@ external scrollToXY: (Types.window, ~x: float, ~y: float) => unit = "scrollTo"
 */
 @send
 external scrollBy: (Types.window, ~options: Types.scrollToOptions=?) => unit = "scrollBy"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollBy)
-*/
-@send
-external scrollBy2: (Types.window, ~x: float, ~y: float) => unit = "scrollBy"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/scrollBy)

--- a/packages/Fetch/src/BodyInit.res
+++ b/packages/Fetch/src/BodyInit.res
@@ -1,44 +1,46 @@
-/**
-[Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
- */
-external fromString: string => Types.bodyInit = "%identity"
+type t = Types.bodyInit
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromArrayBuffer: ArrayBuffer.t => Types.bodyInit = "%identity"
+external fromString: string => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromTypedArray: TypedArray.t<'t> => Types.bodyInit = "%identity"
+external fromArrayBuffer: ArrayBuffer.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromDataView: DataView.t => Types.bodyInit = "%identity"
+external fromTypedArray: TypedArray.t<'t> => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromBlob: WebApiFile.Types.blob => Types.bodyInit = "%identity"
+external fromDataView: DataView.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromFile: WebApiFile.Types.file => Types.bodyInit = "%identity"
+external fromBlob: WebApiFile.Blob.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromURLSearchParams: WebApiURL.Types.urlSearchParams => Types.bodyInit = "%identity"
+external fromFile: WebApiFile.File.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromFormData: Types.formData => Types.bodyInit = "%identity"
+external fromURLSearchParams: WebApiURL.URLSearchParams.t => t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
  */
-external fromReadableStream: WebApiFile.Types.readableStream<'t> => Types.bodyInit = "%identity"
+external fromFormData: FormData.t => t = "%identity"
+
+/**
+[Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
+ */
+external fromReadableStream: WebApiFile.ReadableStream.t<'t> => t = "%identity"

--- a/packages/Fetch/src/FormData.res
+++ b/packages/Fetch/src/FormData.res
@@ -1,23 +1,29 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData)
 */
+type t = Types.formData
+type formDataEntryValue = FormDataEntryValue.t
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData)
+*/
 @new
-external make: (~form: 'form=?, ~submitter: 'submitter=?) => Types.formData = "FormData"
+external make: (~form: 'form=?, ~submitter: 'submitter=?) => t = "FormData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/append)
 */
 @send
-external append: (Types.formData, ~name: string, ~value: string) => unit = "append"
+external append: (t, ~name: string, ~value: string) => unit = "append"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/append)
 */
 @send
 external appendBlob: (
-  Types.formData,
+  t,
   ~name: string,
-  ~blobValue: WebApiFile.Types.blob,
+  ~blobValue: WebApiFile.Blob.t,
   ~filename: string=?,
 ) => unit = "append"
 
@@ -25,51 +31,51 @@ external appendBlob: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/delete)
 */
 @send
-external delete: (Types.formData, string) => unit = "delete"
+external delete: (t, string) => unit = "delete"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/get)
 */
 @send
-external get: (Types.formData, string) => null<Types.formDataEntryValue> = "get"
+external get: (t, string) => null<formDataEntryValue> = "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/getAll)
 */
 @send
-external getAll: (Types.formData, string) => array<Types.formDataEntryValue> = "getAll"
+external getAll: (t, string) => array<formDataEntryValue> = "getAll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/has)
 */
 @send
-external has: (Types.formData, string) => bool = "has"
+external has: (t, string) => bool = "has"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/entries)
 */
 @send
-external entries: Types.formData => Iterator.t<(string, Types.formDataEntryValue)> = "entries"
+external entries: t => Iterator.t<(string, formDataEntryValue)> = "entries"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/keys)
 */
 @send
-external keys: Types.formData => Iterator.t<string> = "keys"
+external keys: t => Iterator.t<string> = "keys"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/set)
 */
 @send
-external set: (Types.formData, ~name: string, ~value: string) => unit = "set"
+external set: (t, ~name: string, ~value: string) => unit = "set"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/set)
 */
 @send
 external setBlob: (
-  Types.formData,
+  t,
   ~name: string,
-  ~blobValue: WebApiFile.Types.blob,
+  ~blobValue: WebApiFile.Blob.t,
   ~filename: string=?,
 ) => unit = "set"

--- a/packages/Fetch/src/FormDataEntryValue.res
+++ b/packages/Fetch/src/FormDataEntryValue.res
@@ -1,14 +1,9 @@
-type t = Types.formDataEntryValue
+@unboxed
+type t =
+  | String(string)
+  | File(WebApiFile.File.t)
 
 external fromString: string => t = "%identity"
 external fromFile: WebApiFile.File.t => t = "%identity"
 
-type decoded =
-  | String(string)
-  | File(WebApiFile.File.t)
-
-let decode = (t: t): decoded =>
-  switch t {
-  | Types.String(value) => String(value)
-  | Types.File(file) => File(file)
-  }
+let decode = (value: t): t => value

--- a/packages/Fetch/src/FormDataEntryValue.res
+++ b/packages/Fetch/src/FormDataEntryValue.res
@@ -1,0 +1,14 @@
+type t = Types.formDataEntryValue
+
+external fromString: string => t = "%identity"
+external fromFile: WebApiFile.File.t => t = "%identity"
+
+type decoded =
+  | String(string)
+  | File(WebApiFile.File.t)
+
+let decode = (t: t): decoded =>
+  switch t {
+  | Types.String(value) => String(value)
+  | Types.File(file) => File(file)
+  }

--- a/packages/Fetch/src/Global.res
+++ b/packages/Fetch/src/Global.res
@@ -2,11 +2,11 @@
 Starts the process of fetching a resource from the network, returning a promise that is fulfilled once the response is available.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
-external fetch: (string, ~init: Types.requestInit=?) => promise<Types.response> = "fetch"
+external fetch: (string, ~init: Request.requestInit=?) => promise<Response.t> = "fetch"
 
 /**
 Starts the process of fetching a resource from the network, returning a promise that is fulfilled once the response is available.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/fetch)
 */
-external fetchWithRequest: (Types.request, ~init: Types.requestInit=?) => promise<Types.response> =
+external fetchWithRequest: (Request.t, ~init: Request.requestInit=?) => promise<Response.t> =
   "fetch"

--- a/packages/Fetch/src/HeadersInit.res
+++ b/packages/Fetch/src/HeadersInit.res
@@ -1,14 +1,16 @@
-/**
- [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_headers)
- */
-external fromDict: dict<string> => Types.headersInit = "%identity"
+type t = Types.headersInit
 
 /**
  [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_headers)
  */
-external fromHeaders: Types.headers => Types.headersInit = "%identity"
+external fromDict: dict<string> => t = "%identity"
 
 /**
  [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_headers)
  */
-external fromKeyValueArray: array<(string, string)> => Types.headersInit = "%identity"
+external fromHeaders: Types.headers => t = "%identity"
+
+/**
+ [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_headers)
+ */
+external fromKeyValueArray: array<(string, string)> => t = "%identity"

--- a/packages/Fetch/src/Request.res
+++ b/packages/Fetch/src/Request.res
@@ -1,53 +1,61 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
 */
-@new
-external fromURL: (string, ~init: Types.requestInit=?) => Types.request = "Request"
+type t = Types.request
+type requestInit = Types.requestInit
+type bodyInit = BodyInit.t
+type headersInit = HeadersInit.t
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
 */
 @new
-external fromRequest: (Types.request, ~init: Types.requestInit=?) => Types.request = "Request"
+external fromURL: (string, ~init: requestInit=?) => t = "Request"
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
+*/
+@new
+external fromRequest: (t, ~init: requestInit=?) => t = "Request"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer)
 */
 @send
-external arrayBuffer: Types.request => promise<ArrayBuffer.t> = "arrayBuffer"
+external arrayBuffer: t => promise<ArrayBuffer.t> = "arrayBuffer"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/blob)
 */
 @send
-external blob: Types.request => promise<WebApiFile.Types.blob> = "blob"
+external blob: t => promise<WebApiFile.Blob.t> = "blob"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/bytes)
 */
 @send
-external bytes: Types.request => promise<array<int>> = "bytes"
+external bytes: t => promise<array<int>> = "bytes"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/formData)
 */
 @send
-external formData: Types.request => promise<Types.formData> = "formData"
+external formData: t => promise<FormData.t> = "formData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/json)
 */
 @send
-external json: Types.request => promise<JSON.t> = "json"
+external json: t => promise<JSON.t> = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/text)
 */
 @send
-external text: Types.request => promise<string> = "text"
+external text: t => promise<string> = "text"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/clone)
 */
 @send
-external clone: Types.request => Types.request = "clone"
+external clone: t => t = "clone"

--- a/packages/Fetch/src/Response.res
+++ b/packages/Fetch/src/Response.res
@@ -1,127 +1,135 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
-@new
-external fromNull: (@as(json`null`) _, ~init: Types.responseInit=?) => Types.response = "Response"
+type t = Types.response
+type responseInit = Types.responseInit
+type bodyInit = BodyInit.t
+type headersInit = HeadersInit.t
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromString: (string, ~init: Types.responseInit=?) => Types.response = "Response"
+external fromNull: (@as(json`null`) _, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromArrayBuffer: (ArrayBuffer.t, ~init: Types.responseInit=?) => Types.response =
+external fromString: (string, ~init: responseInit=?) => t = "Response"
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
+*/
+@new
+external fromArrayBuffer: (ArrayBuffer.t, ~init: responseInit=?) => t =
   "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromTypedArray: (TypedArray.t<'t>, ~init: Types.responseInit=?) => Types.response =
+external fromTypedArray: (TypedArray.t<'t>, ~init: responseInit=?) => t =
   "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromDataView: (DataView.t, ~init: Types.responseInit=?) => Types.response = "Response"
+external fromDataView: (DataView.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromBlob: (WebApiFile.Types.blob, ~init: Types.responseInit=?) => Types.response = "Response"
+external fromBlob: (WebApiFile.Blob.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromFile: (WebApiFile.Types.file, ~init: Types.responseInit=?) => Types.response = "Response"
+external fromFile: (WebApiFile.File.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
 external fromURLSearchParams: (
-  WebApiURL.Types.urlSearchParams,
-  ~init: Types.responseInit=?,
-) => Types.response = "Response"
+  WebApiURL.URLSearchParams.t,
+  ~init: responseInit=?,
+) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
-external fromFormData: (Types.formData, ~init: Types.responseInit=?) => Types.response = "Response"
+external fromFormData: (FormData.t, ~init: responseInit=?) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response)
 */
 @new
 external fromReadableStream: (
-  WebApiFile.Types.readableStream<'t>,
-  ~init: Types.responseInit=?,
-) => Types.response = "Response"
+  WebApiFile.ReadableStream.t<'t>,
+  ~init: responseInit=?,
+) => t = "Response"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer)
 */
 @send
-external arrayBuffer: Types.response => promise<ArrayBuffer.t> = "arrayBuffer"
+external arrayBuffer: t => promise<ArrayBuffer.t> = "arrayBuffer"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/blob)
 */
 @send
-external blob: Types.response => promise<WebApiFile.Types.blob> = "blob"
+external blob: t => promise<WebApiFile.Blob.t> = "blob"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/bytes)
 */
 @send
-external bytes: Types.response => promise<array<int>> = "bytes"
+external bytes: t => promise<array<int>> = "bytes"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/formData)
 */
 @send
-external formData: Types.response => promise<Types.formData> = "formData"
+external formData: t => promise<FormData.t> = "formData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/json)
 */
 @send
-external json: Types.response => promise<JSON.t> = "json"
+external json: t => promise<JSON.t> = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/text)
 */
 @send
-external text: Types.response => promise<string> = "text"
+external text: t => promise<string> = "text"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/error_static)
 */
 @scope("Response")
-external error: unit => Types.response = "error"
+external error: unit => t = "error"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/redirect_static)
 */
 @scope("Response")
-external redirect: (~url: string, ~status: int=?) => Types.response = "redirect"
+external redirect: (~url: string, ~status: int=?) => t = "redirect"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/json_static)
 */
 @scope("Response")
-external jsonR: (~data: JSON.t, ~init: Types.responseInit=?) => Types.response = "json"
+external jsonR: (~data: JSON.t, ~init: responseInit=?) => t = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/clone)
 */
 @send
-external clone: Types.response => Types.response = "clone"
+external clone: t => t = "clone"

--- a/packages/File/src/Blob.res
+++ b/packages/File/src/Blob.res
@@ -1,29 +1,33 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob)
 */
+type t = Types.blob
+type blobPart = Types.blobPart
+type blobPropertyBag = Types.blobPropertyBag
+
 @new
 external make: (
-  ~blobParts: array<Types.blobPart>=?,
-  ~options: Types.blobPropertyBag=?,
-) => Types.blob = "Blob"
+  ~blobParts: array<blobPart>=?,
+  ~options: blobPropertyBag=?,
+) => t = "Blob"
 
 module Impl = (
   T: {
     type t
   },
 ) => {
-  external asBlob: T.t => Types.blob = "%identity"
+  external asBlob: T.t => t = "%identity"
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob/slice)
 */
   @send
-  external slice: (T.t, ~start: int=?, ~end: int=?, ~contentType: string=?) => Types.blob = "slice"
+  external slice: (T.t, ~start: int=?, ~end: int=?, ~contentType: string=?) => t = "slice"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob/stream)
 */
   @send
-  external stream: T.t => Types.readableStream<array<int>> = "stream"
+  external stream: T.t => WebApiFile.ReadableStream.t<array<int>> = "stream"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Blob/text)
@@ -44,4 +48,4 @@ module Impl = (
   external bytes: T.t => promise<array<int>> = "bytes"
 }
 
-include Impl({type t = Types.blob})
+include Impl({type t = t})

--- a/packages/File/src/File.res
+++ b/packages/File/src/File.res
@@ -1,4 +1,6 @@
-include Blob.Impl({type t = Types.file})
+type t = Types.file
+
+include Blob.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiFile)
@@ -8,6 +10,6 @@ external make: (
   ~fileBits: array<Types.blobPart>,
   ~fileName: string,
   ~options: Types.filePropertyBag=?,
-) => Types.file = "WebApiFile"
+) => t = "WebApiFile"
 
 let isInstanceOf = (_: 't): bool => %raw(`param instanceof WebApiFile`)

--- a/packages/File/src/ReadableStream.res
+++ b/packages/File/src/ReadableStream.res
@@ -1,8 +1,13 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)
 */
+type t<'r> = Types.readableStream<'r>
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)
+*/
 @new
-external make: unit => Types.readableStream<array<int>> = "ReadableStream"
+external make: unit => t<array<int>> = "ReadableStream"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)
@@ -20,14 +25,14 @@ external make3: unit => unknown = "ReadableStream"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/cancel)
 */
 @send
-external cancel: (Types.readableStream<'r>, ~reason: JSON.t=?) => promise<unit> = "cancel"
+external cancel: (t<'r>, ~reason: JSON.t=?) => promise<unit> = "cancel"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader)
 */
 @send
 external getReader: (
-  Types.readableStream<'r>,
+  t<'r>,
   ~options: Types.readableStreamGetReaderOptions=?,
 ) => Types.readableStreamReader<'r> = "getReader"
 
@@ -36,17 +41,17 @@ external getReader: (
 */
 @send
 external pipeThrough: (
-  Types.readableStream<'r>,
+  t<'r>,
   ~transform: Types.readableWritablePair<'t, 'r>,
   ~options: Types.streamPipeOptions=?,
-) => Types.readableStream<'t> = "pipeThrough"
+) => t<'t> = "pipeThrough"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeTo)
 */
 @send
 external pipeTo: (
-  Types.readableStream<'r>,
+  t<'r>,
   ~destination: Types.writableStream<'r>,
   ~options: Types.streamPipeOptions=?,
 ) => promise<unit> = "pipeTo"
@@ -55,4 +60,4 @@ external pipeTo: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee)
 */
 @send
-external tee: Types.readableStream<'r> => array<Types.readableStream<unit>> = "tee"
+external tee: t<'r> => array<t<unit>> = "tee"

--- a/packages/MediaCaptureAndStreams/src/MediaDeviceInfo.res
+++ b/packages/MediaCaptureAndStreams/src/MediaDeviceInfo.res
@@ -1,5 +1,7 @@
+type t = Types.mediaDeviceInfo = {...Types.mediaDeviceInfo}
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/toJSON)
 */
 @send
-external toJSON: Types.mediaDeviceInfo => Dict.t<string> = "toJSON"
+external toJSON: t => Dict.t<string> = "toJSON"

--- a/packages/MediaCaptureAndStreams/src/MediaDevices.res
+++ b/packages/MediaCaptureAndStreams/src/MediaDevices.res
@@ -1,17 +1,23 @@
-include WebApiEvent.EventTarget.Impl({type t = Types.mediaDevices})
+type t = Types.mediaDevices = {...Types.mediaDevices}
+type mediaTrackSupportedConstraints =
+  Types.mediaTrackSupportedConstraints = {...Types.mediaTrackSupportedConstraints}
+type mediaStreamConstraints = Types.mediaStreamConstraints = {...Types.mediaStreamConstraints}
+type displayMediaStreamOptions =
+  Types.displayMediaStreamOptions = {...Types.displayMediaStreamOptions}
+
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaDevices/enumerateDevices)
 */
 @send
-external enumerateDevices: Types.mediaDevices => promise<array<Types.mediaDeviceInfo>> =
-  "enumerateDevices"
+external enumerateDevices: t => promise<array<MediaDeviceInfo.t>> = "enumerateDevices"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaDevices/getSupportedConstraints)
 */
 @send
-external getSupportedConstraints: Types.mediaDevices => Types.mediaTrackSupportedConstraints =
+external getSupportedConstraints: t => mediaTrackSupportedConstraints =
   "getSupportedConstraints"
 
 /**
@@ -19,15 +25,15 @@ external getSupportedConstraints: Types.mediaDevices => Types.mediaTrackSupporte
 */
 @send
 external getUserMedia: (
-  Types.mediaDevices,
-  ~constraints: Types.mediaStreamConstraints=?,
-) => promise<Types.mediaStream> = "getUserMedia"
+  t,
+  ~constraints: mediaStreamConstraints=?,
+) => promise<MediaStream.t> = "getUserMedia"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaDevices/getDisplayMedia)
 */
 @send
 external getDisplayMedia: (
-  Types.mediaDevices,
-  ~options: Types.displayMediaStreamOptions=?,
-) => promise<Types.mediaStream> = "getDisplayMedia"
+  t,
+  ~options: displayMediaStreamOptions=?,
+) => promise<MediaStream.t> = "getDisplayMedia"

--- a/packages/MediaCaptureAndStreams/src/MediaStream.res
+++ b/packages/MediaCaptureAndStreams/src/MediaStream.res
@@ -10,13 +10,13 @@ external make: unit => t = "MediaStream"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream)
 */
 @new
-external make2: t => t = "MediaStream"
+external makeFromMediaStream: t => t = "MediaStream"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream)
 */
 @new
-external make3: array<MediaStreamTrack.t> => t = "MediaStream"
+external makeFromMediaStreams: array<MediaStreamTrack.t> => t = "MediaStream"
 
 include WebApiEvent.EventTarget.Impl({type t = t})
 

--- a/packages/MediaCaptureAndStreams/src/MediaStream.res
+++ b/packages/MediaCaptureAndStreams/src/MediaStream.res
@@ -1,61 +1,63 @@
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream)
-*/
-@new
-external make: unit => Types.mediaStream = "MediaStream"
+type t = Types.mediaStream = {...Types.mediaStream}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream)
 */
 @new
-external make2: Types.mediaStream => Types.mediaStream = "MediaStream"
+external make: unit => t = "MediaStream"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream)
 */
 @new
-external make3: array<Types.mediaStreamTrack> => Types.mediaStream = "MediaStream"
+external make2: t => t = "MediaStream"
 
-include WebApiEvent.EventTarget.Impl({type t = Types.mediaStream})
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream)
+*/
+@new
+external make3: array<MediaStreamTrack.t> => t = "MediaStream"
+
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/getAudioTracks)
 */
 @send
-external getAudioTracks: Types.mediaStream => array<Types.mediaStreamTrack> = "getAudioTracks"
+external getAudioTracks: t => array<MediaStreamTrack.t> = "getAudioTracks"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/getVideoTracks)
 */
 @send
-external getVideoTracks: Types.mediaStream => array<Types.mediaStreamTrack> = "getVideoTracks"
+external getVideoTracks: t => array<MediaStreamTrack.t> = "getVideoTracks"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/getTracks)
 */
 @send
-external getTracks: Types.mediaStream => array<Types.mediaStreamTrack> = "getTracks"
+external getTracks: t => array<MediaStreamTrack.t> = "getTracks"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/getTrackById)
 */
 @send
-external getTrackById: (Types.mediaStream, string) => Types.mediaStreamTrack = "getTrackById"
+external getTrackById: (t, string) => MediaStreamTrack.t = "getTrackById"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/addTrack)
 */
 @send
-external addTrack: (Types.mediaStream, Types.mediaStreamTrack) => unit = "addTrack"
+external addTrack: (t, MediaStreamTrack.t) => unit = "addTrack"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/removeTrack)
 */
 @send
-external removeTrack: (Types.mediaStream, Types.mediaStreamTrack) => unit = "removeTrack"
+external removeTrack: (t, MediaStreamTrack.t) => unit = "removeTrack"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/clone)
 */
 @send
-external clone: Types.mediaStream => Types.mediaStream = "clone"
+external clone: t => t = "clone"

--- a/packages/MediaCaptureAndStreams/src/MediaStreamTrack.res
+++ b/packages/MediaCaptureAndStreams/src/MediaStreamTrack.res
@@ -1,40 +1,45 @@
-include WebApiEvent.EventTarget.Impl({type t = Types.mediaStreamTrack})
+type t = Types.mediaStreamTrack = {...Types.mediaStreamTrack}
+type mediaTrackCapabilities = Types.mediaTrackCapabilities = {...Types.mediaTrackCapabilities}
+type mediaTrackConstraints = Types.mediaTrackConstraints = {...Types.mediaTrackConstraints}
+type mediaTrackSettings = Types.mediaTrackSettings = {...Types.mediaTrackSettings}
+
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/clone)
 */
 @send
-external clone: Types.mediaStreamTrack => Types.mediaStreamTrack = "clone"
+external clone: t => t = "clone"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/stop)
 */
 @send
-external stop: Types.mediaStreamTrack => unit = "stop"
+external stop: t => unit = "stop"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/getCapabilities)
 */
 @send
-external getCapabilities: Types.mediaStreamTrack => Types.mediaTrackCapabilities = "getCapabilities"
+external getCapabilities: t => mediaTrackCapabilities = "getCapabilities"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/getConstraints)
 */
 @send
-external getConstraints: Types.mediaStreamTrack => Types.mediaTrackConstraints = "getConstraints"
+external getConstraints: t => mediaTrackConstraints = "getConstraints"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/getSettings)
 */
 @send
-external getSettings: Types.mediaStreamTrack => Types.mediaTrackSettings = "getSettings"
+external getSettings: t => mediaTrackSettings = "getSettings"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/applyConstraints)
 */
 @send
 external applyConstraints: (
-  Types.mediaStreamTrack,
-  ~constraints: Types.mediaTrackConstraints=?,
+  t,
+  ~constraints: mediaTrackConstraints=?,
 ) => promise<unit> = "applyConstraints"

--- a/packages/MediaSession/src/MediaMetadata.res
+++ b/packages/MediaSession/src/MediaMetadata.res
@@ -1,5 +1,8 @@
+type t = Types.mediaMetadata = {...Types.mediaMetadata}
+type mediaMetadataInit = Types.mediaMetadataInit = {...Types.mediaMetadataInit}
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaMetadata)
 */
 @new
-external make: (~init: Types.mediaMetadataInit=?) => Types.mediaMetadata = "MediaMetadata"
+external make: (~init: mediaMetadataInit=?) => t = "MediaMetadata"

--- a/packages/MediaSession/src/MediaSession.res
+++ b/packages/MediaSession/src/MediaSession.res
@@ -1,16 +1,20 @@
+type t = Types.mediaSession = {...Types.mediaSession}
+type mediaSessionAction = Types.mediaSessionAction
+type mediaPositionState = Types.mediaPositionState = {...Types.mediaPositionState}
+type mediaSessionActionHandler = Types.mediaSessionActionHandler
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiMediaSession/setActionHandler)
 */
 @send
 external setActionHandler: (
-  Types.mediaSession,
-  ~action: Types.mediaSessionAction,
-  ~handler: Types.mediaSessionActionHandler,
+  t,
+  ~action: mediaSessionAction,
+  ~handler: mediaSessionActionHandler,
 ) => unit = "setActionHandler"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiMediaSession/setPositionState)
 */
 @send
-external setPositionState: (Types.mediaSession, ~state: Types.mediaPositionState=?) => unit =
-  "setPositionState"
+external setPositionState: (t, ~state: mediaPositionState=?) => unit = "setPositionState"

--- a/packages/Notification/src/Notification.res
+++ b/packages/Notification/src/Notification.res
@@ -1,28 +1,37 @@
+type t = Types.notification
+type notificationDirection = Types.notificationDirection
+type notificationPermission = Types.notificationPermission
+type notificationAction = Types.notificationAction = {...Types.notificationAction}
+type notificationOptions = Types.notificationOptions = {...Types.notificationOptions}
+type getNotificationOptions = Types.getNotificationOptions = {...Types.getNotificationOptions}
+type notificationPermissionCallback = Types.notificationPermissionCallback
+type notificationEvent = Types.notificationEvent = {...Types.notificationEvent}
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiNotification)
 */
 @new
-external make: (~title: string, ~options: Types.notificationOptions=?) => Types.notification =
+external make: (~title: string, ~options: notificationOptions=?) => t =
   "WebApiNotification"
 
-include WebApiEvent.EventTarget.Impl({type t = Types.notification})
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiNotification/requestPermission_static)
 */
 @scope("WebApiNotification")
 external requestPermission: (
-  ~deprecatedCallback: Types.notificationPermissionCallback=?,
-) => promise<Types.notificationPermission> = "requestPermission"
+  ~deprecatedCallback: notificationPermissionCallback=?,
+) => promise<notificationPermission> = "requestPermission"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiNotification/close)
 */
 @send
-external close: Types.notification => unit = "close"
+external close: t => unit = "close"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/WebApiNotification/permission_static)
 */
 @scope("WebApiNotification") @val
-external permission: Types.notificationPermission = "permission"
+external permission: notificationPermission = "permission"

--- a/packages/PictureInPicture/src/PictureInPicture.res
+++ b/packages/PictureInPicture/src/PictureInPicture.res
@@ -1,0 +1,3 @@
+type t = Types.pictureInPictureWindow = {...Types.pictureInPictureWindow}
+
+include WebApiEvent.EventTarget.Impl({type t = t})

--- a/packages/Push/src/PushEvent.res
+++ b/packages/Push/src/PushEvent.res
@@ -1,1 +1,3 @@
-include WebApiEvent.ExtendableEvent.Impl({type t = Types.pushEvent})
+type t = Types.pushEvent
+
+include WebApiEvent.ExtendableEvent.Impl({type t = t})

--- a/packages/Push/src/PushMessageData.res
+++ b/packages/Push/src/PushMessageData.res
@@ -1,13 +1,15 @@
+type t = Types.pushMessageData
+
 /**
 The json() method of the PushMessageData interface extracts push message data by parsing it as a JSON string and returning the result.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushMessageData/json)
 */
 @send
-external json: Types.pushMessageData => JSON.t = "json"
+external json: t => JSON.t = "json"
 
 /**
 The text() method of the PushMessageData interface extracts push message data as a plain text string.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushMessageData/text)
 */
 @send
-external text: Types.pushMessageData => string = "text"
+external text: t => string = "text"

--- a/packages/RemotePlayback/src/RemotePlayback.res
+++ b/packages/RemotePlayback/src/RemotePlayback.res
@@ -1,23 +1,25 @@
-include WebApiEvent.EventTarget.Impl({type t = Types.remotePlayback})
+type t = Types.remotePlayback = {...Types.remotePlayback}
+type remotePlaybackAvailabilityCallback = Types.remotePlaybackAvailabilityCallback
+
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiRemotePlayback/watchAvailability)
 */
 @send
 external watchAvailability: (
-  Types.remotePlayback,
-  Types.remotePlaybackAvailabilityCallback,
+  t,
+  remotePlaybackAvailabilityCallback,
 ) => promise<int> = "watchAvailability"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiRemotePlayback/cancelWatchAvailability)
 */
 @send
-external cancelWatchAvailability: (Types.remotePlayback, ~id: int=?) => promise<unit> =
-  "cancelWatchAvailability"
+external cancelWatchAvailability: (t, ~id: int=?) => promise<unit> = "cancelWatchAvailability"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiRemotePlayback/prompt)
 */
 @send
-external prompt: Types.remotePlayback => promise<unit> = "prompt"
+external prompt: t => promise<unit> = "prompt"

--- a/packages/ServiceWorker/src/ServiceWorker.res
+++ b/packages/ServiceWorker/src/ServiceWorker.res
@@ -1,11 +1,13 @@
-include WebApiEvent.EventTarget.Impl({type t = Types.serviceWorker})
+type t = Types.serviceWorker
+
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiServiceWorker/postMessage)
 */
 @send
 external postMessage: (
-  Types.serviceWorker,
+  t,
   ~message: JSON.t,
   ~transfer: array<Dict.t<string>>,
 ) => unit = "postMessage"
@@ -15,7 +17,17 @@ external postMessage: (
 */
 @send
 external postMessage2: (
-  Types.serviceWorker,
+  t,
   ~message: JSON.t,
-  ~options: WebApiChannelMessaging.Types.structuredSerializeOptions=?,
+  ~options: WebApiChannelMessaging.MessagePort.structuredSerializeOptions=?,
+) => unit = "postMessage"
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiServiceWorker/postMessage)
+*/
+@send
+external postMessageWithOptions: (
+  t,
+  ~message: JSON.t,
+  ~options: WebApiChannelMessaging.MessagePort.structuredSerializeOptions=?,
 ) => unit = "postMessage"

--- a/packages/ServiceWorker/src/ServiceWorkerGlobalScope.res
+++ b/packages/ServiceWorker/src/ServiceWorkerGlobalScope.res
@@ -1,8 +1,10 @@
-include WebApiWebWorkers.WorkerGlobalScope.Impl({type t = Types.serviceWorkerGlobalScope})
+type t = Types.serviceWorkerGlobalScope
+
+include WebApiWebWorkers.WorkerGlobalScope.Impl({type t = t})
 
 /**
 Forces the waiting service worker to become the active service worker.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/skipWaiting)
 */
 @send
-external skipWaiting: Types.serviceWorkerGlobalScope => promise<unit> = "skipWaiting"
+external skipWaiting: t => promise<unit> = "skipWaiting"

--- a/packages/URL/src/URLSearchParams.res
+++ b/packages/URL/src/URLSearchParams.res
@@ -1,99 +1,104 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
 */
-@new
-external make: unit => Types.urlSearchParams = "URLSearchParams"
+type t = Types.urlSearchParams
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
 */
 @new
-external fromKeyValueArray: array<(string, string)> => Types.urlSearchParams = "URLSearchParams"
+external make: unit => t = "URLSearchParams"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
 */
 @new
-external fromDict: dict<string> => Types.urlSearchParams = "URLSearchParams"
+external fromKeyValueArray: array<(string, string)> => t = "URLSearchParams"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
 */
 @new
-external fromString: string => Types.urlSearchParams = "URLSearchParams"
+external fromDict: dict<string> => t = "URLSearchParams"
+
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
+*/
+@new
+external fromString: string => t = "URLSearchParams"
 
 /**
 Appends a specified key/value pair as a new search parameter.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/append)
 */
 @send
-external append: (Types.urlSearchParams, ~name: string, ~value: string) => unit = "append"
+external append: (t, ~name: string, ~value: string) => unit = "append"
 
 /**
 Deletes the given search parameter, and its associated value, from the list of all search parameters.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/delete)
 */
 @send
-external delete: (Types.urlSearchParams, ~name: string, ~value: string=?) => unit = "delete"
+external delete: (t, ~name: string, ~value: string=?) => unit = "delete"
 
 /**
 Returns key/value pairs in the same order as they appear in the query string.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/entries)
 */
 @send
-external entries: Types.urlSearchParams => Iterator.t<(string, string)> = "entries"
+external entries: t => Iterator.t<(string, string)> = "entries"
 
 /**
 Returns the first value associated to the given search parameter.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/get)
 */
 @send
-external get: (Types.urlSearchParams, string) => null<string> = "get"
+external get: (t, string) => null<string> = "get"
 
 /**
 Returns all the values association with a given search parameter.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll)
 */
 @send
-external getAll: (Types.urlSearchParams, string) => array<string> = "getAll"
+external getAll: (t, string) => array<string> = "getAll"
 
 /**
 Returns a Boolean indicating if such a search parameter exists.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/has)
 */
 @send
-external has: (Types.urlSearchParams, ~name: string, ~value: string=?) => bool = "has"
+external has: (t, ~name: string, ~value: string=?) => bool = "has"
 
 /**
 Returns an iterator allowing iteration through all keys contained in this object.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/keys)
 */
 @send
-external keys: Types.urlSearchParams => Iterator.t<string> = "keys"
+external keys: t => Iterator.t<string> = "keys"
 
 /**
 Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/set)
 */
 @send
-external set: (Types.urlSearchParams, ~name: string, ~value: string) => unit = "set"
+external set: (t, ~name: string, ~value: string) => unit = "set"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/sort)
 */
 @send
-external sort: Types.urlSearchParams => unit = "sort"
+external sort: t => unit = "sort"
 
 /**
 Returns the query string suitable for use in a WebApiURL, without the question mark.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/toString)
 */
 @send
-external toString: Types.urlSearchParams => string = "toString"
+external toString: t => string = "toString"
 
 /**
 Returns an iterator allowing iteration through all values contained in this object.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/values)
 */
 @send
-external values: Types.urlSearchParams => Iterator.t<string> = "values"
+external values: t => Iterator.t<string> = "values"

--- a/packages/WebMIDI/src/WebMIDI.res
+++ b/packages/WebMIDI/src/WebMIDI.res
@@ -1,0 +1,5 @@
+type t = Types.midiAccess = {...Types.midiAccess}
+
+include WebApiEvent.EventTarget.Impl({type t = t})
+
+type midiOptions = Types.midiOptions = {...Types.midiOptions}

--- a/packages/WebSockets/src/MessageEvent.res
+++ b/packages/WebSockets/src/MessageEvent.res
@@ -1,37 +1,61 @@
+type event = WebApiEvent.Types.event
+type eventTarget = WebApiEvent.Types.eventTarget
+type messageEventSource = Types.messageEventSource
+
+type messageEvent<'t> = {
+  ...event,
+  data: 't,
+  origin: string,
+  lastEventId: string,
+  source: Null.t<messageEventSource>,
+  ports: array<WebApiChannelMessaging.Types.messagePort>,
+}
+
+type messageEventInit<'t> = {
+  ...WebApiEvent.Types.eventInit,
+  mutable data?: 't,
+  mutable origin?: string,
+  mutable lastEventId?: string,
+  mutable source?: Null.t<messageEventSource>,
+  mutable ports?: array<WebApiChannelMessaging.Types.messagePort>,
+}
+
+type t<'t> = messageEvent<'t>
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessageEvent)
 */
 @new
 external make: (
   ~type_: string,
-  ~eventInitDict: Types.messageEventInit<'t>=?,
-) => Types.messageEvent<'t> = "MessageEvent"
+  ~eventInitDict: messageEventInit<'t>=?,
+) => t<'t> = "MessageEvent"
 
-external asEvent: Types.messageEvent<'t> => WebApiEvent.Types.event = "%identity"
+external asEvent: t<'t> => event = "%identity"
 /**
 Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiEvent/composedPath)
 */
 @send
-external composedPath: Types.messageEvent<'t> => array<WebApiEvent.Types.eventTarget> = "composedPath"
+external composedPath: t<'t> => array<eventTarget> = "composedPath"
 
 /**
 When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiEvent/stopPropagation)
 */
 @send
-external stopPropagation: Types.messageEvent<'t> => unit = "stopPropagation"
+external stopPropagation: t<'t> => unit = "stopPropagation"
 
 /**
 Invoking this method prevents event from reaching any registered event listeners after the current one finishes running and, when dispatched in a tree, also prevents event from reaching any other objects.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiEvent/stopImmediatePropagation)
 */
 @send
-external stopImmediatePropagation: Types.messageEvent<'t> => unit = "stopImmediatePropagation"
+external stopImmediatePropagation: t<'t> => unit = "stopImmediatePropagation"
 
 /**
 If invoked when the cancelable attribute value is true, and while executing a listener for the event with passive set to false, signals to the operation that caused event to be dispatched that it needs to be canceled.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebApiEvent/preventDefault)
 */
 @send
-external preventDefault: Types.messageEvent<'t> => unit = "preventDefault"
+external preventDefault: t<'t> => unit = "preventDefault"

--- a/packages/WebSockets/src/MessageEvent.res
+++ b/packages/WebSockets/src/MessageEvent.res
@@ -2,23 +2,8 @@ type event = WebApiEvent.Types.event
 type eventTarget = WebApiEvent.Types.eventTarget
 type messageEventSource = Types.messageEventSource
 
-type messageEvent<'t> = {
-  ...event,
-  data: 't,
-  origin: string,
-  lastEventId: string,
-  source: Null.t<messageEventSource>,
-  ports: array<WebApiChannelMessaging.Types.messagePort>,
-}
-
-type messageEventInit<'t> = {
-  ...WebApiEvent.Types.eventInit,
-  mutable data?: 't,
-  mutable origin?: string,
-  mutable lastEventId?: string,
-  mutable source?: Null.t<messageEventSource>,
-  mutable ports?: array<WebApiChannelMessaging.Types.messagePort>,
-}
+type messageEvent<'t> = Types.messageEvent<'t>
+type messageEventInit<'t> = Types.messageEventInit<'t>
 
 type t<'t> = messageEvent<'t>
 

--- a/packages/WebSockets/src/WebSocket.res
+++ b/packages/WebSockets/src/WebSocket.res
@@ -1,48 +1,53 @@
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket)
-*/
-@new
-external make: (~url: string, ~protocols: string=?) => Types.webSocket = "WebSocket"
+module Blob = WebApiFile.Blob
+
+type t = Types.webSocket
+type binaryType = Types.binaryType
+type messageEvent<'t> = Types.messageEvent<'t> = {...Types.messageEvent<'t>}
+type closeEvent = Types.closeEvent = {...Types.closeEvent}
+type messageEventSource = Types.messageEventSource
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket)
 */
 @new
-external make2: (~url: string, ~protocols: array<string>=?) => Types.webSocket = "WebSocket"
+external make: (~url: string, ~protocols: string=?) => t = "WebSocket"
 
-include WebApiEvent.EventTarget.Impl({type t = Types.webSocket})
+/**
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket)
+*/
+@new
+external makeWithProtocols: (~url: string, ~protocols: array<string>=?) => t = "WebSocket"
+
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 Closes the WebSocket connection, optionally using code as the the WebSocket connection close code and reason as the the WebSocket connection close reason.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/close)
 */
 @send
-external close: (Types.webSocket, ~code: int=?, ~reason: string=?) => unit = "close"
+external close: (t, ~code: int=?, ~reason: string=?) => unit = "close"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
 @send
-external send: (Types.webSocket, DataView.t) => unit = "send"
+external send: (t, DataView.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
-@send
-external send2: (Types.webSocket, ArrayBuffer.t) => unit = "send"
+external sendArrayBuffer: (t, ArrayBuffer.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
-@send
-external send3: (Types.webSocket, WebApiFile.Types.blob) => unit = "send"
+external sendBlob: (t, Blob.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
-@send
-external send4: (Types.webSocket, string) => unit = "send"
+external sendString: (t, string) => unit = "send"

--- a/packages/WebWorkers/src/SharedWorker.res
+++ b/packages/WebWorkers/src/SharedWorker.res
@@ -1,4 +1,8 @@
-include WebApiEvent.EventTarget.Impl({type t = Types.sharedWorker})
+type t = Types.sharedWorker
+type workerType = Types.workerType
+type workerOptions = Types.workerOptions = {...Types.workerOptions}
+
+include WebApiEvent.EventTarget.Impl({type t = t})
 
 /**
 `make(string)`
@@ -7,13 +11,13 @@ The SharedWorker() constructor creates a SharedWorker object that executes the
 script at the specified WebApiURL. This script must obey the same-origin policy.
 
 ```res
-let shared: sharedWorker = SharedWorker.make("sharedworker.js")
+let shared: SharedWorker.t = SharedWorker.make("sharedworker.js")
 ```
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
 @new
-external make: string => Types.sharedWorker = "SharedWorker"
+external make: string => t = "SharedWorker"
 
 /**
 `makeWithName(string, string)`
@@ -22,13 +26,13 @@ The SharedWorker() constructor creates a SharedWorker object that executes the
 script at the specified WebApiURL. This script must obey the same-origin policy.
 
 ```res
-let shared: sharedWorker = SharedWorker.make("sharedworker.js", "name")
+let shared: SharedWorker.t = SharedWorker.makeWithName("sharedworker.js", "name")
 ```
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
 @new
-external makeWithName: (string, string) => Types.sharedWorker = "SharedWorker"
+external makeWithName: (string, string) => t = "SharedWorker"
 
 /**
 `makeWithOptions(string, workerOptions)`
@@ -37,16 +41,16 @@ The SharedWorker() constructor creates a SharedWorker object that executes the
 script at the specified WebApiURL. This script must obey the same-origin policy.
 
 ```res
-let shared: sharedWorker = SharedWorker.makeWithOptions("sharedworker.js", {
+let shared: SharedWorker.t = SharedWorker.makeWithOptions("sharedworker.js", {
   name: "workerName",
-  type_: Module
+  type_: Module,
 })
 ```
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
 @new
-external makeWithOptions: (string, Types.workerOptions) => Types.sharedWorker = "SharedWorker"
+external makeWithOptions: (string, workerOptions) => t = "SharedWorker"
 
 /**
 `port(sharedWorker)`
@@ -55,10 +59,10 @@ The port property of the SharedWorker interface returns a MessagePort object
 used to communicate and control the shared worker.
 
 ```res
-let port: WebAPI.ChannelMessagingAPI.messagePort = SharedWorker.port(myWorker)
+let port: MessagePort.t = SharedWorker.port(myWorker)
 ```
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/port)
 */
 @get
-external port: Types.sharedWorker => WebApiChannelMessaging.Types.messagePort = "port"
+external port: t => WebApiChannelMessaging.MessagePort.t = "port"

--- a/packages/WebWorkers/src/SharedWorkerGlobalScope.res
+++ b/packages/WebWorkers/src/SharedWorkerGlobalScope.res
@@ -1,3 +1,5 @@
+type t = Types.sharedWorkerGlobalScope
+
 module Impl = (
   T: {
     type t
@@ -22,4 +24,4 @@ self -> SharedWorkerGlobalScope.close
   external close: T.t => unit = "close"
 }
 
-include Impl({type t = Types.sharedWorkerGlobalScope})
+include Impl({type t = t})

--- a/packages/WebWorkers/src/WorkerGlobalScope.res
+++ b/packages/WebWorkers/src/WorkerGlobalScope.res
@@ -5,6 +5,8 @@ module Impl = (
 ) => {
   include WebApiEvent.EventTarget.Impl({type t = T.t})
 
+  external current: T.t = "self"
+
   /**
 `fetch(workerGlobalScope, string, init)`
 
@@ -18,7 +20,11 @@ let response = await self->WorkerGlobalScope.fetch("https://rescript-lang.org")
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/fetch)
 */
   @send
-  external fetch: (T.t, string, ~init: WebApiFetch.Types.requestInit=?) => promise<WebApiFetch.Types.response> =
+  external fetch: (
+    T.t,
+    string,
+    ~init: WebApiFetch.Request.requestInit=?,
+  ) => promise<WebApiFetch.Response.t> =
     "fetch"
 
   /**
@@ -35,9 +41,9 @@ let response = await self->WorkerGlobalScope.fetch(myRequest)
 */
   external fetchWithRequest: (
     T.t,
-    WebApiFetch.Types.request,
-    ~init: WebApiFetch.Types.requestInit=?,
-  ) => promise<WebApiFetch.Types.response> = "fetch"
+    WebApiFetch.Request.t,
+    ~init: WebApiFetch.Request.requestInit=?,
+  ) => promise<WebApiFetch.Response.t> = "fetch"
 }
 
 include Impl({type t = Types.workerGlobalScope})

--- a/tests/FetchAPI/FormData__test.res
+++ b/tests/FetchAPI/FormData__test.res
@@ -1,39 +1,52 @@
 /* This works when your form has an id of "myForm" */
 @scope(("document", "forms"))
-external myForm: WebApiDOM.Types.htmlFormElement = "myForm"
+external myForm: WebApiDOM.HTMLFormElement.t = "myForm"
 
-let formData = WebApiFetch.FormData.make(~form=myForm)
+module FormData = WebApiFetch.FormData
+module EntryValue = WebApiFetch.FormDataEntryValue
+
+open EntryValue
+
+let logEntry = (~stringPrefix: string, ~filePrefix: string, entry: EntryValue.t) =>
+  switch EntryValue.decode(entry) {
+  | String(value) => Console.log(`${stringPrefix}${value}`)
+  | File(file) => Console.log(`${filePrefix}${file.name}`)
+  }
+
+let formData: FormData.t = FormData.make(~form=myForm)
 
 // Get a form field - returns formDataEntryValue which could be string or WebApiFile
-let phoneEntry: null<WebApiFetch.Types.formDataEntryValue> = formData->WebApiFetch.FormData.get("phone")
+let phoneEntry: null<EntryValue.t> = formData->FormData.get("phone")
 
 // Decode the entry to handle both string and WebApiFile cases
 let _ = switch phoneEntry->Null.toOption {
 | None => Console.log("No phone field")
-| Some(WebApiFetch.Types.String(value)) => Console.log(`Phone: ${value}`)
-| Some(WebApiFetch.Types.File(file)) => Console.log(`Unexpected file: ${file.name}`)
+| Some(entry) => logEntry(~stringPrefix="Phone: ", ~filePrefix="Unexpected file: ", entry)
 }
 
 // Get all values for a field (useful for multi-select or multiple file inputs)
-let allImages: array<WebApiFetch.Types.formDataEntryValue> = formData->WebApiFetch.FormData.getAll("images")
-
-// Process all entries
-let _ = allImages->Array.forEach(entry => {
-  switch entry {
-  | WebApiFetch.Types.String(value) => Console.log(`String value: ${value}`)
-  | WebApiFetch.Types.File(file) => Console.log(`WebApiFile: ${file.name}`)
-  }
-})
+let allImages: array<EntryValue.t> = formData->FormData.getAll("images")
+let _ = allImages->Array.forEach(entry =>
+  logEntry(~stringPrefix="String value: ", ~filePrefix="WebApiFile: ", entry)
+)
 
 // Create formDataEntryValue from string or file
-let stringEntry = WebApiFetch.Types.String("test value")
-let fileEntry = WebApiFetch.Types.File(WebApiFile.File.make(~fileBits=[], ~fileName="test.txt"))
+let stringEntry = EntryValue.fromString("test value")
+let blob: WebApiFile.Blob.t = WebApiFile.Blob.make(~blobParts=[])
+let file: WebApiFile.File.t = WebApiFile.File.make(~fileBits=[], ~fileName="test.txt")
+let fileEntry = EntryValue.fromFile(file)
+
+formData->FormData.appendBlob(~name="avatar", ~blobValue=blob)
+
+logEntry(~stringPrefix="String entry: ", ~filePrefix="Unexpected file entry: ", stringEntry)
+
+logEntry(~stringPrefix="Unexpected string entry: ", ~filePrefix="File entry: ", fileEntry)
 
 // Iterate over all entries in the FormData
-let entries: Iterator.t<(string, WebApiFetch.Types.formDataEntryValue)> = formData->WebApiFetch.FormData.entries
+let entries: Iterator.t<(string, EntryValue.t)> = formData->FormData.entries
 let _ = entries->Iterator.forEach(((key, value)) => {
-  switch value {
-  | WebApiFetch.Types.String(s) => Console.log(`${key}: ${s}`)
-  | WebApiFetch.Types.File(f) => Console.log(`${key}: [WebApiFile] ${f.name}`)
+  switch EntryValue.decode(value) {
+  | String(s) => Console.log(`${key}: ${s}`)
+  | File(f) => Console.log(`${key}: [WebApiFile] ${f.name}`)
   }
 })

--- a/tests/FetchAPI/Request__test.res
+++ b/tests/FetchAPI/Request__test.res
@@ -1,17 +1,17 @@
 let req = WebApiFetch.Request.fromURL("https://example.com")
 
-let blob: WebApiFile.Blob.t = WebApiFile.Blob.make(~blobParts=[])
-let file: WebApiFile.File.t = WebApiFile.File.make(~fileBits=[], ~fileName="hello.txt")
-let params: WebApiURL.URLSearchParams.t = WebApiURL.URLSearchParams.fromString("greeting=hello")
-let formData: WebApiFetch.FormData.t = WebApiFetch.FormData.make()
-let stream: WebApiFile.ReadableStream.t<array<int>> = WebApiFile.ReadableStream.make()
+let blob = WebApiFile.Blob.make(~blobParts=[])
+let file = WebApiFile.File.make(~fileBits=[], ~fileName="hello.txt")
+let params = WebApiURL.URLSearchParams.fromString("greeting=hello")
+let formData = WebApiFetch.FormData.make()
+let stream = WebApiFile.ReadableStream.make()
 
-let stringBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromString("hello")
-let blobBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromBlob(blob)
-let fileBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromFile(file)
-let paramsBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromURLSearchParams(params)
-let formDataBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromFormData(formData)
-let streamBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromReadableStream(stream)
+let stringBody = WebApiFetch.BodyInit.fromString("hello")
+let blobBody = WebApiFetch.BodyInit.fromBlob(blob)
+let fileBody = WebApiFetch.BodyInit.fromFile(file)
+let paramsBody = WebApiFetch.BodyInit.fromURLSearchParams(params)
+let formDataBody = WebApiFetch.BodyInit.fromFormData(formData)
+let streamBody = WebApiFetch.BodyInit.fromReadableStream(stream)
 
 let req1 = WebApiFetch.Request.fromURL(
   "https://example.com/api",

--- a/tests/FetchAPI/Request__test.res
+++ b/tests/FetchAPI/Request__test.res
@@ -1,10 +1,26 @@
 let req = WebApiFetch.Request.fromURL("https://example.com")
 
+let blob: WebApiFile.Blob.t = WebApiFile.Blob.make(~blobParts=[])
+let file: WebApiFile.File.t = WebApiFile.File.make(~fileBits=[], ~fileName="hello.txt")
+let params: WebApiURL.URLSearchParams.t = WebApiURL.URLSearchParams.fromString("greeting=hello")
+let formData: WebApiFetch.FormData.t = WebApiFetch.FormData.make()
+let stream: WebApiFile.ReadableStream.t<array<int>> = WebApiFile.ReadableStream.make()
+
+let stringBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromString("hello")
+let blobBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromBlob(blob)
+let fileBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromFile(file)
+let paramsBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromURLSearchParams(params)
+let formDataBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromFormData(formData)
+let streamBody: WebApiFetch.BodyInit.t = WebApiFetch.BodyInit.fromReadableStream(stream)
+
 let req1 = WebApiFetch.Request.fromURL(
   "https://example.com/api",
-  ~init={method: "POST", body: WebApiFetch.BodyInit.fromString("hello")},
+  ~init={method: "POST", body: stringBody},
 )
 
 let req2 = WebApiFetch.Request.fromRequest(req1)
+
+let _blobPromise: promise<WebApiFile.Blob.t> = req2->WebApiFetch.Request.blob
+let _formDataPromise: promise<WebApiFetch.FormData.t> = req2->WebApiFetch.Request.formData
 
 Console.log(await req2->WebApiFetch.Request.text)

--- a/tests/FetchAPI/Response__test.res
+++ b/tests/FetchAPI/Response__test.res
@@ -1,6 +1,22 @@
-let response = WebApiFetch.Response.fromNull(~init={status: 204})
+let headers: WebApiFetch.HeadersInit.t = WebApiFetch.HeadersInit.fromDict(dict{"X-Fruit": "Peach"})
+let blob: WebApiFile.Blob.t = WebApiFile.Blob.make(~blobParts=[])
+let file: WebApiFile.File.t = WebApiFile.File.make(~fileBits=[], ~fileName="pong.txt")
+let params: WebApiURL.URLSearchParams.t = WebApiURL.URLSearchParams.fromString("fruit=peach")
+let formData: WebApiFetch.FormData.t = WebApiFetch.FormData.make()
+let stream: WebApiFile.ReadableStream.t<array<int>> = WebApiFile.ReadableStream.make()
+
+let response = WebApiFetch.Response.fromNull(~init={status: 204, headers})
 
 let response1 = WebApiFetch.Response.fromString(
   "pong",
-  ~init={status: 200, headers: WebApiFetch.HeadersInit.fromDict(dict{"X-Fruit": "Peach"})},
+  ~init={status: 200, headers},
 )
+
+let response2 = WebApiFetch.Response.fromBlob(blob)
+let response3 = WebApiFetch.Response.fromFile(file)
+let response4 = WebApiFetch.Response.fromURLSearchParams(params)
+let response5 = WebApiFetch.Response.fromFormData(formData)
+let response6 = WebApiFetch.Response.fromReadableStream(stream)
+
+let _blobPromise: promise<WebApiFile.Blob.t> = response1->WebApiFetch.Response.blob
+let _formDataPromise: promise<WebApiFetch.FormData.t> = response1->WebApiFetch.Response.formData

--- a/tests/FetchAPI/Response__test.res
+++ b/tests/FetchAPI/Response__test.res
@@ -1,9 +1,9 @@
-let headers: WebApiFetch.HeadersInit.t = WebApiFetch.HeadersInit.fromDict(dict{"X-Fruit": "Peach"})
-let blob: WebApiFile.Blob.t = WebApiFile.Blob.make(~blobParts=[])
-let file: WebApiFile.File.t = WebApiFile.File.make(~fileBits=[], ~fileName="pong.txt")
-let params: WebApiURL.URLSearchParams.t = WebApiURL.URLSearchParams.fromString("fruit=peach")
-let formData: WebApiFetch.FormData.t = WebApiFetch.FormData.make()
-let stream: WebApiFile.ReadableStream.t<array<int>> = WebApiFile.ReadableStream.make()
+let headers = WebApiFetch.HeadersInit.fromDict(dict{"X-Fruit": "Peach"})
+let blob = WebApiFile.Blob.make(~blobParts=[])
+let file = WebApiFile.File.make(~fileBits=[], ~fileName="pong.txt")
+let params = WebApiURL.URLSearchParams.fromString("fruit=peach")
+let formData = WebApiFetch.FormData.make()
+let stream = WebApiFile.ReadableStream.make()
 
 let response = WebApiFetch.Response.fromNull(~init={status: 204, headers})
 

--- a/tests/Global__test.res
+++ b/tests/Global__test.res
@@ -50,9 +50,3 @@ let (auth, p256dh) = switch pushSubscriptionJSON.keys {
 }
 Console.log(`For subscription ${subscription.endpoint}, auth is ${auth} and p256dh is ${p256dh}`)
 
-let _setIntervalWithCallback = WebApiDOM.Window.setIntervalWithCallback
-let _alertWithMessage = WebApiDOM.Window.alertWithMessage
-let _postMessageWithOptions = WebApiDOM.Window.postMessageWithOptions
-let _scrollXY = WebApiDOM.Window.scrollXY
-let _scrollToXY = WebApiDOM.Window.scrollToXY
-let _scrollByXY = WebApiDOM.Window.scrollByXY

--- a/tests/Global__test.res
+++ b/tests/Global__test.res
@@ -32,7 +32,8 @@ WebApiDOM.Global.removeEventListener(
   ~options={capture: false},
 )
 
-let registrationResult = await WebApiDOM.Global.navigator
+let registrationResult = await WebApiDOM.Window.current
+->WebApiDOM.Window.navigator
 ->WebApiDOM.Navigator.serviceWorker
 ->WebApiServiceWorker.ServiceWorkerContainer.register("/sw.js")
 let subscription = await registrationResult.pushManager->WebApiPush.PushManager.subscribe(
@@ -48,3 +49,10 @@ let (auth, p256dh) = switch pushSubscriptionJSON.keys {
 | Some(keys) => (keys.auth, keys.p256dh)
 }
 Console.log(`For subscription ${subscription.endpoint}, auth is ${auth} and p256dh is ${p256dh}`)
+
+let _setIntervalWithCallback = WebApiDOM.Window.setIntervalWithCallback
+let _alertWithMessage = WebApiDOM.Window.alertWithMessage
+let _postMessageWithOptions = WebApiDOM.Window.postMessageWithOptions
+let _scrollXY = WebApiDOM.Window.scrollXY
+let _scrollToXY = WebApiDOM.Window.scrollToXY
+let _scrollByXY = WebApiDOM.Window.scrollByXY

--- a/tests/ServiceWorkerAPI/ServiceWorker__test.res
+++ b/tests/ServiceWorkerAPI/ServiceWorker__test.res
@@ -1,7 +1,7 @@
-external self: WebApiServiceWorker.Types.serviceWorkerGlobalScope = "self"
+let self = WebApiServiceWorker.ServiceWorkerGlobalScope.current
 
 self->WebApiServiceWorker.ServiceWorkerGlobalScope.addEventListener(WebApiEvent.Types.Push, (
-  event: WebApiPush.Types.pushEvent,
+  event: WebApiPush.PushEvent.t,
 ) => {
   Console.log("received push event")
 
@@ -37,7 +37,7 @@ self->WebApiServiceWorker.ServiceWorkerGlobalScope.addEventListener(WebApiEvent.
 })
 
 self->WebApiServiceWorker.ServiceWorkerGlobalScope.addEventListener(WebApiEvent.Types.NotificationClick, (
-  event: WebApiNotification.Types.notificationEvent,
+  event: WebApiNotification.Notification.notificationEvent,
 ) => {
   Console.log(`notification clicked: ${event.action}`)
   // Close the notification

--- a/tests/WebWorkersAPI/SharedWorkerGlobalScope__test.res
+++ b/tests/WebWorkersAPI/SharedWorkerGlobalScope__test.res
@@ -1,5 +1,3 @@
-external getSelf: unit => WebApiWebWorkers.Types.sharedWorkerGlobalScope = "self"
-
-let self = getSelf()
+let self = WebApiWebWorkers.SharedWorkerGlobalScope.current
 
 self->WebApiWebWorkers.SharedWorkerGlobalScope.close

--- a/tests/WebWorkersAPI/SharedWorker__test.res
+++ b/tests/WebWorkersAPI/SharedWorker__test.res
@@ -1,11 +1,11 @@
-let shared1: WebApiWebWorkers.Types.sharedWorker = WebApiWebWorkers.SharedWorker.make("sharedworker.js")
+let shared1: WebApiWebWorkers.SharedWorker.t = WebApiWebWorkers.SharedWorker.make("sharedworker.js")
 
-let shared2: WebApiWebWorkers.Types.sharedWorker = WebApiWebWorkers.SharedWorker.makeWithName(
+let shared2: WebApiWebWorkers.SharedWorker.t = WebApiWebWorkers.SharedWorker.makeWithName(
   "sharedworker.js",
   "name",
 )
 
-let shared3: WebApiWebWorkers.Types.sharedWorker = WebApiWebWorkers.SharedWorker.makeWithOptions(
+let shared3: WebApiWebWorkers.SharedWorker.t = WebApiWebWorkers.SharedWorker.makeWithOptions(
   "sharedworker.js",
   {
     name: "workerName",
@@ -13,10 +13,8 @@ let shared3: WebApiWebWorkers.Types.sharedWorker = WebApiWebWorkers.SharedWorker
   },
 )
 
-let port: WebApiChannelMessaging.Types.messagePort = WebApiWebWorkers.SharedWorker.port(shared1)
+let port: WebApiChannelMessaging.MessagePort.t = WebApiWebWorkers.SharedWorker.port(shared1)
 
-external getSelf: unit => WebApiWebWorkers.Types.sharedWorkerGlobalScope = "self"
-
-let self = getSelf()
+let self = WebApiWebWorkers.SharedWorkerGlobalScope.current
 
 self->WebApiWebWorkers.SharedWorkerGlobalScope.close


### PR DESCRIPTION
## Summary
  - port the surviving post-pre-alpha cleanup onto the #249 monorepo split
  - add the missing concrete modules and translate the fetch/runtime/canvas/websocket/media API cleanup into package-local
  surfaces
  - keep the carryover green with the related test updates

  ## Test Plan
  - npm run build
  - npm test