### PR TITLE
Rename bs-dependencies & bsc-flags in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ and add `@rescript/webapi` to your `rescript.json`:
 
 ```json
 {
-  "bs-dependencies": [
-+    "@rescript/webapi",
+  "dependencies": [
++    "@rescript/webapi"
   ],
-  "bsc-flags": [
+  "compiler-flags": [
 +    "-open WebAPI.Global"
   ]
 }

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -38,10 +38,10 @@ and add `@rescript/webapi` to your `rescript.json`:
 
 export const rescriptJson = `
 {
-  "bs-dependencies": [
-    "@rescript/webapi",
+  "dependencies": [
+    "@rescript/webapi"
   ],
-  "bsc-flags": [
+  "compiler-flags": [
     "-open WebAPI.Global"
   ]
 }


### PR DESCRIPTION
since this is only for v12+ it shouldn't use the old names

also remove trailing comma