### PR TITLE
refactor: expose browser window from DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and add `@rescript/webapi` to your `rescript.json`:
 ## Usage
 
 ```rescript
-let location = WebAPI.Window.current->WebAPI.Window.location
+let location = WebAPI.DOM.window->WebAPI.Window.location
 let href = location.href
 location->WebAPI.Location.reload
 ```

--- a/docs/content/docs/api-surface.mdx
+++ b/docs/content/docs/api-surface.mdx
@@ -13,12 +13,12 @@ add the package to `rescript.json`:
 }
 ```
 
-Use `WebAPI.Window.current` for the browser `window`. Interface-specific methods live on
+Use `WebAPI.DOM.window` for the browser `window`. Interface-specific methods live on
 public modules such as `WebAPI.Window`, `WebAPI.Location`, `WebAPI.Document`,
 `WebAPI.Element`, `WebAPI.Request`, and `WebAPI.Response`.
 
 ```ReScript
-let location = WebAPI.Window.current->WebAPI.Window.location
+let location = WebAPI.DOM.window->WebAPI.Window.location
 let href = location.href
 
 location->WebAPI.Location.reload
@@ -32,7 +32,7 @@ helper modules.
 ```ReScript
 let req: WebAPI.Request.t = WebAPI.Request.fromURL("https://example.com")
 let headers = WebAPI.Headers.make()
-let document = WebAPI.Window.current->WebAPI.Window.document
+let document = WebAPI.DOM.window->WebAPI.Window.document
 let element = document->WebAPI.Document.createElement("button")
 ```
 
@@ -243,7 +243,7 @@ let redirect = WebAPI.Response.redirect(~url="/login", ~status=302)
 DOM values are operated on through public interface modules.
 
 ```ReScript
-let document = WebAPI.Window.current->WebAPI.Window.document
+let document = WebAPI.DOM.window->WebAPI.Window.document
 
 let maybeButton = document
 ->WebAPI.Document.querySelector("button")
@@ -271,7 +271,7 @@ let node = element->WebAPI.Element.asNode
 `Window.visualViewport` returns a nullable `WebAPI.VisualViewport.t`.
 
 ```ReScript
-let maybeViewport = WebAPI.Window.current
+let maybeViewport = WebAPI.DOM.window
 ->WebAPI.Window.visualViewport
 ->Null.toOption
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -51,7 +51,7 @@ export const rescriptJson = `
 After installing the package , you can use bindings for the various Web APIs as defined in [MDN](https://developer.mozilla.org/en-US/docs/Web/API).
 
 export const rescriptSample = `
-let location = WebAPI.Window.current->WebAPI.Window.location
+let location = WebAPI.DOM.window->WebAPI.Window.location
 
 // Access properties using \`.\`
 let href = location.href

--- a/src/Base/DOM.res
+++ b/src/Base/DOM.res
@@ -27,7 +27,9 @@ type domStringList = {
   length: int,
 }
 
-type window
+@editor.completeFrom(Window)
+type window = private {}
+external window: window = "window"
 
 type shadowRootMode =
   | @as("closed") Closed

--- a/tests/DOMAPI/Event__test.res
+++ b/tests/DOMAPI/Event__test.res
@@ -25,4 +25,4 @@ let fn = (target: DOM.eventTarget) =>
 let x = fn(target)
 
 // Testing out global event listeners
-Window.current->Window.addEventListener(Click, () => Console.log("Click 2"))
+DOM.window->Window.addEventListener(Click, () => Console.log("Click 2"))

--- a/tests/DOMAPI/Location__test.res
+++ b/tests/DOMAPI/Location__test.res
@@ -1,4 +1,5 @@
-let location = DomGlobal.document.location
+let window = DOM.window
+let location = window->Window.location
 
 // Access properties using `.`
 let href = location.href

--- a/tests/Fetch__test.res
+++ b/tests/Fetch__test.res
@@ -26,7 +26,7 @@ let response3 = await Fetch.fetchWithRequest(
   },
 )
 
-Window.current->Window.removeEventListener(
+DOM.window->Window.removeEventListener(
   EventType.Mousedown,
   MouseEvent.preventDefault,
   ~options={capture: false},

--- a/tests/VisualViewport__test.res
+++ b/tests/VisualViewport__test.res
@@ -1,1 +1,1 @@
-let maybeViewport: Null.t<VisualViewport.t> = Window.current->Window.visualViewport
+let maybeViewport: Null.t<VisualViewport.t> = DOM.window->Window.visualViewport


### PR DESCRIPTION
Tracking issue: #342

## Summary

- expose the browser global as `WebAPI.DOM.window`
- migrate examples and API documentation from `WebAPI.Window.current` to the shared DOM value
- cover event, location, fetch, and visual-viewport usage through `DOM.window`
- retain `Window.current` for source compatibility

## Temporary state

- `Window.t` is still backed by the broad `DomTypes.window` definition in this layer; #310 moves the remaining window types out of `DomTypes` and deletes that compatibility module
- `DOM.window` itself is the intended foundational entry point, not temporary scaffolding
- physical folder ownership and the partial feature map are completed in the follow-up Option 5 stack

## Review focus

- the canonical browser-global entry point and documentation migration
- preserving the existing `Window.current` API while consumers move to `DOM.window`

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`