### PR TITLE
refactor: migrate core DOM tree interfaces

### DIFF
--- a/src/DOM/AbstractRange.res
+++ b/src/DOM/AbstractRange.res
@@ -1,0 +1,30 @@
+/**
+[See AbstractRange on MDN](https://developer.mozilla.org/docs/Web/API/AbstractRange)
+*/
+type t = {
+  /**
+    Returns range's start node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AbstractRange/startContainer)
+    */
+  startContainer: DOMTree.node,
+  /**
+    Returns range's start offset.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AbstractRange/startOffset)
+    */
+  startOffset: int,
+  /**
+    Returns range's end node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AbstractRange/endContainer)
+    */
+  endContainer: DOMTree.node,
+  /**
+    Returns range's end offset.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AbstractRange/endOffset)
+    */
+  endOffset: int,
+  /**
+    Returns true if range is collapsed, and false otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AbstractRange/collapsed)
+    */
+  collapsed: bool,
+}

--- a/src/DOM/Attr.res
+++ b/src/DOM/Attr.res
@@ -1,14 +1,8 @@
 /**
-An object providing methods which are not dependent on any particular document. Such an object is returned by the Document.implementation property.
-[See DOMImplementation on MDN](https://developer.mozilla.org/docs/Web/API/DOMImplementation)
+A WebApiDOM element's attribute as an object. In most WebApiDOM methods, you will probably directly retrieve the attribute as a string (e.g., Element.getAttribute(), but certain functions (e.g., Element.getAttributeNode()) or means of iterating give Attr types.
+[See Attr on MDN](https://developer.mozilla.org/docs/Web/API/Attr)
 */
-type t = private {}
-
-/**
-A Node containing a doctype.
-[See DocumentType on MDN](https://developer.mozilla.org/docs/Web/API/DocumentType)
-*/
-type documentType = {
+type t = {
   // Base properties from Node
   /**
     Returns the type of node.
@@ -81,51 +75,27 @@ type documentType = {
   // End base properties from Node
 
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentType/name)
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Attr/namespaceURI)
+    */
+  namespaceURI: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Attr/prefix)
+    */
+  prefix: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Attr/localName)
+    */
+  localName: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Attr/name)
     */
   name: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentType/publicId)
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Attr/value)
     */
-  publicId: string,
+  mutable value: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentType/systemId)
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Attr/ownerElement)
     */
-  systemId: string,
+  ownerElement: Null.t<DOMTree.element>,
 }
-
-/**
-An XML document. It inherits from the generic Document and does not add any specific methods or properties to it: nevertheless, several algorithms behave differently with the two types of documents.
-[See XMLDocument on MDN](https://developer.mozilla.org/docs/Web/API/XMLDocument)
-*/
-type xmlDocument = {
-  ...DOM.document,
-}
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMImplementation/createDocumentType)
-*/
-@send
-external createDocumentType: (
-  t,
-  ~qualifiedName: string,
-  ~publicId: string,
-  ~systemId: string,
-) => documentType = "createDocumentType"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMImplementation/createDocument)
-*/
-@send
-external createDocument: (
-  t,
-  ~namespace: string,
-  ~qualifiedName: string,
-  ~doctype: documentType=?,
-) => xmlDocument = "createDocument"
-
-/**
-[Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMImplementation/createHTMLDocument)
-*/
-@send
-external createHTMLDocument: (t, ~title: string=?) => DOM.document = "createHTMLDocument"

--- a/src/DOM/CDATASection.res
+++ b/src/DOM/CDATASection.res
@@ -1,0 +1,7 @@
+/**
+A CDATA section that can be used within XML to include extended portions of unescaped text. The symbols < and & don't need escaping as they normally do when inside a CDATA section.
+[See CDATASection on MDN](https://developer.mozilla.org/docs/Web/API/CDATASection)
+*/
+type t = {
+  ...Text.t,
+}

--- a/src/DOM/CharacterData.res
+++ b/src/DOM/CharacterData.res
@@ -1,3 +1,100 @@
+/**
+The CharacterData abstract interface represents a Node object that contains characters. This is an abstract interface, meaning there aren't any object of type CharacterData: it is implemented by other interfaces, like Text, Comment, or ProcessingInstruction which aren't abstract.
+[See CharacterData on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  // Base properties from Node
+  /**
+    Returns the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeType)
+    */
+  nodeType: int,
+  /**
+    Returns a string appropriate for the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeName)
+    */
+  nodeName: string,
+  /**
+    Returns node's node document's document base URL.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/baseURI)
+    */
+  baseURI: string,
+  /**
+    Returns true if node is connected and false otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/isConnected)
+    */
+  isConnected: bool,
+  /**
+    Returns the node document. Returns null for documents.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/ownerDocument)
+    */
+  ownerDocument: Null.t<DOM.document>,
+  /**
+    Returns the parent.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentNode)
+    */
+  parentNode: Null.t<DOMTree.node>,
+  /**
+    Returns the parent element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentElement)
+    */
+  parentElement: Null.t<DOMTree.htmlElement>,
+  /**
+    Returns the children.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/childNodes)
+    */
+  childNodes: DOM.nodeList<DOMTree.node>,
+  /**
+    Returns the first child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/firstChild)
+    */
+  firstChild: Null.t<DOMTree.node>,
+  /**
+    Returns the last child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/lastChild)
+    */
+  lastChild: Null.t<DOMTree.node>,
+  /**
+    Returns the previous sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/previousSibling)
+    */
+  previousSibling: Null.t<DOMTree.node>,
+  /**
+    Returns the next sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nextSibling)
+    */
+  nextSibling: Null.t<DOMTree.node>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeValue)
+    */
+  mutable nodeValue: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/textContent)
+    */
+  mutable textContent: Null.t<string>,
+  // End base properties from Node
+
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/data)
+    */
+  mutable data: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/length)
+    */
+  length: int,
+  /**
+    Returns the first preceding sibling that is an element, and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/previousElementSibling)
+    */
+  previousElementSibling: Null.t<DOMTree.element>,
+  /**
+    Returns the first following sibling that is an element, and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/nextElementSibling)
+    */
+  nextElementSibling: Null.t<DOMTree.element>,
+}
+
 module Impl = (
   T: {
     type t
@@ -5,7 +102,7 @@ module Impl = (
 ) => {
   include Node.Impl({type t = T.t})
 
-  external asCharacterData: T.t => DomTypes.characterData = "%identity"
+  external asCharacterData: T.t => t = "%identity"
 
   /**
 Inserts nodes just after node, while replacing strings in nodes with equivalent Text nodes.
@@ -14,7 +111,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/after)
 */
   @send
-  external after: (T.t, DomTypes.node) => unit = "after"
+  external after: (T.t, DOMTree.node) => unit = "after"
 
   /**
 Inserts nodes just after node, while replacing strings in nodes with equivalent Text nodes.
@@ -38,7 +135,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/before)
 */
   @send
-  external before: (T.t, DomTypes.node) => unit = "before"
+  external before: (T.t, DOMTree.node) => unit = "before"
 
   /**
 Inserts nodes just before node, while replacing strings in nodes with equivalent Text nodes.
@@ -81,7 +178,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
 */
   @send
-  external replaceWith: (T.t, DomTypes.node) => unit = "replaceWith"
+  external replaceWith: (T.t, DOMTree.node) => unit = "replaceWith"
 
   /**
 Replaces node with nodes, while replacing strings in nodes with equivalent Text nodes.
@@ -99,4 +196,4 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
   external substringData: (T.t, ~offset: int, ~count: int) => string = "substringData"
 }
 
-include Impl({type t = DomTypes.characterData})
+include Impl({type t = t})

--- a/src/DOM/Comment.res
+++ b/src/DOM/Comment.res
@@ -1,7 +1,15 @@
-include CharacterData.Impl({type t = DomTypes.comment})
+/**
+Textual notations within markup; although it is generally not visually shown, such comments are available to be read in the source view.
+[See Comment on MDN](https://developer.mozilla.org/docs/Web/API/Comment)
+*/
+type t = private {
+  ...CharacterData.t,
+}
+
+include CharacterData.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Comment)
 */
 @new
-external make: (~data: string=?) => DomTypes.comment = "Comment"
+external make: (~data: string=?) => t = "Comment"

--- a/src/DOM/Document.res
+++ b/src/DOM/Document.res
@@ -11,7 +11,7 @@ Returns the first element within node's descendants whose ID is elementId.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getElementById)
 */
 @send
-external getElementById: (DOM.document, string) => null<DOM.element> = "getElementById"
+external getElementById: (DOM.document, string) => null<DOMTree.element> = "getElementById"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getAnimations)
@@ -26,7 +26,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/prepend)
 */
 @send
-external prepend: (DOM.document, DOM.node) => unit = "prepend"
+external prepend: (DOM.document, DOMTree.node) => unit = "prepend"
 
 /**
 Inserts nodes before the first child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -44,7 +44,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/append)
 */
 @send
-external append: (DOM.document, DOM.node) => unit = "append"
+external append: (DOM.document, DOMTree.node) => unit = "append"
 
 /**
 Inserts nodes after the last child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -62,7 +62,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
 */
 @send
-external replaceChildren: (DOM.document, DOM.node) => unit = "replaceChildren"
+external replaceChildren: (DOM.document, DOMTree.node) => unit = "replaceChildren"
 
 /**
 Replace all children of node with nodes, while replacing strings in nodes with equivalent Text nodes.
@@ -78,14 +78,15 @@ Returns the first element that is a descendant of node that matches selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/querySelector)
 */
 @send
-external querySelector: (DOM.document, string) => Null.t<DOM.element> = "querySelector"
+external querySelector: (DOM.document, string) => Null.t<DOMTree.element> = "querySelector"
 
 /**
 Returns all element descendants of node that match selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/querySelectorAll)
 */
 @send
-external querySelectorAll: (DOM.document, string) => DOM.nodeList<DOM.element> = "querySelectorAll"
+external querySelectorAll: (DOM.document, string) => DOM.nodeList<DOMTree.element> =
+  "querySelectorAll"
 
 /**
 This method compiles an XPathExpression which can then be used for (repeated) evaluations.
@@ -109,7 +110,7 @@ external createExpression: (
 external evaluate: (
   DOM.document,
   ~expression: string,
-  ~contextNode: DOM.node,
+  ~contextNode: DOMTree.node,
   ~resolver: Null.t<string> => Null.t<string>=?,
   ~type_: int=?,
   ~result: XPathResult.t=?,
@@ -121,7 +122,7 @@ Retrieves a collection of objects based on the specified element name.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getElementsByTagName)
 */
 @send
-external getElementsByTagName: (DOM.document, string) => DOM.htmlCollection<DOM.element> =
+external getElementsByTagName: (DOM.document, string) => HTMLCollection.t<DOMTree.element> =
   "getElementsByTagName"
 
 /**
@@ -139,14 +140,14 @@ external getElementsByTagNameNS: (
   DOM.document,
   ~namespace: string,
   ~localName: string,
-) => DOM.htmlCollection<DOM.element> = "getElementsByTagNameNS"
+) => HTMLCollection.t<DOMTree.element> = "getElementsByTagNameNS"
 
 /**
 Returns a HTMLCollection of the elements in the object on which the method was invoked (a document or an element) that have all the classes given by classNames. The classNames argument is interpreted as a space-separated list of classes.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getElementsByClassName)
 */
 @send
-external getElementsByClassName: (DOM.document, string) => DOM.htmlCollection<DOM.element> =
+external getElementsByClassName: (DOM.document, string) => HTMLCollection.t<DOMTree.element> =
   "getElementsByClassName"
 
 type elementCreationOptions = {mutable is?: string}
@@ -156,8 +157,11 @@ Creates an instance of the element for the specified tag.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createElement)
 */
 @send
-external createElement: (DOM.document, string, ~options: elementCreationOptions=?) => DOM.element =
-  "createElement"
+external createElement: (
+  DOM.document,
+  string,
+  ~options: elementCreationOptions=?,
+) => DOMTree.element = "createElement"
 
 /**
 Returns an element with namespace namespace. Its namespace prefix will be everything before ":" (U+003E) in qualifiedName or null. Its local name will be everything after ":" (U+003E) in qualifiedName or qualifiedName.
@@ -181,7 +185,7 @@ external createElementNS: (
   ~namespace: string,
   ~qualifiedName: string,
   ~options: string=?,
-) => DOM.element = "createElementNS"
+) => DOMTree.element = "createElementNS"
 
 /**
 Returns an element with namespace namespace. Its namespace prefix will be everything before ":" (U+003E) in qualifiedName or null. Its local name will be everything after ":" (U+003E) in qualifiedName or qualifiedName.
@@ -205,14 +209,14 @@ external createElementNS2: (
   ~namespace: string,
   ~qualifiedName: string,
   ~options: elementCreationOptions=?,
-) => DOM.element = "createElementNS"
+) => DOMTree.element = "createElementNS"
 
 /**
 Creates a new document.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createDocumentFragment)
 */
 @send
-external createDocumentFragment: DOM.document => DOM.documentFragment = "createDocumentFragment"
+external createDocumentFragment: DOM.document => DOMTree.documentFragment = "createDocumentFragment"
 
 /**
 Creates a text string from the specified value.
@@ -220,14 +224,14 @@ Creates a text string from the specified value.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createTextNode)
 */
 @send
-external createTextNode: (DOM.document, string) => DOM.text = "createTextNode"
+external createTextNode: (DOM.document, string) => Text.t = "createTextNode"
 
 /**
 Returns a CDATASection node whose data is data.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createCDATASection)
 */
 @send
-external createCDATASection: (DOM.document, string) => DOM.cdataSection = "createCDATASection"
+external createCDATASection: (DOM.document, string) => CDATASection.t = "createCDATASection"
 
 /**
 Creates a comment object with the specified data.
@@ -235,7 +239,7 @@ Creates a comment object with the specified data.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createComment)
 */
 @send
-external createComment: (DOM.document, string) => DOM.comment = "createComment"
+external createComment: (DOM.document, string) => Comment.t = "createComment"
 
 /**
 Returns a ProcessingInstruction node whose target is target and data is data. If target does not match the Name production an "InvalidCharacterError" DOMException will be thrown. If data contains "?>" an "InvalidCharacterError" DOMException will be thrown.
@@ -246,7 +250,7 @@ external createProcessingInstruction: (
   DOM.document,
   ~target: string,
   ~data: string,
-) => DOM.processingInstruction = "createProcessingInstruction"
+) => ProcessingInstruction.t = "createProcessingInstruction"
 
 /**
 Returns a copy of node. If deep is true, the copy also includes the node's descendants.
@@ -272,13 +276,13 @@ Creates an attribute object with a specified name.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createAttribute)
 */
 @send
-external createAttribute: (DOM.document, string) => DOM.attr = "createAttribute"
+external createAttribute: (DOM.document, string) => Attr.t = "createAttribute"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createAttributeNS)
 */
 @send
-external createAttributeNS: (DOM.document, ~namespace: string, ~qualifiedName: string) => DOM.attr =
+external createAttributeNS: (DOM.document, ~namespace: string, ~qualifiedName: string) => Attr.t =
   "createAttributeNS"
 
 /**
@@ -292,7 +296,7 @@ external createEvent: (DOM.document, string) => DOM.event = "createEvent"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createRange)
 */
 @send
-external createRange: DOM.document => DOM.range = "createRange"
+external createRange: DOM.document => Range.t = "createRange"
 
 /**
 Creates a NodeIterator object that you can use to traverse filtered lists of nodes or elements in a document.
@@ -304,10 +308,10 @@ Creates a NodeIterator object that you can use to traverse filtered lists of nod
 @send
 external createNodeIterator: (
   DOM.document,
-  ~root: DOM.node,
+  ~root: DOMTree.node,
   ~whatToShow: int=?,
-  ~filter: DOM.nodeFilter=?,
-) => DOM.nodeIterator = "createNodeIterator"
+  ~filter: NodeFilter.t=?,
+) => NodeIterator.t = "createNodeIterator"
 
 /**
 Creates a TreeWalker object that you can use to traverse filtered lists of nodes or elements in a document.
@@ -319,10 +323,10 @@ Creates a TreeWalker object that you can use to traverse filtered lists of nodes
 @send
 external createTreeWalker: (
   DOM.document,
-  ~root: DOM.node,
+  ~root: DOMTree.node,
   ~whatToShow: int=?,
-  ~filter: DOM.nodeFilter=?,
-) => DOM.treeWalker = "createTreeWalker"
+  ~filter: NodeFilter.t=?,
+) => TreeWalker.t = "createTreeWalker"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/startViewTransition)
@@ -333,7 +337,7 @@ external startViewTransition: (
   ~callbackOptions: ViewTransitionsTypes.viewTransitionUpdateCallback=?,
 ) => ViewTransitionsTypes.viewTransition = "startViewTransition"
 
-type caretPositionFromPointOptions = {mutable shadowRoots?: array<DOM.shadowRoot>}
+type caretPositionFromPointOptions = {mutable shadowRoots?: array<DOMTree.shadowRoot>}
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/caretPositionFromPoint)
@@ -365,7 +369,7 @@ Gets a collection of objects based on the value of the NAME or ID attribute.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getElementsByName)
 */
 @send
-external getElementsByName: (DOM.document, string) => DOM.nodeList<DOM.htmlElement> =
+external getElementsByName: (DOM.document, string) => DOM.nodeList<DOMTree.htmlElement> =
   "getElementsByName"
 
 /**
@@ -438,7 +442,7 @@ Returns an object representing the current selection of the document that is loa
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getSelection)
 */
 @send
-external getSelection: DOM.document => null<DOM.selection> = "getSelection"
+external getSelection: DOM.document => null<Selection.t> = "getSelection"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess)

--- a/src/DOM/DocumentFragment.res
+++ b/src/DOM/DocumentFragment.res
@@ -2,7 +2,7 @@
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragmentFragment)
 */
 @new
-external make: unit => DomTypes.documentFragment = "DocumentFragment"
+external make: unit => DOMTree.documentFragment = "DocumentFragment"
 
 module Impl = (
   T: {
@@ -11,7 +11,7 @@ module Impl = (
 ) => {
   include Node.Impl({type t = T.t})
 
-  external asDocumentFragment: T.t => DomTypes.documentFragment = "%identity"
+  external asDocumentFragment: T.t => DOMTree.documentFragment = "%identity"
 
   /**
 Inserts nodes after the last child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -20,7 +20,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/append)
 */
   @send
-  external append: (T.t, DomTypes.node) => unit = "append"
+  external append: (T.t, DOMTree.node) => unit = "append"
 
   /**
 Inserts nodes after the last child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -36,7 +36,7 @@ Returns the first element within node's descendants whose ID is elementId.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/getElementById)
 */
   @send
-  external getElementById: (T.t, string) => null<DomTypes.element> = "getElementById"
+  external getElementById: (T.t, string) => null<DOMTree.element> = "getElementById"
 
   /**
 Inserts nodes before the first child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -45,7 +45,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/prepend)
 */
   @send
-  external prepend: (T.t, DomTypes.node) => unit = "prepend"
+  external prepend: (T.t, DOMTree.node) => unit = "prepend"
 
   /**
 Inserts nodes before the first child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -61,15 +61,14 @@ Returns the first element that is a descendant of node that matches selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/querySelector)
 */
   @send
-  external querySelector: (T.t, string) => Null.t<DomTypes.element> = "querySelector"
+  external querySelector: (T.t, string) => Null.t<DOMTree.element> = "querySelector"
 
   /**
 Returns all element descendants of node that match selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/querySelectorAll)
 */
   @send
-  external querySelectorAll: (T.t, string) => DomTypes.nodeList<DomTypes.element> =
-    "querySelectorAll"
+  external querySelectorAll: (T.t, string) => DOM.nodeList<DOMTree.element> = "querySelectorAll"
 
   /**
 Replace all children of node with nodes, while replacing strings in nodes with equivalent Text nodes.
@@ -78,7 +77,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/replaceChildren)
 */
   @send
-  external replaceChildren: (T.t, DomTypes.node) => unit = "replaceChildren"
+  external replaceChildren: (T.t, DOMTree.node) => unit = "replaceChildren"
 
   /**
 Replace all children of node with nodes, while replacing strings in nodes with equivalent Text nodes.
@@ -90,4 +89,4 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
   external replaceChildren2: (T.t, string) => unit = "replaceChildren"
 }
 
-include Impl({type t = DomTypes.documentFragment})
+include Impl({type t = DOMTree.documentFragment})

--- a/src/DOM/Element.res
+++ b/src/DOM/Element.res
@@ -5,7 +5,7 @@ module Impl = (
 ) => {
   include Node.Impl({type t = T.t})
 
-  external asElement: T.t => DomTypes.element = "%identity"
+  external asElement: T.t => DOMTree.element = "%identity"
 
   /**
 Inserts nodes just after node, while replacing strings in nodes with equivalent Text nodes.
@@ -14,7 +14,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/after)
 */
   @send
-  external after: (T.t, DomTypes.node) => unit = "after"
+  external after: (T.t, DOMTree.node) => unit = "after"
 
   /**
 Inserts nodes just after node, while replacing strings in nodes with equivalent Text nodes.
@@ -48,7 +48,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/append)
 */
   @send
-  external append: (T.t, DomTypes.node) => unit = "append"
+  external append: (T.t, DOMTree.node) => unit = "append"
 
   /**
 Inserts nodes after the last child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -64,7 +64,7 @@ Creates a shadow root for element and returns it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/attachShadow)
 */
   @send
-  external attachShadow: (T.t, DomTypes.shadowRootInit) => DomTypes.shadowRoot = "attachShadow"
+  external attachShadow: (T.t, DomTypes.shadowRootInit) => DOMTree.shadowRoot = "attachShadow"
 
   /**
 Inserts nodes just before node, while replacing strings in nodes with equivalent Text nodes.
@@ -73,7 +73,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/before)
 */
   @send
-  external before: (T.t, DomTypes.node) => unit = "before"
+  external before: (T.t, DOMTree.node) => unit = "before"
 
   /**
 Inserts nodes just before node, while replacing strings in nodes with equivalent Text nodes.
@@ -102,7 +102,7 @@ Returns the first (starting at element) inclusive ancestor that matches selector
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/computedStyleMap)
 */
   @send
-  external computedStyleMap: T.t => DomTypes.stylePropertyMapReadOnly = "computedStyleMap"
+  external computedStyleMap: T.t => DOM.stylePropertyMapReadOnly = "computedStyleMap"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getAnimations)
@@ -129,13 +129,13 @@ Returns the qualified names of all element's attributes. Can contain duplicates.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getAttributeNode)
 */
   @send
-  external getAttributeNode: (T.t, string) => DomTypes.attr = "getAttributeNode"
+  external getAttributeNode: (T.t, string) => Attr.t = "getAttributeNode"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getAttributeNodeNS)
 */
   @send
-  external getAttributeNodeNS: (T.t, ~namespace: string, ~localName: string) => DomTypes.attr =
+  external getAttributeNodeNS: (T.t, ~namespace: string, ~localName: string) => Attr.t =
     "getAttributeNodeNS"
 
   /**
@@ -150,27 +150,27 @@ Returns element's attribute whose namespace is namespace and local name is local
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getBoundingClientRect)
 */
   @send
-  external getBoundingClientRect: T.t => DomTypes.domRect = "getBoundingClientRect"
+  external getBoundingClientRect: T.t => DOM.domRect = "getBoundingClientRect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getClientRects)
 */
   @send
-  external getClientRects: T.t => DomTypes.domRectList = "getClientRects"
+  external getClientRects: T.t => DOM.domRectList = "getClientRects"
 
   /**
 Returns a HTMLCollection of the elements in the object on which the method was invoked (a document or an element) that have all the classes given by classNames. The classNames argument is interpreted as a space-separated list of classes.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getElementsByClassName)
 */
   @send
-  external getElementsByClassName: (T.t, string) => DomTypes.htmlCollection<DomTypes.element> =
+  external getElementsByClassName: (T.t, string) => HTMLCollection.t<DOMTree.element> =
     "getElementsByClassName"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getElementsByTagName)
 */
   @send
-  external getElementsByTagName: (T.t, string) => DomTypes.htmlCollection<DomTypes.element> =
+  external getElementsByTagName: (T.t, string) => HTMLCollection.t<DOMTree.element> =
     "getElementsByTagName"
 
   /**
@@ -178,10 +178,10 @@ Returns a HTMLCollection of the elements in the object on which the method was i
 */
   @send
   external getElementsByTagNameNS: (
-    DomTypes.element,
+    DOMTree.element,
     ~namespace: string,
     ~localName: string,
-  ) => DomTypes.htmlCollection<DomTypes.element> = "getElementsByTagNameNS"
+  ) => HTMLCollection.t<DOMTree.element> = "getElementsByTagNameNS"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getHTML)
@@ -222,22 +222,22 @@ Returns true if element has attributes, and false otherwise.
   @send
   external insertAdjacentElement: (
     T.t,
-    ~where: DomTypes.insertPosition,
-    ~element: DomTypes.element,
-  ) => DomTypes.element = "insertAdjacentElement"
+    ~where: DOM.insertPosition,
+    ~element: DOMTree.element,
+  ) => DOMTree.element = "insertAdjacentElement"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentHTML)
 */
   @send
-  external insertAdjacentHTML: (T.t, ~position: DomTypes.insertPosition, ~string: string) => unit =
+  external insertAdjacentHTML: (T.t, ~position: DOM.insertPosition, ~string: string) => unit =
     "insertAdjacentHTML"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentText)
 */
   @send
-  external insertAdjacentText: (T.t, ~where: DomTypes.insertPosition, ~data: string) => unit =
+  external insertAdjacentText: (T.t, ~where: DOM.insertPosition, ~data: string) => unit =
     "insertAdjacentText"
 
   /**
@@ -254,7 +254,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/prepend)
 */
   @send
-  external prepend: (T.t, DomTypes.node) => unit = "prepend"
+  external prepend: (T.t, DOMTree.node) => unit = "prepend"
 
   /**
 Inserts nodes before the first child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -270,15 +270,14 @@ Returns the first element that is a descendant of node that matches selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/querySelector)
 */
   @send
-  external querySelector: (T.t, string) => Null.t<DomTypes.element> = "querySelector"
+  external querySelector: (T.t, string) => Null.t<DOMTree.element> = "querySelector"
 
   /**
 Returns all element descendants of node that match selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/querySelectorAll)
 */
   @send
-  external querySelectorAll: (T.t, string) => DomTypes.nodeList<DomTypes.element> =
-    "querySelectorAll"
+  external querySelectorAll: (T.t, string) => DOM.nodeList<DOMTree.element> = "querySelectorAll"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/releasePointerCapture)
@@ -304,7 +303,7 @@ Removes element's first attribute whose qualified name is qualifiedName.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/removeAttributeNode)
 */
   @send
-  external removeAttributeNode: (T.t, DomTypes.attr) => DomTypes.attr = "removeAttributeNode"
+  external removeAttributeNode: (T.t, Attr.t) => Attr.t = "removeAttributeNode"
 
   /**
 Removes element's attribute whose namespace is namespace and local name is localName.
@@ -321,7 +320,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
 */
   @send
-  external replaceChildren: (T.t, DomTypes.node) => unit = "replaceChildren"
+  external replaceChildren: (T.t, DOMTree.node) => unit = "replaceChildren"
 
   /**
 Replace all children of node with nodes, while replacing strings in nodes with equivalent Text nodes.
@@ -339,7 +338,7 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
 */
   @send
-  external replaceWith: (T.t, DomTypes.node) => unit = "replaceWith"
+  external replaceWith: (T.t, DOMTree.node) => unit = "replaceWith"
 
   /**
 Replaces node with nodes, while replacing strings in nodes with equivalent Text nodes.
@@ -457,13 +456,13 @@ Sets the value of element's first attribute whose qualified name is qualifiedNam
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNode)
 */
   @send
-  external setAttributeNode: (T.t, DomTypes.attr) => DomTypes.attr = "setAttributeNode"
+  external setAttributeNode: (T.t, Attr.t) => Attr.t = "setAttributeNode"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNodeNS)
 */
   @send
-  external setAttributeNodeNS: (T.t, DomTypes.attr) => DomTypes.attr = "setAttributeNodeNS"
+  external setAttributeNodeNS: (T.t, Attr.t) => Attr.t = "setAttributeNodeNS"
 
   /**
 Sets the value of element's attribute whose namespace is namespace and local name is localName to value.
@@ -471,7 +470,7 @@ Sets the value of element's attribute whose namespace is namespace and local nam
 */
   @send
   external setAttributeNS: (
-    DomTypes.element,
+    DOMTree.element,
     ~namespace: string,
     ~qualifiedName: string,
     ~value: string,
@@ -500,6 +499,6 @@ Returns true if qualifiedName is now present, and false otherwise.
     "toggleAttribute"
 }
 
-include Impl({type t = DomTypes.element})
+include Impl({type t = DOMTree.element})
 
 let isInstanceOf = (_: 't): bool => %raw(`param instanceof Element`)

--- a/src/DOM/ElementInternals.res
+++ b/src/DOM/ElementInternals.res
@@ -5,7 +5,7 @@ If value is null, the element won't participate in form submission.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ElementInternals/setFormValue)
 */
 @send
-external setFormValue: (DomTypes.elementInternals, ~value: unknown, ~state: unknown=?) => unit =
+external setFormValue: (DOMTree.elementInternals, ~value: unknown, ~state: unknown=?) => unit =
   "setFormValue"
 
 /**
@@ -14,10 +14,10 @@ Marks internals's target element as suffering from the constraints indicated by 
 */
 @send
 external setValidity: (
-  DomTypes.elementInternals,
+  DOMTree.elementInternals,
   ~flags: DomTypes.validityStateFlags=?,
   ~message: string=?,
-  ~anchor: DomTypes.htmlElement=?,
+  ~anchor: DOMTree.htmlElement=?,
 ) => unit = "setValidity"
 
 /**
@@ -25,11 +25,11 @@ Returns true if internals's target element has no validity problems; false other
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ElementInternals/checkValidity)
 */
 @send
-external checkValidity: DomTypes.elementInternals => bool = "checkValidity"
+external checkValidity: DOMTree.elementInternals => bool = "checkValidity"
 
 /**
 Returns true if internals's target element has no validity problems; otherwise, returns false, fires an invalid event at the element, and (if the event isn't canceled) reports the problem to the user.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ElementInternals/reportValidity)
 */
 @send
-external reportValidity: DomTypes.elementInternals => bool = "reportValidity"
+external reportValidity: DOMTree.elementInternals => bool = "reportValidity"

--- a/src/DOM/HTMLElement.res
+++ b/src/DOM/HTMLElement.res
@@ -1,5 +1,3 @@
-type t = DomTypes.htmlElement
-
 module Impl = (
   T: {
     type t
@@ -7,13 +5,13 @@ module Impl = (
 ) => {
   include Element.Impl({type t = T.t})
 
-  external asHTMLElement: T.t => t = "%identity"
+  external asHTMLElement: T.t => DOMTree.htmlElement = "%identity"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/attachInternals)
 */
   @send
-  external attachInternals: T.t => DomTypes.elementInternals = "attachInternals"
+  external attachInternals: T.t => DOMTree.elementInternals = "attachInternals"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/blur)
@@ -52,4 +50,4 @@ module Impl = (
   external togglePopover: (T.t, ~force: bool=?) => bool = "togglePopover"
 }
 
-include Impl({type t = t})
+include Impl({type t = DOMTree.htmlElement})

--- a/src/DOM/HTMLFormControlsCollection.res
+++ b/src/DOM/HTMLFormControlsCollection.res
@@ -1,16 +1,16 @@
-external asHTMLCollection: DomTypes.htmlFormControlsCollection => DomTypes.htmlCollection<
-  DomTypes.element,
-> = "%identity"
+external asHTMLCollection: DOMTree.htmlFormControlsCollection => HTMLCollection.t<DOMTree.element> =
+  "%identity"
+
 /**
 Retrieves an object from various collections.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/item)
 */
 @send
-external item: (DomTypes.htmlFormControlsCollection, int) => DomTypes.element = "item"
+external item: (DOMTree.htmlFormControlsCollection, int) => DOMTree.element = "item"
 
 /**
 Retrieves a select object or an object from an options collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/namedItem)
 */
 @send
-external namedItem: (DomTypes.htmlFormControlsCollection, string) => DomTypes.element = "namedItem"
+external namedItem: (DOMTree.htmlFormControlsCollection, string) => DOMTree.element = "namedItem"

--- a/src/DOM/HTMLFormElement.res
+++ b/src/DOM/HTMLFormElement.res
@@ -1,6 +1,6 @@
 type t = DOMTree.htmlFormElement
 
-include HTMLElement.Impl({type t = DOMTree.htmlFormElement})
+include HTMLElement.Impl({type t = t})
 
 /**
 Fires when a FORM is about to be submitted.

--- a/src/DOM/HTMLFormElement.res
+++ b/src/DOM/HTMLFormElement.res
@@ -1,36 +1,37 @@
-type t = DomTypes.htmlFormElement
+type t = DOMTree.htmlFormElement
 
-include HTMLElement.Impl({type t = t})
+include HTMLElement.Impl({type t = DOMTree.htmlFormElement})
 
 /**
 Fires when a FORM is about to be submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/submit)
 */
 @send
-external submit: t => unit = "submit"
+external submit: DOMTree.htmlFormElement => unit = "submit"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/requestSubmit)
 */
 @send
-external requestSubmit: (t, ~submitter: HTMLElement.t=?) => unit = "requestSubmit"
+external requestSubmit: (DOMTree.htmlFormElement, ~submitter: DOMTree.htmlElement=?) => unit =
+  "requestSubmit"
 
 /**
 Fires when the user resets a form.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reset)
 */
 @send
-external reset: t => unit = "reset"
+external reset: DOMTree.htmlFormElement => unit = "reset"
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/checkValidity)
 */
 @send
-external checkValidity: t => bool = "checkValidity"
+external checkValidity: DOMTree.htmlFormElement => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reportValidity)
 */
 @send
-external reportValidity: t => bool = "reportValidity"
+external reportValidity: DOMTree.htmlFormElement => bool = "reportValidity"

--- a/src/DOM/HTMLSlotElement.res
+++ b/src/DOM/HTMLSlotElement.res
@@ -1,31 +1,290 @@
-include HTMLElement.Impl({type t = DomTypes.htmlSlotElement})
+/**
+[See HTMLSlotElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  // Base properties from HTMLElement
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/title)
+    */
+  mutable title: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/lang)
+    */
+  mutable lang: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/translate)
+    */
+  mutable translate: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/dir)
+    */
+  mutable dir: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
+    */
+  mutable hidden: unknown,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
+    */
+  mutable inert: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKey)
+    */
+  mutable accessKey: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKeyLabel)
+    */
+  accessKeyLabel: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/draggable)
+    */
+  mutable draggable: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/spellcheck)
+    */
+  mutable spellcheck: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/autocapitalize)
+    */
+  mutable autocapitalize: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/innerText)
+    */
+  mutable innerText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/outerText)
+    */
+  mutable outerText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/popover)
+    */
+  mutable popover: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetParent)
+    */
+  offsetParent: Null.t<DOMTree.element>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetTop)
+    */
+  offsetTop: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetLeft)
+    */
+  offsetLeft: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth)
+    */
+  offsetWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetHeight)
+    */
+  offsetHeight: int,
+  // End base properties from HTMLElement
+
+  // Base properties from Element
+  /**
+    Returns the namespace.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/namespaceURI)
+    */
+  namespaceURI: Null.t<string>,
+  /**
+    Returns the namespace prefix.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/prefix)
+    */
+  prefix: Null.t<string>,
+  /**
+    Returns the local name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/localName)
+    */
+  localName: string,
+  /**
+    Returns the HTML-uppercased qualified name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/tagName)
+    */
+  tagName: string,
+  /**
+    Returns the value of element's id content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/id)
+    */
+  mutable id: string,
+  /**
+    Returns the value of element's class content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/className)
+    */
+  mutable className: string,
+  /**
+    Allows for manipulation of element's class content attribute as a set of whitespace-separated tokens through a DOMTokenList object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/classList)
+    */
+  classList: DOM.domTokenList,
+  /**
+    Returns the value of element's slot content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/slot)
+    */
+  mutable slot: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/attributes)
+    */
+  attributes: DOM.namedNodeMap,
+  /**
+    Returns element's shadow root, if any, and if shadow root's mode is "open", and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/shadowRoot)
+    */
+  shadowRoot: Null.t<DOMTree.shadowRoot>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/part)
+    */
+  part: DOM.domTokenList,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollTop)
+    */
+  mutable scrollTop: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollLeft)
+    */
+  mutable scrollLeft: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollWidth)
+    */
+  scrollWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollHeight)
+    */
+  scrollHeight: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientTop)
+    */
+  clientTop: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientLeft)
+    */
+  clientLeft: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientWidth)
+    */
+  clientWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientHeight)
+    */
+  clientHeight: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/currentCSSZoom)
+    */
+  currentCSSZoom: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
+    */
+  mutable innerHTML: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
+    */
+  mutable outerHTML: string,
+  // End base properties from Element
+
+  // Base properties from Node
+  /**
+    Returns the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeType)
+    */
+  nodeType: int,
+  /**
+    Returns a string appropriate for the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeName)
+    */
+  nodeName: string,
+  /**
+    Returns node's node document's document base URL.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/baseURI)
+    */
+  baseURI: string,
+  /**
+    Returns true if node is connected and false otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/isConnected)
+    */
+  isConnected: bool,
+  /**
+    Returns the node document. Returns null for documents.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/ownerDocument)
+    */
+  ownerDocument: Null.t<DOM.document>,
+  /**
+    Returns the parent.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentNode)
+    */
+  parentNode: Null.t<DOMTree.node>,
+  /**
+    Returns the parent element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentElement)
+    */
+  parentElement: Null.t<DOMTree.htmlElement>,
+  /**
+    Returns the children.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/childNodes)
+    */
+  childNodes: DOM.nodeList<DOMTree.node>,
+  /**
+    Returns the first child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/firstChild)
+    */
+  firstChild: Null.t<DOMTree.node>,
+  /**
+    Returns the last child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/lastChild)
+    */
+  lastChild: Null.t<DOMTree.node>,
+  /**
+    Returns the previous sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/previousSibling)
+    */
+  previousSibling: Null.t<DOMTree.node>,
+  /**
+    Returns the next sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nextSibling)
+    */
+  nextSibling: Null.t<DOMTree.node>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeValue)
+    */
+  mutable nodeValue: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/textContent)
+    */
+  mutable textContent: Null.t<string>,
+  // End base properties from Node
+
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/name)
+    */
+  mutable name: string,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assignedNodes)
 */
 @send
-external assignedNodes: (
-  DomTypes.htmlSlotElement,
-  ~options: DomTypes.assignedNodesOptions=?,
-) => array<DomTypes.node> = "assignedNodes"
+external assignedNodes: (t, ~options: DomTypes.assignedNodesOptions=?) => array<DOMTree.node> =
+  "assignedNodes"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assignedElements)
 */
 @send
 external assignedElements: (
-  DomTypes.htmlSlotElement,
+  t,
   ~options: DomTypes.assignedNodesOptions=?,
-) => array<DomTypes.element> = "assignedElements"
+) => array<DOMTree.element> = "assignedElements"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assign)
 */
 @send
-external assign: (DomTypes.htmlSlotElement, DomTypes.element) => unit = "assign"
+external assign: (t, DOMTree.element) => unit = "assign"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assign)
 */
 @send
-external assign2: (DomTypes.htmlSlotElement, DomTypes.text) => unit = "assign"
+external assign2: (t, Text.t) => unit = "assign"

--- a/src/DOM/NamedNodeMap.res
+++ b/src/DOM/NamedNodeMap.res
@@ -2,48 +2,42 @@
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/item)
 */
 @send
-external item: (DomTypes.namedNodeMap, int) => DomTypes.attr = "item"
+external item: (DOM.namedNodeMap, int) => Attr.t = "item"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/getNamedItem)
 */
 @send
-external getNamedItem: (DomTypes.namedNodeMap, string) => DomTypes.attr = "getNamedItem"
+external getNamedItem: (DOM.namedNodeMap, string) => Attr.t = "getNamedItem"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/getNamedItemNS)
 */
 @send
-external getNamedItemNS: (
-  DomTypes.namedNodeMap,
-  ~namespace: string,
-  ~localName: string,
-) => DomTypes.attr = "getNamedItemNS"
+external getNamedItemNS: (DOM.namedNodeMap, ~namespace: string, ~localName: string) => Attr.t =
+  "getNamedItemNS"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/setNamedItem)
 */
 @send
-external setNamedItem: (DomTypes.namedNodeMap, DomTypes.attr) => DomTypes.attr = "setNamedItem"
+external setNamedItem: (DOM.namedNodeMap, Attr.t) => Attr.t = "setNamedItem"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/setNamedItemNS)
 */
 @send
-external setNamedItemNS: (DomTypes.namedNodeMap, DomTypes.attr) => DomTypes.attr = "setNamedItemNS"
+external setNamedItemNS: (DOM.namedNodeMap, Attr.t) => Attr.t = "setNamedItemNS"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/removeNamedItem)
 */
 @send
-external removeNamedItem: (DomTypes.namedNodeMap, string) => DomTypes.attr = "removeNamedItem"
+external removeNamedItem: (DOM.namedNodeMap, string) => Attr.t = "removeNamedItem"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/removeNamedItemNS)
 */
 @send
-external removeNamedItemNS: (
-  DomTypes.namedNodeMap,
-  ~namespace: string,
-  ~localName: string,
-) => DomTypes.attr = "removeNamedItemNS"
+external removeNamedItemNS: (DOM.namedNodeMap, ~namespace: string, ~localName: string) => Attr.t =
+  "removeNamedItemNS"

--- a/src/DOM/Node.res
+++ b/src/DOM/Node.res
@@ -5,15 +5,16 @@ module Impl = (
 ) => {
   include EventTarget.Impl({type t = T.t})
 
-  external asNode: T.t => DomTypes.node = "%identity"
+  external asNode: T.t => DOMTree.node = "%identity"
+
+  type getRootNodeOptions = {mutable composed?: bool}
 
   /**
 Returns node's root.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/getRootNode)
 */
   @send
-  external getRootNode: (T.t, ~options: DomTypes.getRootNodeOptions=?) => DomTypes.node =
-    "getRootNode"
+  external getRootNode: (T.t, ~options: getRootNodeOptions=?) => DOMTree.node = "getRootNode"
 
   /**
 Returns whether node has children.
@@ -41,27 +42,27 @@ Returns whether node and otherNode have the same properties.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/isEqualNode)
 */
   @send
-  external isEqualNode: (T.t, DomTypes.node) => bool = "isEqualNode"
+  external isEqualNode: (T.t, DOMTree.node) => bool = "isEqualNode"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/isSameNode)
 */
   @send
-  external isSameNode: (T.t, DomTypes.node) => bool = "isSameNode"
+  external isSameNode: (T.t, DOMTree.node) => bool = "isSameNode"
 
   /**
 Returns a bitmask indicating the position of other relative to node.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/compareDocumentPosition)
 */
   @send
-  external compareDocumentPosition: (T.t, DomTypes.node) => int = "compareDocumentPosition"
+  external compareDocumentPosition: (T.t, DOMTree.node) => int = "compareDocumentPosition"
 
   /**
 Returns true if other is an inclusive descendant of node, and false otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/contains)
 */
   @send
-  external contains: (T.t, DomTypes.node) => bool = "contains"
+  external contains: (T.t, DOMTree.node) => bool = "contains"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/lookupPrefix)
@@ -85,7 +86,7 @@ Returns true if other is an inclusive descendant of node, and false otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/insertBefore)
 */
   @send
-  external insertBefore: (T.t, 't, ~child: DomTypes.node) => 't = "insertBefore"
+  external insertBefore: (T.t, 't, ~child: DOMTree.node) => 't = "insertBefore"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/appendChild)
@@ -97,7 +98,7 @@ Returns true if other is an inclusive descendant of node, and false otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/replaceChild)
 */
   @send
-  external replaceChild: (T.t, ~node: DomTypes.node, 't) => 't = "replaceChild"
+  external replaceChild: (T.t, ~node: DOMTree.node, 't) => 't = "replaceChild"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/removeChild)
@@ -106,4 +107,4 @@ Returns true if other is an inclusive descendant of node, and false otherwise.
   external removeChild: (T.t, 't) => 't = "removeChild"
 }
 
-include Impl({type t = DomTypes.node})
+include Impl({type t = DOMTree.node})

--- a/src/DOM/NodeFilter.res
+++ b/src/DOM/NodeFilter.res
@@ -1,2 +1,5 @@
+@editor.completeFrom(NodeFilter)
+type t = private {}
+
 @send
-external acceptNode: (DomTypes.nodeFilter, DomTypes.node) => int = "acceptNode"
+external acceptNode: (t, DOMTree.node) => int = "acceptNode"

--- a/src/DOM/NodeFilter.res
+++ b/src/DOM/NodeFilter.res
@@ -1,4 +1,3 @@
-@editor.completeFrom(NodeFilter)
 type t = private {}
 
 @send

--- a/src/DOM/NodeIterator.res
+++ b/src/DOM/NodeIterator.res
@@ -1,11 +1,38 @@
 /**
+An iterator over the members of a list of the nodes in a subtree of the DOM. The nodes will be returned in document order.
+[See NodeIterator on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator)
+*/
+type t = private {
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/root)
+    */
+  root: DOMTree.node,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/referenceNode)
+    */
+  referenceNode: DOMTree.node,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/pointerBeforeReferenceNode)
+    */
+  pointerBeforeReferenceNode: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/whatToShow)
+    */
+  whatToShow: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/filter)
+    */
+  filter: Null.t<NodeFilter.t>,
+}
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/nextNode)
 */
 @send
-external nextNode: DomTypes.nodeIterator => DomTypes.node = "nextNode"
+external nextNode: t => DOMTree.node = "nextNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/previousNode)
 */
 @send
-external previousNode: DomTypes.nodeIterator => DomTypes.node = "previousNode"
+external previousNode: t => DOMTree.node = "previousNode"

--- a/src/DOM/ProcessingInstruction.res
+++ b/src/DOM/ProcessingInstruction.res
@@ -1,0 +1,15 @@
+/**
+A processing instruction embeds application-specific instructions in XML which can be ignored by other applications that don't recognize them.
+[See ProcessingInstruction on MDN](https://developer.mozilla.org/docs/Web/API/ProcessingInstruction)
+*/
+type t = {
+  ...CharacterData.t,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/target)
+    */
+  target: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/sheet)
+    */
+  sheet: Null.t<DOM.cssStyleSheet>,
+}

--- a/src/DOM/Range.res
+++ b/src/DOM/Range.res
@@ -1,149 +1,156 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range)
 */
-@new
-external make: unit => DomTypes.range = "Range"
+type t = private {
+  ...AbstractRange.t,
+  /**
+    Returns the node, furthest away from the document, that is an ancestor of both range's start node and end node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/commonAncestorContainer)
+    */
+  commonAncestorContainer: DOMTree.node,
+}
 
-external asAbstractRange: DomTypes.range => DomTypes.abstractRange = "%identity"
+@new
+external make: unit => t = "Range"
+
+external asAbstractRange: t => AbstractRange.t = "%identity"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/setStart)
 */
 @send
-external setStart: (DomTypes.range, ~node: DomTypes.node, ~offset: int) => unit = "setStart"
+external setStart: (t, ~node: DOMTree.node, ~offset: int) => unit = "setStart"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/setEnd)
 */
 @send
-external setEnd: (DomTypes.range, ~node: DomTypes.node, ~offset: int) => unit = "setEnd"
+external setEnd: (t, ~node: DOMTree.node, ~offset: int) => unit = "setEnd"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/setStartBefore)
 */
 @send
-external setStartBefore: (DomTypes.range, DomTypes.node) => unit = "setStartBefore"
+external setStartBefore: (t, DOMTree.node) => unit = "setStartBefore"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/setStartAfter)
 */
 @send
-external setStartAfter: (DomTypes.range, DomTypes.node) => unit = "setStartAfter"
+external setStartAfter: (t, DOMTree.node) => unit = "setStartAfter"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/setEndBefore)
 */
 @send
-external setEndBefore: (DomTypes.range, DomTypes.node) => unit = "setEndBefore"
+external setEndBefore: (t, DOMTree.node) => unit = "setEndBefore"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/setEndAfter)
 */
 @send
-external setEndAfter: (DomTypes.range, DomTypes.node) => unit = "setEndAfter"
+external setEndAfter: (t, DOMTree.node) => unit = "setEndAfter"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/collapse)
 */
 @send
-external collapse: (DomTypes.range, ~toStart: bool=?) => unit = "collapse"
+external collapse: (t, ~toStart: bool=?) => unit = "collapse"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/selectNode)
 */
 @send
-external selectNode: (DomTypes.range, DomTypes.node) => unit = "selectNode"
+external selectNode: (t, DOMTree.node) => unit = "selectNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/selectNodeContents)
 */
 @send
-external selectNodeContents: (DomTypes.range, DomTypes.node) => unit = "selectNodeContents"
+external selectNodeContents: (t, DOMTree.node) => unit = "selectNodeContents"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/compareBoundaryPoints)
 */
 @send
-external compareBoundaryPoints: (DomTypes.range, ~how: int, ~sourceRange: DomTypes.range) => int =
-  "compareBoundaryPoints"
+external compareBoundaryPoints: (t, ~how: int, ~sourceRange: t) => int = "compareBoundaryPoints"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/deleteContents)
 */
 @send
-external deleteContents: DomTypes.range => unit = "deleteContents"
+external deleteContents: t => unit = "deleteContents"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/extractContents)
 */
 @send
-external extractContents: DomTypes.range => DomTypes.documentFragment = "extractContents"
+external extractContents: t => DOMTree.documentFragment = "extractContents"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/cloneContents)
 */
 @send
-external cloneContents: DomTypes.range => DomTypes.documentFragment = "cloneContents"
+external cloneContents: t => DOMTree.documentFragment = "cloneContents"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/insertNode)
 */
 @send
-external insertNode: (DomTypes.range, DomTypes.node) => unit = "insertNode"
+external insertNode: (t, DOMTree.node) => unit = "insertNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/surroundContents)
 */
 @send
-external surroundContents: (DomTypes.range, DomTypes.node) => unit = "surroundContents"
+external surroundContents: (t, DOMTree.node) => unit = "surroundContents"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/cloneRange)
 */
 @send
-external cloneRange: DomTypes.range => DomTypes.range = "cloneRange"
+external cloneRange: t => t = "cloneRange"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/detach)
 */
 @send
-external detach: DomTypes.range => unit = "detach"
+external detach: t => unit = "detach"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/isPointInRange)
 */
 @send
-external isPointInRange: (DomTypes.range, ~node: DomTypes.node, ~offset: int) => bool =
-  "isPointInRange"
+external isPointInRange: (t, ~node: DOMTree.node, ~offset: int) => bool = "isPointInRange"
 
 /**
 Returns −1 if the point is before the range, 0 if the point is in the range, and 1 if the point is after the range.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/comparePoint)
 */
 @send
-external comparePoint: (DomTypes.range, ~node: DomTypes.node, ~offset: int) => int = "comparePoint"
+external comparePoint: (t, ~node: DOMTree.node, ~offset: int) => int = "comparePoint"
 
 /**
 Returns whether range intersects node.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/intersectsNode)
 */
 @send
-external intersectsNode: (DomTypes.range, DomTypes.node) => bool = "intersectsNode"
+external intersectsNode: (t, DOMTree.node) => bool = "intersectsNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/getClientRects)
 */
 @send
-external getClientRects: DomTypes.range => DomTypes.domRectList = "getClientRects"
+external getClientRects: t => DOM.domRectList = "getClientRects"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/getBoundingClientRect)
 */
 @send
-external getBoundingClientRect: DomTypes.range => DomTypes.domRect = "getBoundingClientRect"
+external getBoundingClientRect: t => DOM.domRect = "getBoundingClientRect"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/createContextualFragment)
 */
 @send
-external createContextualFragment: (DomTypes.range, string) => DomTypes.documentFragment =
+external createContextualFragment: (t, string) => DOMTree.documentFragment =
   "createContextualFragment"

--- a/src/DOM/Selection.res
+++ b/src/DOM/Selection.res
@@ -1,73 +1,112 @@
 /**
+A Selection object represents the range of text selected by the user or the current position of the caret. To obtain a Selection object for examination or modification, call Window.getSelection().
+[See Selection on MDN](https://developer.mozilla.org/docs/Web/API/Selection)
+*/
+type t = private {
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/anchorNode)
+    */
+  anchorNode: Null.t<DOMTree.node>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/anchorOffset)
+    */
+  anchorOffset: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/focusNode)
+    */
+  focusNode: Null.t<DOMTree.node>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/focusOffset)
+    */
+  focusOffset: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/isCollapsed)
+    */
+  isCollapsed: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/rangeCount)
+    */
+  rangeCount: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/type)
+    */
+  @as("type")
+  type_: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/direction)
+    */
+  direction: string,
+}
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/getRangeAt)
 */
 @send
-external getRangeAt: (DomTypes.selection, int) => DomTypes.range = "getRangeAt"
+external getRangeAt: (t, int) => Range.t = "getRangeAt"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/addRange)
 */
 @send
-external addRange: (DomTypes.selection, DomTypes.range) => unit = "addRange"
+external addRange: (t, Range.t) => unit = "addRange"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/removeRange)
 */
 @send
-external removeRange: (DomTypes.selection, DomTypes.range) => unit = "removeRange"
+external removeRange: (t, Range.t) => unit = "removeRange"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/removeAllRanges)
 */
 @send
-external removeAllRanges: DomTypes.selection => unit = "removeAllRanges"
+external removeAllRanges: t => unit = "removeAllRanges"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/removeAllRanges)
 */
 @send
-external empty: DomTypes.selection => unit = "empty"
+external empty: t => unit = "empty"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/collapse)
 */
 @send
-external collapse: (DomTypes.selection, ~node: DomTypes.node, ~offset: int=?) => unit = "collapse"
+external collapse: (t, ~node: DOMTree.node, ~offset: int=?) => unit = "collapse"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/collapse)
 */
 @send
-external setPosition: (DomTypes.selection, ~node: DomTypes.node, ~offset: int=?) => unit =
-  "setPosition"
+external setPosition: (t, ~node: DOMTree.node, ~offset: int=?) => unit = "setPosition"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/collapseToStart)
 */
 @send
-external collapseToStart: DomTypes.selection => unit = "collapseToStart"
+external collapseToStart: t => unit = "collapseToStart"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/collapseToEnd)
 */
 @send
-external collapseToEnd: DomTypes.selection => unit = "collapseToEnd"
+external collapseToEnd: t => unit = "collapseToEnd"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/extend)
 */
 @send
-external extend: (DomTypes.selection, ~node: DomTypes.node, ~offset: int=?) => unit = "extend"
+external extend: (t, ~node: DOMTree.node, ~offset: int=?) => unit = "extend"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/setBaseAndExtent)
 */
 @send
 external setBaseAndExtent: (
-  DomTypes.selection,
-  ~anchorNode: DomTypes.node,
+  t,
+  ~anchorNode: DOMTree.node,
   ~anchorOffset: int,
-  ~focusNode: DomTypes.node,
+  ~focusNode: DOMTree.node,
   ~focusOffset: int,
 ) => unit = "setBaseAndExtent"
 
@@ -75,31 +114,24 @@ external setBaseAndExtent: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/selectAllChildren)
 */
 @send
-external selectAllChildren: (DomTypes.selection, DomTypes.node) => unit = "selectAllChildren"
+external selectAllChildren: (t, DOMTree.node) => unit = "selectAllChildren"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/modify)
 */
 @send
-external modify: (
-  DomTypes.selection,
-  ~alter: string=?,
-  ~direction: string=?,
-  ~granularity: string=?,
-) => unit = "modify"
+external modify: (t, ~alter: string=?, ~direction: string=?, ~granularity: string=?) => unit =
+  "modify"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/deleteFromDocument)
 */
 @send
-external deleteFromDocument: DomTypes.selection => unit = "deleteFromDocument"
+external deleteFromDocument: t => unit = "deleteFromDocument"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/containsNode)
 */
 @send
-external containsNode: (
-  DomTypes.selection,
-  ~node: DomTypes.node,
-  ~allowPartialContainment: bool=?,
-) => bool = "containsNode"
+external containsNode: (t, ~node: DOMTree.node, ~allowPartialContainment: bool=?) => bool =
+  "containsNode"

--- a/src/DOM/ShadowRoot.res
+++ b/src/DOM/ShadowRoot.res
@@ -1,19 +1,19 @@
-include DocumentFragment.Impl({type t = DomTypes.shadowRoot})
+include DocumentFragment.Impl({type t = DOMTree.shadowRoot})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getAnimations)
 */
 @send
-external getAnimations: DomTypes.shadowRoot => array<Animation.t> = "getAnimations"
+external getAnimations: DOMTree.shadowRoot => array<Animation.t> = "getAnimations"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ShadowRoot/setHTMLUnsafe)
 */
 @send
-external setHTMLUnsafe: (DomTypes.shadowRoot, string) => unit = "setHTMLUnsafe"
+external setHTMLUnsafe: (DOMTree.shadowRoot, string) => unit = "setHTMLUnsafe"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ShadowRoot/getHTML)
 */
 @send
-external getHTML: (DomTypes.shadowRoot, ~options: DomTypes.getHTMLOptions=?) => string = "getHTML"
+external getHTML: (DOMTree.shadowRoot, ~options: DomTypes.getHTMLOptions=?) => string = "getHTML"

--- a/src/DOM/StaticRange.res
+++ b/src/DOM/StaticRange.res
@@ -1,6 +1,6 @@
 /**
 [See StaticRange on MDN](https://developer.mozilla.org/docs/Web/API/StaticRange)
 */
-type t = {
+type t = AbstractRange.t = private {
   ...AbstractRange.t,
 }

--- a/src/DOM/StaticRange.res
+++ b/src/DOM/StaticRange.res
@@ -1,0 +1,6 @@
+/**
+[See StaticRange on MDN](https://developer.mozilla.org/docs/Web/API/StaticRange)
+*/
+type t = {
+  ...AbstractRange.t,
+}

--- a/src/DOM/Text.res
+++ b/src/DOM/Text.res
@@ -1,14 +1,31 @@
-include CharacterData.Impl({type t = DomTypes.text})
+/**
+The textual content of Element or Attr. If an element has no markup within its content, it has a single child implementing Text that contains the element's text. However, if the element contains markup, it is parsed into information items and Text nodes that form its children.
+[See Text on MDN](https://developer.mozilla.org/docs/Web/API/Text)
+*/
+type t = private {
+  ...CharacterData.t,
+  /**
+    Returns the combined data of all direct Text node siblings.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Text/wholeText)
+    */
+  wholeText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/assignedSlot)
+    */
+  assignedSlot: Null.t<DOMTree.htmlSlotElement>,
+}
+
+include CharacterData.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Text)
 */
 @new
-external make: (~data: string=?) => DomTypes.text = "Text"
+external make: (~data: string=?) => t = "Text"
 
 /**
 Splits data at the given offset and returns the remainder as Text node.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Text/splitText)
 */
 @send
-external splitText: (DomTypes.text, int) => DomTypes.text = "splitText"
+external splitText: (t, int) => t = "splitText"

--- a/src/DOM/TreeWalker.res
+++ b/src/DOM/TreeWalker.res
@@ -1,41 +1,65 @@
 /**
+The nodes of a document subtree and a position within them.
+[See TreeWalker on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/root)
+    */
+  root: DOMTree.node,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/whatToShow)
+    */
+  whatToShow: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/filter)
+    */
+  filter: Null.t<NodeFilter.t>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/currentNode)
+    */
+  mutable currentNode: DOMTree.node,
+}
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/parentNode)
 */
 @send
-external parentNode: DomTypes.treeWalker => DomTypes.node = "parentNode"
+external parentNode: t => DOMTree.node = "parentNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/firstChild)
 */
 @send
-external firstChild: DomTypes.treeWalker => DomTypes.node = "firstChild"
+external firstChild: t => DOMTree.node = "firstChild"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/lastChild)
 */
 @send
-external lastChild: DomTypes.treeWalker => DomTypes.node = "lastChild"
+external lastChild: t => DOMTree.node = "lastChild"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/previousSibling)
 */
 @send
-external previousSibling: DomTypes.treeWalker => DomTypes.node = "previousSibling"
+external previousSibling: t => DOMTree.node = "previousSibling"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/nextSibling)
 */
 @send
-external nextSibling: DomTypes.treeWalker => DomTypes.node = "nextSibling"
+external nextSibling: t => DOMTree.node = "nextSibling"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/previousNode)
 */
 @send
-external previousNode: DomTypes.treeWalker => DomTypes.node = "previousNode"
+external previousNode: t => DOMTree.node = "previousNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/nextNode)
 */
 @send
-external nextNode: DomTypes.treeWalker => DomTypes.node = "nextNode"
+external nextNode: t => DOMTree.node = "nextNode"

--- a/src/DOM/XPathExpression.res
+++ b/src/DOM/XPathExpression.res
@@ -10,7 +10,7 @@ type t = private {}
 @send
 external evaluate: (
   t,
-  ~contextNode: DOM.node,
+  ~contextNode: DOMTree.node,
   ~type_: int=?,
   ~result: XPathResult.t=?,
 ) => XPathResult.t = "evaluate"

--- a/src/DOM/XPathResult.res
+++ b/src/DOM/XPathResult.res
@@ -22,7 +22,7 @@ type t = private {
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/XPathResult/singleNodeValue)
 */
-  singleNodeValue: Null.t<DOM.node>,
+  singleNodeValue: Null.t<DOMTree.node>,
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/XPathResult/invalidIteratorState)
 */
@@ -37,10 +37,10 @@ type t = private {
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/XPathResult/iterateNext)
 */
 @send
-external iterateNext: t => DOM.node = "iterateNext"
+external iterateNext: t => DOMTree.node = "iterateNext"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/XPathResult/snapshotItem)
 */
 @send
-external snapshotItem: (t, int) => DOM.node = "snapshotItem"
+external snapshotItem: (t, int) => DOMTree.node = "snapshotItem"


### PR DESCRIPTION
Tracking issue: #342

## Summary

- migrate core node, element, range, traversal, selection, and character-data APIs onto `DOMTree`
- add focused interface modules including `Attr`, `AbstractRange`, `StaticRange`, `CDATASection`, and `ProcessingInstruction`
- move interface-specific operations out of the broad type modules

## Temporary state

- the `DOMTree` types used here are still aliases to the old recursive definitions from #301
- some shared option and helper types continue to come from `DomTypes` so this layer compiles independently
- #310 makes `DOMTree` concrete, relocates the remaining helpers, and deletes `DomTypes`

## Review focus

- recursive type relationships and public method signatures
- completeness of each newly owning interface module
- absence of behavioral changes beyond type ownership

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`