### PR TITLE
[codex] upgrade to ReScript 13 alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
-  "name": "experimental-rescript-webapi",
+  "name": "@rescript/webapi",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "experimental-rescript-webapi",
+      "name": "@rescript/webapi",
       "version": "0.1.0",
       "license": "MIT",
-      "workspaces": [
-        "packages/*"
-      ],
       "devDependencies": {
         "@astrojs/starlight": "0.37.7",
         "astro": "^5.10.1",
@@ -18,11 +15,11 @@
         "oxfmt": "^0.47.0",
         "prettier": "^3.8.3",
         "prettier-plugin-astro": "^0.14.1",
-        "rescript": ">=12.0.0 <13",
+        "rescript": "^13.0.0-alpha.4",
         "sharp": "^0.34.0"
       },
       "peerDependencies": {
-        "rescript": ">=12.0.0 <13"
+        "rescript": ">=13"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1614,189 +1611,15 @@
         "win32"
       ]
     },
-    "node_modules/@rescript-webapi/base": {
-      "resolved": "packages/Base",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/canvas": {
-      "resolved": "packages/Canvas",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/channel-messaging": {
-      "resolved": "packages/ChannelMessaging",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/clipboard": {
-      "resolved": "packages/Clipboard",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/credential-management": {
-      "resolved": "packages/CredentialManagement",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/css-font-loading": {
-      "resolved": "packages/CSSFontLoading",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/dom": {
-      "resolved": "packages/DOM",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/encrypted-media-extensions": {
-      "resolved": "packages/EncryptedMediaExtensions",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/event": {
-      "resolved": "packages/Event",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/fetch": {
-      "resolved": "packages/Fetch",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/file": {
-      "resolved": "packages/File",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/file-and-directory-entries": {
-      "resolved": "packages/FileAndDirectoryEntries",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/gamepad": {
-      "resolved": "packages/Gamepad",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/geolocation": {
-      "resolved": "packages/Geolocation",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/history": {
-      "resolved": "packages/History",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/indexed-db": {
-      "resolved": "packages/IndexedDB",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/intersection-observer": {
-      "resolved": "packages/IntersectionObserver",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/media-capabilities": {
-      "resolved": "packages/MediaCapabilities",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/media-capture-and-streams": {
-      "resolved": "packages/MediaCaptureAndStreams",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/media-session": {
-      "resolved": "packages/MediaSession",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/mutation-observer": {
-      "resolved": "packages/MutationObserver",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/notification": {
-      "resolved": "packages/Notification",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/performance": {
-      "resolved": "packages/Performance",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/permissions": {
-      "resolved": "packages/Permissions",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/picture-in-picture": {
-      "resolved": "packages/PictureInPicture",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/push": {
-      "resolved": "packages/Push",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/remote-playback": {
-      "resolved": "packages/RemotePlayback",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/resize-observer": {
-      "resolved": "packages/ResizeObserver",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/screen-wake-lock": {
-      "resolved": "packages/ScreenWakeLock",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/service-worker": {
-      "resolved": "packages/ServiceWorker",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/storage": {
-      "resolved": "packages/Storage",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/ui-events": {
-      "resolved": "packages/UIEvents",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/url": {
-      "resolved": "packages/URL",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/view-transitions": {
-      "resolved": "packages/ViewTransitions",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/visual-viewport": {
-      "resolved": "packages/VisualViewport",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-audio": {
-      "resolved": "packages/WebAudio",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-crypto": {
-      "resolved": "packages/WebCrypto",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-locks": {
-      "resolved": "packages/WebLocks",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-midi": {
-      "resolved": "packages/WebMIDI",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-sockets": {
-      "resolved": "packages/WebSockets",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-speech": {
-      "resolved": "packages/WebSpeech",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-storage": {
-      "resolved": "packages/WebStorage",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-vtt": {
-      "resolved": "packages/WebVTT",
-      "link": true
-    },
-    "node_modules/@rescript-webapi/web-workers": {
-      "resolved": "packages/WebWorkers",
-      "link": true
-    },
     "node_modules/@rescript/darwin-arm64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/darwin-arm64/-/darwin-arm64-12.2.0.tgz",
-      "integrity": "sha512-xc3K/J7Ujl1vPiFY2009mRf3kWRlUe/VZyJWprseKxlcEtUQv89ter7r6pY+YFbtYvA/fcaEncL9CVGEdattAg==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/darwin-arm64/-/darwin-arm64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-3+uPQvuPoweXQ2MatnADRa6PgXhRI/LtkdWkoy8DFSKN7lhtF3Pg+eVjKxY4x4OCECNvHYWLWBKaiVRa22tocA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
       "optional": true,
       "os": [
         "darwin"
@@ -1806,12 +1629,14 @@
       }
     },
     "node_modules/@rescript/darwin-x64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/darwin-x64/-/darwin-x64-12.2.0.tgz",
-      "integrity": "sha512-qqcTvnlSeoKkywLjG7cXfYvKZ1e4Gz2kUKcD6SiqDgCqm8TF+spwlFAiM6sloRUOFsc0bpC/0R0B3yr01FCB1A==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/darwin-x64/-/darwin-x64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-L71KY+BfSgrMYPUEGMDmrtbrqgBnoYJ/2nJZQNhPV0FP9oQ23rHw8pPVO8+/OzHYPr/OklnB5RbaBphzMBnaxg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
       "optional": true,
       "os": [
         "darwin"
@@ -1821,12 +1646,14 @@
       }
     },
     "node_modules/@rescript/linux-arm64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/linux-arm64/-/linux-arm64-12.2.0.tgz",
-      "integrity": "sha512-ODmpG3ji+Nj/8d5yvXkeHlfKkmbw1Q4t1iIjVuNwtmFpz7TiEa7n/sQqoYdE+WzbDX3DoJfmJNbp3Ob7qCUoOg==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/linux-arm64/-/linux-arm64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-2sJ4+Ali2PHhNRwIW53jYSuRSbMoioawl1WKAKoH7sQ++1+bIzdMuB3TQpi9oOqTUGlm/5l6bK2Amf8nUiJQ7Q==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
       "optional": true,
       "os": [
         "linux"
@@ -1836,12 +1663,14 @@
       }
     },
     "node_modules/@rescript/linux-x64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/linux-x64/-/linux-x64-12.2.0.tgz",
-      "integrity": "sha512-2W9Y9/g19Y4F/subl8yV3T8QBG2oRaP+HciNRcBjptyEdw9LmCKH8+rhWO6sp3E+nZLwoE2IAkwH0WKV3wqlxQ==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/linux-x64/-/linux-x64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-Gbmk44xkW4+1qG5g2iAATwx/Y6fZvGgEGUFZw1wK1sDpn2DKblmXIV3JLcWROgpmQv4Mfp4RHPSzZdmcBdPUoQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
       "optional": true,
       "os": [
         "linux"
@@ -1851,17 +1680,21 @@
       }
     },
     "node_modules/@rescript/runtime": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/runtime/-/runtime-12.2.0.tgz",
-      "integrity": "sha512-NwfljDRq1rjFPHUaca1nzFz13xsa9ZGkBkLvMhvVgavJT5+A4rMcLu8XAaVTi/oAhO/tlHf9ZDoOTF1AfyAk9Q=="
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/runtime/-/runtime-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-pOGJdN0R3+PeB+tvxqmJB9qWPLTgitHmQY89lBbF3Ddtcbu/aUra9gEeFiX5gXGznEUcS1SVU24Zjr3GBqfy8w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rescript/win32-x64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/win32-x64/-/win32-x64-12.2.0.tgz",
-      "integrity": "sha512-fhf8CBj3p1lkIXPeNko3mVTKQfXXm4BoxJtR1xAXxUn43wDpd8Lox4w8/EPBbbW6C/YFQW6H7rtpY+2AKuNaDA==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/win32-x64/-/win32-x64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-NadOoXUe4ek9ZMdHp1hvfc6U11HAOV4VKczCZuM13MvNM0RsmiFUG6jsSNt37ZQuC3iY6I/v3qeKglVv/LG11g==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
       "optional": true,
       "os": [
         "win32"
@@ -6673,28 +6506,39 @@
       }
     },
     "node_modules/rescript": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-12.2.0.tgz",
-      "integrity": "sha512-1Jf2cmNhyx5Mj2vwZ4XXPcXvNSjGj9D1jPBUcoqIOqRpLPo1ch2Ta/7eWh23xAHWHK5ow7BCDyYFjvZSjyjLzg==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-bkUiLFWxwwQ2cEjA9j3h0xQSgVk5ZngmhAhoB8oTyGrrzYzWoFaF0IEJhT0ZV0bqc+sen2xJtfqF1V8kyMql/A==",
+      "dev": true,
+      "license": "(LGPL-3.0-or-later AND MIT)",
+      "workspaces": [
+        "packages/playground",
+        "packages/@rescript/*",
+        "tests/dependencies/**",
+        "tests/analysis_tests/**",
+        "tests/docstring_tests",
+        "tests/gentype_tests/**",
+        "tests/tools_tests",
+        "tests/commonjs_tests",
+        "scripts/res"
+      ],
       "dependencies": {
-        "@rescript/runtime": "12.2.0"
+        "@rescript/runtime": "13.0.0-alpha.4"
       },
       "bin": {
         "bsc": "cli/bsc.js",
-        "bstracing": "cli/bstracing.js",
         "rescript": "cli/rescript.js",
-        "rescript-legacy": "cli/rescript-legacy.js",
         "rescript-tools": "cli/rescript-tools.js"
       },
       "engines": {
         "node": ">=20.11.0"
       },
       "optionalDependencies": {
-        "@rescript/darwin-arm64": "12.2.0",
-        "@rescript/darwin-x64": "12.2.0",
-        "@rescript/linux-arm64": "12.2.0",
-        "@rescript/linux-x64": "12.2.0",
-        "@rescript/win32-x64": "12.2.0"
+        "@rescript/darwin-arm64": "13.0.0-alpha.4",
+        "@rescript/darwin-x64": "13.0.0-alpha.4",
+        "@rescript/linux-arm64": "13.0.0-alpha.4",
+        "@rescript/linux-x64": "13.0.0-alpha.4",
+        "@rescript/win32-x64": "13.0.0-alpha.4"
       }
     },
     "node_modules/retext": {
@@ -7668,6 +7512,7 @@
     "packages/Base": {
       "name": "@rescript-webapi/base",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
         "rescript": ">=12.0.0 <13"
@@ -7676,6 +7521,7 @@
     "packages/Canvas": {
       "name": "@rescript-webapi/canvas",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -7691,6 +7537,7 @@
     "packages/ChannelMessaging": {
       "name": "@rescript-webapi/channel-messaging",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7702,6 +7549,7 @@
     "packages/Clipboard": {
       "name": "@rescript-webapi/clipboard",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0",
@@ -7714,6 +7562,7 @@
     "packages/CredentialManagement": {
       "name": "@rescript-webapi/credential-management",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -7726,6 +7575,7 @@
     "packages/CSSFontLoading": {
       "name": "@rescript-webapi/css-font-loading",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7737,6 +7587,7 @@
     "packages/DOM": {
       "name": "@rescript-webapi/dom",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -7780,6 +7631,7 @@
     "packages/EncryptedMediaExtensions": {
       "name": "@rescript-webapi/encrypted-media-extensions",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -7793,6 +7645,7 @@
     "packages/Event": {
       "name": "@rescript-webapi/event",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/dom": "0.1.0"
@@ -7804,6 +7657,7 @@
     "packages/Fetch": {
       "name": "@rescript-webapi/fetch",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -7818,6 +7672,7 @@
     "packages/File": {
       "name": "@rescript-webapi/file",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7829,6 +7684,7 @@
     "packages/FileAndDirectoryEntries": {
       "name": "@rescript-webapi/file-and-directory-entries",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0"
@@ -7840,6 +7696,7 @@
     "packages/Gamepad": {
       "name": "@rescript-webapi/gamepad",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0"
@@ -7851,6 +7708,7 @@
     "packages/Geolocation": {
       "name": "@rescript-webapi/geolocation",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
         "rescript": ">=12.0.0 <13"
@@ -7859,6 +7717,7 @@
     "packages/History": {
       "name": "@rescript-webapi/history",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
         "rescript": ">=12.0.0 <13"
@@ -7867,6 +7726,7 @@
     "packages/IndexedDB": {
       "name": "@rescript-webapi/indexed-db",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -7879,6 +7739,7 @@
     "packages/IntersectionObserver": {
       "name": "@rescript-webapi/intersection-observer",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/dom": "0.1.0"
@@ -7890,6 +7751,7 @@
     "packages/MediaCapabilities": {
       "name": "@rescript-webapi/media-capabilities",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
         "rescript": ">=12.0.0 <13"
@@ -7898,6 +7760,7 @@
     "packages/MediaCaptureAndStreams": {
       "name": "@rescript-webapi/media-capture-and-streams",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7909,6 +7772,7 @@
     "packages/MediaSession": {
       "name": "@rescript-webapi/media-session",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
         "rescript": ">=12.0.0 <13"
@@ -7917,6 +7781,7 @@
     "packages/MutationObserver": {
       "name": "@rescript-webapi/mutation-observer",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/dom": "0.1.0"
@@ -7928,6 +7793,7 @@
     "packages/Notification": {
       "name": "@rescript-webapi/notification",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7939,6 +7805,7 @@
     "packages/Performance": {
       "name": "@rescript-webapi/performance",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7950,6 +7817,7 @@
     "packages/Permissions": {
       "name": "@rescript-webapi/permissions",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7961,6 +7829,7 @@
     "packages/PictureInPicture": {
       "name": "@rescript-webapi/picture-in-picture",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7972,6 +7841,7 @@
     "packages/Push": {
       "name": "@rescript-webapi/push",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7983,6 +7853,7 @@
     "packages/RemotePlayback": {
       "name": "@rescript-webapi/remote-playback",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -7994,6 +7865,7 @@
     "packages/ResizeObserver": {
       "name": "@rescript-webapi/resize-observer",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/dom": "0.1.0"
@@ -8005,6 +7877,7 @@
     "packages/ScreenWakeLock": {
       "name": "@rescript-webapi/screen-wake-lock",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -8016,6 +7889,7 @@
     "packages/ServiceWorker": {
       "name": "@rescript-webapi/service-worker",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -8033,6 +7907,7 @@
     "packages/Storage": {
       "name": "@rescript-webapi/storage",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/file": "0.1.0"
@@ -8044,6 +7919,7 @@
     "packages/UIEvents": {
       "name": "@rescript-webapi/ui-events",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -8059,6 +7935,7 @@
     "packages/URL": {
       "name": "@rescript-webapi/url",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
         "rescript": ">=12.0.0 <13"
@@ -8067,6 +7944,7 @@
     "packages/ViewTransitions": {
       "name": "@rescript-webapi/view-transitions",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
         "rescript": ">=12.0.0 <13"
@@ -8075,6 +7953,7 @@
     "packages/VisualViewport": {
       "name": "@rescript-webapi/visual-viewport",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -8086,6 +7965,7 @@
     "packages/WebAudio": {
       "name": "@rescript-webapi/web-audio",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -8101,6 +7981,7 @@
     "packages/WebCrypto": {
       "name": "@rescript-webapi/web-crypto",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0"
@@ -8112,6 +7993,7 @@
     "packages/WebLocks": {
       "name": "@rescript-webapi/web-locks",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -8123,6 +8005,7 @@
     "packages/WebMIDI": {
       "name": "@rescript-webapi/web-midi",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/base": "0.1.0",
@@ -8135,6 +8018,7 @@
     "packages/WebSockets": {
       "name": "@rescript-webapi/web-sockets",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/channel-messaging": "0.1.0",
@@ -8148,6 +8032,7 @@
     "packages/WebSpeech": {
       "name": "@rescript-webapi/web-speech",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -8159,6 +8044,7 @@
     "packages/WebStorage": {
       "name": "@rescript-webapi/web-storage",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -8170,6 +8056,7 @@
     "packages/WebVTT": {
       "name": "@rescript-webapi/web-vtt",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/event": "0.1.0"
@@ -8181,6 +8068,7 @@
     "packages/WebWorkers": {
       "name": "@rescript-webapi/web-workers",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rescript-webapi/channel-messaging": "0.1.0",
@@ -9035,353 +8923,45 @@
       "dev": true,
       "optional": true
     },
-    "@rescript-webapi/base": {
-      "version": "file:packages/Base",
-      "requires": {}
-    },
-    "@rescript-webapi/canvas": {
-      "version": "file:packages/Canvas",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/dom": "0.1.0",
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/file": "0.1.0",
-        "@rescript-webapi/media-capture-and-streams": "0.1.0"
-      }
-    },
-    "@rescript-webapi/channel-messaging": {
-      "version": "file:packages/ChannelMessaging",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/clipboard": {
-      "version": "file:packages/Clipboard",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/file": "0.1.0"
-      }
-    },
-    "@rescript-webapi/credential-management": {
-      "version": "file:packages/CredentialManagement",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/css-font-loading": {
-      "version": "file:packages/CSSFontLoading",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/dom": {
-      "version": "file:packages/DOM",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/channel-messaging": "0.1.0",
-        "@rescript-webapi/clipboard": "0.1.0",
-        "@rescript-webapi/credential-management": "0.1.0",
-        "@rescript-webapi/css-font-loading": "0.1.0",
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/fetch": "0.1.0",
-        "@rescript-webapi/file": "0.1.0",
-        "@rescript-webapi/file-and-directory-entries": "0.1.0",
-        "@rescript-webapi/gamepad": "0.1.0",
-        "@rescript-webapi/geolocation": "0.1.0",
-        "@rescript-webapi/history": "0.1.0",
-        "@rescript-webapi/indexed-db": "0.1.0",
-        "@rescript-webapi/media-capabilities": "0.1.0",
-        "@rescript-webapi/media-capture-and-streams": "0.1.0",
-        "@rescript-webapi/media-session": "0.1.0",
-        "@rescript-webapi/performance": "0.1.0",
-        "@rescript-webapi/permissions": "0.1.0",
-        "@rescript-webapi/picture-in-picture": "0.1.0",
-        "@rescript-webapi/remote-playback": "0.1.0",
-        "@rescript-webapi/screen-wake-lock": "0.1.0",
-        "@rescript-webapi/service-worker": "0.1.0",
-        "@rescript-webapi/storage": "0.1.0",
-        "@rescript-webapi/url": "0.1.0",
-        "@rescript-webapi/view-transitions": "0.1.0",
-        "@rescript-webapi/visual-viewport": "0.1.0",
-        "@rescript-webapi/web-crypto": "0.1.0",
-        "@rescript-webapi/web-locks": "0.1.0",
-        "@rescript-webapi/web-midi": "0.1.0",
-        "@rescript-webapi/web-speech": "0.1.0",
-        "@rescript-webapi/web-storage": "0.1.0",
-        "@rescript-webapi/web-vtt": "0.1.0",
-        "@rescript-webapi/web-workers": "0.1.0"
-      }
-    },
-    "@rescript-webapi/encrypted-media-extensions": {
-      "version": "file:packages/EncryptedMediaExtensions",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/dom": "0.1.0",
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/event": {
-      "version": "file:packages/Event",
-      "requires": {
-        "@rescript-webapi/dom": "0.1.0"
-      }
-    },
-    "@rescript-webapi/fetch": {
-      "version": "file:packages/Fetch",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/file": "0.1.0",
-        "@rescript-webapi/url": "0.1.0"
-      }
-    },
-    "@rescript-webapi/file": {
-      "version": "file:packages/File",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/file-and-directory-entries": {
-      "version": "file:packages/FileAndDirectoryEntries",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0"
-      }
-    },
-    "@rescript-webapi/gamepad": {
-      "version": "file:packages/Gamepad",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0"
-      }
-    },
-    "@rescript-webapi/geolocation": {
-      "version": "file:packages/Geolocation",
-      "requires": {}
-    },
-    "@rescript-webapi/history": {
-      "version": "file:packages/History",
-      "requires": {}
-    },
-    "@rescript-webapi/indexed-db": {
-      "version": "file:packages/IndexedDB",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/intersection-observer": {
-      "version": "file:packages/IntersectionObserver",
-      "requires": {
-        "@rescript-webapi/dom": "0.1.0"
-      }
-    },
-    "@rescript-webapi/media-capabilities": {
-      "version": "file:packages/MediaCapabilities",
-      "requires": {}
-    },
-    "@rescript-webapi/media-capture-and-streams": {
-      "version": "file:packages/MediaCaptureAndStreams",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/media-session": {
-      "version": "file:packages/MediaSession",
-      "requires": {}
-    },
-    "@rescript-webapi/mutation-observer": {
-      "version": "file:packages/MutationObserver",
-      "requires": {
-        "@rescript-webapi/dom": "0.1.0"
-      }
-    },
-    "@rescript-webapi/notification": {
-      "version": "file:packages/Notification",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/performance": {
-      "version": "file:packages/Performance",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/permissions": {
-      "version": "file:packages/Permissions",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/picture-in-picture": {
-      "version": "file:packages/PictureInPicture",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/push": {
-      "version": "file:packages/Push",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/remote-playback": {
-      "version": "file:packages/RemotePlayback",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/resize-observer": {
-      "version": "file:packages/ResizeObserver",
-      "requires": {
-        "@rescript-webapi/dom": "0.1.0"
-      }
-    },
-    "@rescript-webapi/screen-wake-lock": {
-      "version": "file:packages/ScreenWakeLock",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/service-worker": {
-      "version": "file:packages/ServiceWorker",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/channel-messaging": "0.1.0",
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/fetch": "0.1.0",
-        "@rescript-webapi/notification": "0.1.0",
-        "@rescript-webapi/push": "0.1.0",
-        "@rescript-webapi/web-workers": "0.1.0"
-      }
-    },
-    "@rescript-webapi/storage": {
-      "version": "file:packages/Storage",
-      "requires": {
-        "@rescript-webapi/file": "0.1.0"
-      }
-    },
-    "@rescript-webapi/ui-events": {
-      "version": "file:packages/UIEvents",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/dom": "0.1.0",
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/file": "0.1.0",
-        "@rescript-webapi/file-and-directory-entries": "0.1.0"
-      }
-    },
-    "@rescript-webapi/url": {
-      "version": "file:packages/URL",
-      "requires": {}
-    },
-    "@rescript-webapi/view-transitions": {
-      "version": "file:packages/ViewTransitions",
-      "requires": {}
-    },
-    "@rescript-webapi/visual-viewport": {
-      "version": "file:packages/VisualViewport",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-audio": {
-      "version": "file:packages/WebAudio",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/channel-messaging": "0.1.0",
-        "@rescript-webapi/dom": "0.1.0",
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/media-capture-and-streams": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-crypto": {
-      "version": "file:packages/WebCrypto",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-locks": {
-      "version": "file:packages/WebLocks",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-midi": {
-      "version": "file:packages/WebMIDI",
-      "requires": {
-        "@rescript-webapi/base": "0.1.0",
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-sockets": {
-      "version": "file:packages/WebSockets",
-      "requires": {
-        "@rescript-webapi/channel-messaging": "0.1.0",
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/file": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-speech": {
-      "version": "file:packages/WebSpeech",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-storage": {
-      "version": "file:packages/WebStorage",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-vtt": {
-      "version": "file:packages/WebVTT",
-      "requires": {
-        "@rescript-webapi/event": "0.1.0"
-      }
-    },
-    "@rescript-webapi/web-workers": {
-      "version": "file:packages/WebWorkers",
-      "requires": {
-        "@rescript-webapi/channel-messaging": "0.1.0",
-        "@rescript-webapi/event": "0.1.0",
-        "@rescript-webapi/fetch": "0.1.0",
-        "@rescript-webapi/url": "0.1.0"
-      }
-    },
     "@rescript/darwin-arm64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/darwin-arm64/-/darwin-arm64-12.2.0.tgz",
-      "integrity": "sha512-xc3K/J7Ujl1vPiFY2009mRf3kWRlUe/VZyJWprseKxlcEtUQv89ter7r6pY+YFbtYvA/fcaEncL9CVGEdattAg==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/darwin-arm64/-/darwin-arm64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-3+uPQvuPoweXQ2MatnADRa6PgXhRI/LtkdWkoy8DFSKN7lhtF3Pg+eVjKxY4x4OCECNvHYWLWBKaiVRa22tocA==",
+      "dev": true,
       "optional": true
     },
     "@rescript/darwin-x64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/darwin-x64/-/darwin-x64-12.2.0.tgz",
-      "integrity": "sha512-qqcTvnlSeoKkywLjG7cXfYvKZ1e4Gz2kUKcD6SiqDgCqm8TF+spwlFAiM6sloRUOFsc0bpC/0R0B3yr01FCB1A==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/darwin-x64/-/darwin-x64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-L71KY+BfSgrMYPUEGMDmrtbrqgBnoYJ/2nJZQNhPV0FP9oQ23rHw8pPVO8+/OzHYPr/OklnB5RbaBphzMBnaxg==",
+      "dev": true,
       "optional": true
     },
     "@rescript/linux-arm64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/linux-arm64/-/linux-arm64-12.2.0.tgz",
-      "integrity": "sha512-ODmpG3ji+Nj/8d5yvXkeHlfKkmbw1Q4t1iIjVuNwtmFpz7TiEa7n/sQqoYdE+WzbDX3DoJfmJNbp3Ob7qCUoOg==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/linux-arm64/-/linux-arm64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-2sJ4+Ali2PHhNRwIW53jYSuRSbMoioawl1WKAKoH7sQ++1+bIzdMuB3TQpi9oOqTUGlm/5l6bK2Amf8nUiJQ7Q==",
+      "dev": true,
       "optional": true
     },
     "@rescript/linux-x64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/linux-x64/-/linux-x64-12.2.0.tgz",
-      "integrity": "sha512-2W9Y9/g19Y4F/subl8yV3T8QBG2oRaP+HciNRcBjptyEdw9LmCKH8+rhWO6sp3E+nZLwoE2IAkwH0WKV3wqlxQ==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/linux-x64/-/linux-x64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-Gbmk44xkW4+1qG5g2iAATwx/Y6fZvGgEGUFZw1wK1sDpn2DKblmXIV3JLcWROgpmQv4Mfp4RHPSzZdmcBdPUoQ==",
+      "dev": true,
       "optional": true
     },
     "@rescript/runtime": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/runtime/-/runtime-12.2.0.tgz",
-      "integrity": "sha512-NwfljDRq1rjFPHUaca1nzFz13xsa9ZGkBkLvMhvVgavJT5+A4rMcLu8XAaVTi/oAhO/tlHf9ZDoOTF1AfyAk9Q=="
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/runtime/-/runtime-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-pOGJdN0R3+PeB+tvxqmJB9qWPLTgitHmQY89lBbF3Ddtcbu/aUra9gEeFiX5gXGznEUcS1SVU24Zjr3GBqfy8w==",
+      "dev": true
     },
     "@rescript/win32-x64": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@rescript/win32-x64/-/win32-x64-12.2.0.tgz",
-      "integrity": "sha512-fhf8CBj3p1lkIXPeNko3mVTKQfXXm4BoxJtR1xAXxUn43wDpd8Lox4w8/EPBbbW6C/YFQW6H7rtpY+2AKuNaDA==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rescript/win32-x64/-/win32-x64-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-NadOoXUe4ek9ZMdHp1hvfc6U11HAOV4VKczCZuM13MvNM0RsmiFUG6jsSNt37ZQuC3iY6I/v3qeKglVv/LG11g==",
+      "dev": true,
       "optional": true
     },
     "@rollup/pluginutils": {
@@ -12629,16 +12209,17 @@
       }
     },
     "rescript": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-12.2.0.tgz",
-      "integrity": "sha512-1Jf2cmNhyx5Mj2vwZ4XXPcXvNSjGj9D1jPBUcoqIOqRpLPo1ch2Ta/7eWh23xAHWHK5ow7BCDyYFjvZSjyjLzg==",
+      "version": "13.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-13.0.0-alpha.4.tgz",
+      "integrity": "sha512-bkUiLFWxwwQ2cEjA9j3h0xQSgVk5ZngmhAhoB8oTyGrrzYzWoFaF0IEJhT0ZV0bqc+sen2xJtfqF1V8kyMql/A==",
+      "dev": true,
       "requires": {
-        "@rescript/darwin-arm64": "12.2.0",
-        "@rescript/darwin-x64": "12.2.0",
-        "@rescript/linux-arm64": "12.2.0",
-        "@rescript/linux-x64": "12.2.0",
-        "@rescript/runtime": "12.2.0",
-        "@rescript/win32-x64": "12.2.0"
+        "@rescript/darwin-arm64": "13.0.0-alpha.4",
+        "@rescript/darwin-x64": "13.0.0-alpha.4",
+        "@rescript/linux-arm64": "13.0.0-alpha.4",
+        "@rescript/linux-x64": "13.0.0-alpha.4",
+        "@rescript/runtime": "13.0.0-alpha.4",
+        "@rescript/win32-x64": "13.0.0-alpha.4"
       }
     },
     "retext": {

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     "oxfmt": "^0.47.0",
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",
-    "rescript": ">=12.0.0 <13",
+    "rescript": "^13.0.0-alpha.4",
     "sharp": "^0.34.0"
   },
   "peerDependencies": {
-    "rescript": ">=12.0.0 <13"
+    "rescript": ">=13"
   }
 }

--- a/src/Fetch/FormData.res
+++ b/src/Fetch/FormData.res
@@ -50,13 +50,13 @@ external has: (t, string) => bool = "has"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/entries)
 */
 @send
-external entries: t => Iterator.t<(string, formDataEntryValue)> = "entries"
+external entries: t => iterable<(string, formDataEntryValue)> = "entries"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/keys)
 */
 @send
-external keys: t => Iterator.t<string> = "keys"
+external keys: t => iterable<string> = "keys"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/set)

--- a/src/URL/URLSearchParams.res
+++ b/src/URL/URLSearchParams.res
@@ -46,7 +46,7 @@ Returns key/value pairs in the same order as they appear in the query string.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/entries)
 */
 @send
-external entries: t => Iterator.t<(string, string)> = "entries"
+external entries: t => iterable<(string, string)> = "entries"
 
 /**
 Returns the first value associated to the given search parameter.
@@ -74,7 +74,7 @@ Returns an iterator allowing iteration through all keys contained in this object
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/keys)
 */
 @send
-external keys: t => Iterator.t<string> = "keys"
+external keys: t => iterable<string> = "keys"
 
 /**
 Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
@@ -101,4 +101,4 @@ Returns an iterator allowing iteration through all values contained in this obje
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/values)
 */
 @send
-external values: t => Iterator.t<string> = "values"
+external values: t => iterable<string> = "values"

--- a/tests/FetchAPI/FormData__test.res
+++ b/tests/FetchAPI/FormData__test.res
@@ -43,10 +43,13 @@ logEntry(~stringPrefix="String entry: ", ~filePrefix="Unexpected file entry: ", 
 logEntry(~stringPrefix="Unexpected string entry: ", ~filePrefix="File entry: ", fileEntry)
 
 // Iterate over all entries in the FormData
-let entries: Iterator.t<(string, EntryValue.t)> = formData->FormData.entries
-let _ = entries->Iterator.forEach(((key, value)) => {
-  switch value {
-  | String(s) => Console.log(`${key}: ${s}`)
-  | File(f) => Console.log(`${key}: [WebApiFile] ${f.name}`)
-  }
-})
+let entries: iterable<(string, EntryValue.t)> = formData->FormData.entries
+let _ =
+  entries
+  ->Array.fromIterable
+  ->Array.forEach(((key, value)) => {
+    switch value {
+    | String(s) => Console.log(`${key}: ${s}`)
+    | File(f) => Console.log(`${key}: [WebApiFile] ${f.name}`)
+    }
+  })

--- a/tests/FetchAPI/URLSearchParams__test.res
+++ b/tests/FetchAPI/URLSearchParams__test.res
@@ -1,13 +1,13 @@
 let params1 = URLSearchParams.fromString("foo=1&bar=2")
-params1->URLSearchParams.keys->Iterator.toArray->Array.forEach(Console.log)
+params1->URLSearchParams.keys->Array.fromIterable->Array.forEach(Console.log)
 
 let params2 = URLSearchParams.fromKeyValueArray([("foo", "1"), ("bar", "b")])
-params2->URLSearchParams.values->Iterator.toArray->Array.forEach(Console.log)
+params2->URLSearchParams.values->Array.fromIterable->Array.forEach(Console.log)
 
 let params3 = URLSearchParams.fromDict(dict{"foo": "1", "bar": "b"})
 params3
 ->URLSearchParams.entries
-->Iterator.toArray
+->Array.fromIterable
 ->Array.forEach(((key, value)) => Console.log2(key, value))
 
 let paramStr = params3->URLSearchParams.toString


### PR DESCRIPTION
## Summary

This extracts only the ReScript 13 upgrade pieces from PR #282.

- Bumps the project dev dependency to `rescript@^13.0.0-alpha.4` and peer range to `>=13`.
- Updates `package-lock.json` for the ReScript 13 alpha packages.
- Updates FormData and URLSearchParams iterator-return bindings/tests to use ReScript 13 `iterable` values and `Array.fromIterable`.

## Out of Scope

This intentionally excludes the Event owner-type split from PR #282.

## Validation

- `npm test`
- `npm run format:check`