### PR TITLE
refactor: colocate animation and mutation types

### DIFF
--- a/src/DOM/Animation.res
+++ b/src/DOM/Animation.res
@@ -136,7 +136,7 @@ type iterationCompositeOperation =
   | @as("replace") Replace
 
 type keyframeEffectOptions = {
-  ...DomTypes.effectTiming,
+  ...AnimationEffect.effectTiming,
   mutable composite?: compositeOperation,
   mutable pseudoElement?: Null.t<string>,
   mutable iterationComposite?: iterationCompositeOperation,

--- a/src/DOM/AnimationEffect.res
+++ b/src/DOM/AnimationEffect.res
@@ -3,20 +3,69 @@
 */
 type t = private {}
 
+type fillMode =
+  | @as("auto") Auto
+  | @as("backwards") Backwards
+  | @as("both") Both
+  | @as("forwards") Forwards
+  | @as("none") None
+
+type playbackDirection =
+  | @as("alternate") Alternate
+  | @as("alternate-reverse") AlternateReverse
+  | @as("normal") Normal
+  | @as("reverse") Reverse
+
+type effectTiming = {
+  mutable fill?: fillMode,
+  mutable iterationStart?: float,
+  mutable iterations?: float,
+  mutable direction?: playbackDirection,
+  mutable easing?: string,
+  mutable delay?: float,
+  mutable endDelay?: float,
+  mutable playbackRate?: float,
+  mutable duration?: unknown,
+}
+
+type getAnimationsOptions = {mutable subtree?: bool}
+
+type computedEffectTiming = {
+  ...effectTiming,
+  mutable progress?: Null.t<float>,
+  mutable currentIteration?: Null.t<float>,
+  mutable startTime?: float,
+  mutable endTime?: float,
+  mutable activeDuration?: float,
+  mutable localTime?: Null.t<float>,
+}
+
+type optionalEffectTiming = {
+  mutable delay?: float,
+  mutable endDelay?: float,
+  mutable fill?: fillMode,
+  mutable iterationStart?: float,
+  mutable iterations?: float,
+  mutable duration?: unknown,
+  mutable direction?: playbackDirection,
+  mutable easing?: string,
+  mutable playbackRate?: float,
+}
+
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnimationEffect/getTiming)
 */
 @send
-external getTiming: t => DomTypes.effectTiming = "getTiming"
+external getTiming: t => effectTiming = "getTiming"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnimationEffect/getComputedTiming)
 */
 @send
-external getComputedTiming: t => DomTypes.computedEffectTiming = "getComputedTiming"
+external getComputedTiming: t => computedEffectTiming = "getComputedTiming"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnimationEffect/updateTiming)
 */
 @send
-external updateTiming: (t, ~timing: DomTypes.optionalEffectTiming=?) => unit = "updateTiming"
+external updateTiming: (t, ~timing: optionalEffectTiming=?) => unit = "updateTiming"

--- a/src/MutationObserver/MutationObserver.res
+++ b/src/MutationObserver/MutationObserver.res
@@ -1,31 +1,94 @@
 /**
+Represents an individual DOM mutation.
+[See MutationRecord on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord)
+*/
+type mutationRecord = {
+  /**
+    Returns "attributes" if it was an attribute mutation. "characterData" if it was a mutation to a CharacterData node. And "childList" if it was a mutation to the tree of nodes.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/type)
+    */
+  @as("type")
+  type_: string,
+  /**
+    Returns the node the mutation affected, depending on the type. For "attributes", it is the element whose attribute changed. For "characterData", it is the CharacterData node. For "childList", it is the node whose children changed.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/target)
+    */
+  target: DOMTree.node,
+  /**
+    Return the nodes added and removed respectively.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/addedNodes)
+    */
+  addedNodes: DOM.nodeList<DOMTree.node>,
+  /**
+    Return the nodes added and removed respectively.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/removedNodes)
+    */
+  removedNodes: DOM.nodeList<DOMTree.node>,
+  /**
+    Return the previous and next sibling respectively of the added or removed nodes, and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/previousSibling)
+    */
+  previousSibling: Null.t<DOMTree.node>,
+  /**
+    Return the previous and next sibling respectively of the added or removed nodes, and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/nextSibling)
+    */
+  nextSibling: Null.t<DOMTree.node>,
+  /**
+    Returns the local name of the changed attribute, and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/attributeName)
+    */
+  attributeName: Null.t<string>,
+  /**
+    Returns the namespace of the changed attribute, and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/attributeNamespace)
+    */
+  attributeNamespace: Null.t<string>,
+  /**
+    The return value depends on type. For "attributes", it is the value of the changed attribute before the change. For "characterData", it is the data of the changed node before the change. For "childList", it is null.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationRecord/oldValue)
+    */
+  oldValue: Null.t<string>,
+}
+
+/**
+[See WebApiMutationObserver on MDN](https://developer.mozilla.org/docs/Web/API/MutationObserver)
+*/
+@editor.completeFrom(WebApiMutationObserver)
+type t
+
+type mutationObserverInit = {
+  mutable childList?: bool,
+  mutable attributes?: bool,
+  mutable characterData?: bool,
+  mutable subtree?: bool,
+  mutable attributeOldValue?: bool,
+  mutable characterDataOldValue?: bool,
+  mutable attributeFilter?: array<string>,
+}
+
+type mutationObserverCallback = (array<mutationRecord>, t) => unit
+
+/**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationObserver)
 */
 @new
-external make: MutationObserverTypes.mutationObserverCallback => MutationObserverTypes.mutationObserver =
-  "MutationObserver"
+external make: mutationObserverCallback => t = "MutationObserver"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationObserver/observe)
 */
 @send
-external observe: (
-  MutationObserverTypes.mutationObserver,
-  ~target: DomTypes.node,
-  ~options: MutationObserverTypes.mutationObserverInit=?,
-) => unit = "observe"
+external observe: (t, ~target: DOMTree.node, ~options: mutationObserverInit=?) => unit = "observe"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationObserver/disconnect)
 */
 @send
-external disconnect: MutationObserverTypes.mutationObserver => unit = "disconnect"
+external disconnect: t => unit = "disconnect"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationObserver/takeRecords)
 */
 @send
-external takeRecords: MutationObserverTypes.mutationObserver => array<DOM.mutationRecord> =
-  "takeRecords"
-
-module Types = MutationObserverTypes
+external takeRecords: t => array<mutationRecord> = "takeRecords"


### PR DESCRIPTION
Tracking issue: #342

## Summary

- move animation timing records into `Animation` and `AnimationEffect`
- move mutation records, observer initialization options, and callbacks into `MutationObserver`
- update the owning APIs to use their local types

## Temporary state

- the legacy `MutationObserverTypes` module remains available in this layer while downstream references are migrated
- #310 updates the residual consumers and deletes `MutationObserverTypes`
- the recursive DOM types referenced here remain behind the temporary `DOMTree` aliases until #310

## Review focus

- type ownership and signature equivalence
- preserving mutation-observer callback and initialization behavior

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`