### PR TITLE
refactor: introduce DOMTree compatibility foundation

### DIFF
--- a/rescript.json
+++ b/rescript.json
@@ -95,6 +95,7 @@
         "DOMRectReadOnly",
         "DOMStringList",
         "DOMTokenList",
+        "DOMTree",
         "Document",
         "DocumentFragment",
         "DocumentTimeline",

--- a/src/DOM/DOMStringMap.res
+++ b/src/DOM/DOMStringMap.res
@@ -2,4 +2,4 @@
 Used by the dataset HTML attribute to represent data for custom attributes added to elements.
 [See DOMStringMap on MDN](https://developer.mozilla.org/docs/Web/API/DOMStringMap)
 */
-type t = {}
+type t = private {}

--- a/src/DOM/DOMStringMap.res
+++ b/src/DOM/DOMStringMap.res
@@ -1,0 +1,5 @@
+/**
+Used by the dataset HTML attribute to represent data for custom attributes added to elements.
+[See DOMStringMap on MDN](https://developer.mozilla.org/docs/Web/API/DOMStringMap)
+*/
+type t = {}

--- a/src/DOM/DOMTree.res
+++ b/src/DOM/DOMTree.res
@@ -1,0 +1,20 @@
+/**
+ * Compatibility aliases for the recursive DOM interface family.
+ *
+ * Keeping these aliases in one module lets interface modules migrate from
+ * DOM/DomTypes independently. The aliases are replaced with the concrete
+ * recursive definitions once all consumers use DOMTree.
+ */
+type shadowRootMode = DOM.shadowRootMode
+type slotAssignmentMode = DOM.slotAssignmentMode
+type customStateSet = DOM.customStateSet
+
+type node = DOM.node
+type element = DOM.element
+type documentFragment = DOM.documentFragment
+type shadowRoot = DOM.shadowRoot
+type htmlElement = DOM.htmlElement
+type htmlFormElement = DOM.htmlFormElement
+type htmlFormControlsCollection = DOM.htmlFormControlsCollection
+type htmlSlotElement = DOM.htmlSlotElement
+type elementInternals = DOM.elementInternals

--- a/src/DOM/DOMTree.res
+++ b/src/DOM/DOMTree.res
@@ -1,9 +1,10 @@
 /**
  * Compatibility aliases for the recursive DOM interface family.
  *
- * Keeping these aliases in one module lets interface modules migrate from
- * DOM/DomTypes independently. The aliases are replaced with the concrete
- * recursive definitions once all consumers use DOMTree.
+ * DOMTree and these public type names are permanent; only the aliases below
+ * are temporary. PRs #302 through #308 migrate consumers from DOM/DomTypes,
+ * then PR #310 replaces the aliases in place with concrete recursive
+ * definitions and removes their old DOM/DomTypes definitions.
  */
 type shadowRootMode = DOM.shadowRootMode
 type slotAssignmentMode = DOM.slotAssignmentMode

--- a/src/DOM/HTMLCollection.res
+++ b/src/DOM/HTMLCollection.res
@@ -1,13 +1,25 @@
 /**
+A generic collection (array-like object similar to arguments) of elements (in document order) and offers methods and properties for selecting from the list.
+[See HTMLCollection on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection)
+*/
+type t<'item> = private {
+  /**
+    Sets or retrieves the number of objects in a collection.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/length)
+    */
+  length: int,
+}
+
+/**
 Retrieves an object from various collections.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/item)
 */
 @send
-external item: (DomTypes.htmlCollection<'t>, int) => 't = "item"
+external item: (t<'item>, int) => 'item = "item"
 
 /**
 Retrieves a select object or an object from an options collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/namedItem)
 */
 @send
-external namedItem: (DomTypes.htmlCollection<'t>, string) => 't = "namedItem"
+external namedItem: (t<'item>, string) => 'item = "namedItem"


### PR DESCRIPTION
Tracking issue: #342

## Summary

- add the public `DOMTree` module with aliases for the recursive DOM interface family
- add `DOMStringMap.t` and make `HTMLCollection.t` generic
- establish a buildable boundary so interface modules can migrate independently

## Temporary state

- every type alias in the initial `DOMTree` module is compatibility scaffolding
- #302 through #308 migrate consumers onto that boundary
- #310 replaces the aliases with concrete recursive definitions and removes their old `DOM`/`DomTypes` sources atomically

## Review focus

- whether the alias bridge is behavior-neutral
- whether it provides the minimum boundary required for the following incremental migrations

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`