### PR TITLE
refactor: define HTML form and table interfaces locally

### DIFF
--- a/src/DOM/HTMLButtonElement.res
+++ b/src/DOM/HTMLButtonElement.res
@@ -1,17 +1,93 @@
-include HTMLElement.Impl({type t = DomTypes.htmlButtonElement})
+/**
+Provides properties and methods (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating <button> elements.
+[See HTMLButtonElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type rec t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/disabled)
+    */
+  mutable disabled: bool,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    Overrides the action attribute (where the data on a form is sent) on the parent form element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/formAction)
+    */
+  mutable formAction: string,
+  /**
+    Used to override the encoding (formEnctype attribute) specified on the form element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/formEnctype)
+    */
+  mutable formEnctype: string,
+  /**
+    Overrides the submit method attribute previously specified on a form element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/formMethod)
+    */
+  mutable formMethod: string,
+  /**
+    Sets or retrieves the name of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/name)
+    */
+  mutable name: string,
+  /**
+    Gets the classification and default behavior of the button.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/type)
+    */
+  @as("type")
+  mutable type_: string,
+  /**
+    Sets or retrieves the default or selected value of the control.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/value)
+    */
+  mutable value: string,
+  /**
+    Returns whether an element will successfully validate based on forms validation rules and constraints.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/willValidate)
+    */
+  willValidate: bool,
+  /**
+    Returns a  ValidityState object that represents the validity states of an element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/validity)
+    */
+  validity: DOM.validityState,
+  /**
+    Returns the error message that would be displayed if the user submits the form, or an empty string if no error message. It also triggers the standard error message, such as "this is a required field". The result is that the user sees validation messages without actually submitting.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/validationMessage)
+    */
+  validationMessage: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/labels)
+    */
+  labels: DOM.nodeList<HTMLLabelElement.t>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetElement)
+    */
+  mutable popoverTargetElement: Null.t<DOMTree.element>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetAction)
+    */
+  mutable popoverTargetAction: string,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/checkValidity)
 */
 @send
-external checkValidity: DomTypes.htmlButtonElement => bool = "checkValidity"
+external checkValidity: t => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/reportValidity)
 */
 @send
-external reportValidity: DomTypes.htmlButtonElement => bool = "reportValidity"
+external reportValidity: t => bool = "reportValidity"
 
 /**
 Sets a custom error message that is displayed when a form is submitted.
@@ -19,4 +95,4 @@ Sets a custom error message that is displayed when a form is submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/setCustomValidity)
 */
 @send
-external setCustomValidity: (DomTypes.htmlButtonElement, string) => unit = "setCustomValidity"
+external setCustomValidity: (t, string) => unit = "setCustomValidity"

--- a/src/DOM/HTMLDataListElement.res
+++ b/src/DOM/HTMLDataListElement.res
@@ -1,1 +1,14 @@
-include HTMLElement.Impl({type t = DomTypes.htmlDataListElement})
+/**
+Provides special properties (beyond the HTMLElement object interface it also has available to it by inheritance) to manipulate <datalist> elements and their content.
+[See HTMLDataListElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDataListElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+  /**
+    Returns an HTMLCollection of the option elements of the datalist element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDataListElement/options)
+    */
+  options: HTMLCollection.t<HTMLOptionElement.t>,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLDialogElement.res
+++ b/src/DOM/HTMLDialogElement.res
@@ -1,17 +1,34 @@
-include HTMLElement.Impl({type t = DomTypes.htmlDialogElement})
+/**
+[See HTMLDialogElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/open)
+    */
+  @as("open")
+  mutable open_: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/returnValue)
+    */
+  mutable returnValue: string,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Displays the dialog element.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/show)
 */
 @send
-external show: DomTypes.htmlDialogElement => unit = "show"
+external show: t => unit = "show"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/showModal)
 */
 @send
-external showModal: DomTypes.htmlDialogElement => unit = "showModal"
+external showModal: t => unit = "showModal"
 
 /**
 Closes the dialog element.
@@ -20,4 +37,4 @@ The argument, if provided, provides a return value.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/close)
 */
 @send
-external close: (DomTypes.htmlDialogElement, ~returnValue: string=?) => unit = "close"
+external close: (t, ~returnValue: string=?) => unit = "close"

--- a/src/DOM/HTMLFieldSetElement.res
+++ b/src/DOM/HTMLFieldSetElement.res
@@ -1,17 +1,65 @@
-include HTMLElement.Impl({type t = DomTypes.htmlFieldSetElement})
+/**
+Provides special properties and methods (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of <fieldset> elements.
+[See HTMLFieldSetElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/disabled)
+    */
+  mutable disabled: bool,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/name)
+    */
+  mutable name: string,
+  /**
+    Returns the string "fieldset".
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/type)
+    */
+  @as("type")
+  type_: string,
+  /**
+    Returns an HTMLCollection of the form controls in the element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/elements)
+    */
+  elements: HTMLCollection.t<DOMTree.element>,
+  /**
+    Returns whether an element will successfully validate based on forms validation rules and constraints.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/willValidate)
+    */
+  willValidate: bool,
+  /**
+    Returns a  ValidityState object that represents the validity states of an element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/validity)
+    */
+  validity: DOM.validityState,
+  /**
+    Returns the error message that would be displayed if the user submits the form, or an empty string if no error message. It also triggers the standard error message, such as "this is a required field". The result is that the user sees validation messages without actually submitting.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/validationMessage)
+    */
+  validationMessage: string,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/checkValidity)
 */
 @send
-external checkValidity: DomTypes.htmlFieldSetElement => bool = "checkValidity"
+external checkValidity: t => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/reportValidity)
 */
 @send
-external reportValidity: DomTypes.htmlFieldSetElement => bool = "reportValidity"
+external reportValidity: t => bool = "reportValidity"
 
 /**
 Sets a custom error message that is displayed when a form is submitted.
@@ -19,4 +67,4 @@ Sets a custom error message that is displayed when a form is submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/setCustomValidity)
 */
 @send
-external setCustomValidity: (DomTypes.htmlFieldSetElement, string) => unit = "setCustomValidity"
+external setCustomValidity: (t, string) => unit = "setCustomValidity"

--- a/src/DOM/HTMLInputElement.res
+++ b/src/DOM/HTMLInputElement.res
@@ -1,4 +1,228 @@
-include HTMLElement.Impl({type t = DomTypes.htmlInputElement})
+/**
+Provides special properties and methods for manipulating the options, layout, and presentation of <input> elements.
+[See HTMLInputElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Sets or retrieves a comma-separated list of content types.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/accept)
+    */
+  mutable accept: string,
+  /**
+    Sets or retrieves a text alternative to the graphic.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/alt)
+    */
+  mutable alt: string,
+  /**
+    Specifies whether autocomplete is applied to an editable text field.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/autocomplete)
+    */
+  mutable autocomplete: string,
+  /**
+    Sets or retrieves the state of the check box or radio button.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/defaultChecked)
+    */
+  mutable defaultChecked: bool,
+  /**
+    Sets or retrieves the state of the check box or radio button.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/checked)
+    */
+  mutable checked: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/disabled)
+    */
+  mutable disabled: bool,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    Returns a FileList object on a file type input object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/files)
+    */
+  mutable files: Null.t<DOM.fileList>,
+  /**
+    Overrides the action attribute (where the data on a form is sent) on the parent form element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/formAction)
+    */
+  mutable formAction: string,
+  /**
+    Used to override the encoding (formEnctype attribute) specified on the form element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/formEnctype)
+    */
+  mutable formEnctype: string,
+  /**
+    Overrides the submit method attribute previously specified on a form element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/formMethod)
+    */
+  mutable formMethod: string,
+  /**
+    Sets or retrieves the height of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/height)
+    */
+  mutable height: int,
+  /**
+    When set, overrides the rendering of checkbox controls so that the current value is not visible.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/indeterminate)
+    */
+  mutable indeterminate: bool,
+  /**
+    Specifies the ID of a pre-defined datalist of options for an input element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/list)
+    */
+  list: Null.t<HTMLDataListElement.t>,
+  /**
+    Defines the maximum acceptable value for an input element with type="number".When used with the min and step attributes, lets you control the range and increment (such as only even numbers) that the user can enter into an input field.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/max)
+    */
+  mutable max: string,
+  /**
+    Sets or retrieves the maximum number of characters that the user can enter in a text control.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/maxLength)
+    */
+  mutable maxLength: int,
+  /**
+    Defines the minimum acceptable value for an input element with type="number". When used with the max and step attributes, lets you control the range and increment (such as even numbers only) that the user can enter into an input field.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/min)
+    */
+  mutable min: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/minLength)
+    */
+  mutable minLength: int,
+  /**
+    Sets or retrieves the Boolean value indicating whether multiple items can be selected from a list.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/multiple)
+    */
+  mutable multiple: bool,
+  /**
+    Sets or retrieves the name of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/name)
+    */
+  mutable name: string,
+  /**
+    Gets or sets a string containing a regular expression that the user's input must match.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/pattern)
+    */
+  mutable pattern: string,
+  /**
+    Gets or sets a text string that is displayed in an input field as a hint or prompt to users as the format or type of information they need to enter.The text appears in an input field until the user puts focus on the field.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/placeholder)
+    */
+  mutable placeholder: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/readOnly)
+    */
+  mutable readOnly: bool,
+  /**
+    When present, marks an element that can't be submitted without a value.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/required)
+    */
+  mutable required: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/size)
+    */
+  mutable size: int,
+  /**
+    The address or WebApiURL of the a media resource that is to be considered.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/src)
+    */
+  mutable src: string,
+  /**
+    Defines an increment or jump between values that you want to allow the user to enter. When used with the max and min attributes, lets you control the range and increment (for example, allow only even numbers) that the user can enter into an input field.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/step)
+    */
+  mutable step: string,
+  /**
+    Returns the content type of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/type)
+    */
+  @as("type")
+  mutable type_: string,
+  /**
+    Sets or retrieves the initial contents of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/defaultValue)
+    */
+  mutable defaultValue: string,
+  /**
+    Returns the value of the data at the cursor's current position.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/value)
+    */
+  mutable value: string,
+  /**
+    Returns a Date object representing the form control's value, if applicable; otherwise, returns null. Can be set, to change the value. Throws an "InvalidStateError" DOMException if the control isn't date- or time-based.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/valueAsDate)
+    */
+  mutable valueAsDate: Null.t<Date.t>,
+  /**
+    Returns the input field value as a number.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/valueAsNumber)
+    */
+  mutable valueAsNumber: float,
+  /**
+    Sets or retrieves the width of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/width)
+    */
+  mutable width: int,
+  /**
+    Returns whether an element will successfully validate based on forms validation rules and constraints.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/willValidate)
+    */
+  willValidate: bool,
+  /**
+    Returns a  ValidityState object that represents the validity states of an element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/validity)
+    */
+  validity: DOM.validityState,
+  /**
+    Returns the error message that would be displayed if the user submits the form, or an empty string if no error message. It also triggers the standard error message, such as "this is a required field". The result is that the user sees validation messages without actually submitting.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/validationMessage)
+    */
+  validationMessage: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/labels)
+    */
+  labels: Null.t<DOM.nodeList<HTMLLabelElement.t>>,
+  /**
+    Gets or sets the starting position or offset of a text selection.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/selectionStart)
+    */
+  mutable selectionStart: Null.t<int>,
+  /**
+    Gets or sets the end position or offset of a text selection.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/selectionEnd)
+    */
+  mutable selectionEnd: Null.t<int>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/selectionDirection)
+    */
+  mutable selectionDirection: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory)
+    */
+  mutable webkitdirectory: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitEntries)
+    */
+  webkitEntries: array<BaseFileAndDirectoryEntries.fileSystemEntry>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/capture)
+    */
+  mutable capture: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetElement)
+    */
+  mutable popoverTargetElement: Null.t<DOMTree.element>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetAction)
+    */
+  mutable popoverTargetAction: string,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Increments a range input control's value by the value given by the Step attribute. If the optional parameter is used, will increment the input control's value by that value.
@@ -6,7 +230,7 @@ Increments a range input control's value by the value given by the Step attribut
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/stepUp)
 */
 @send
-external stepUp: (DomTypes.htmlInputElement, ~n: int=?) => unit = "stepUp"
+external stepUp: (t, ~n: int=?) => unit = "stepUp"
 
 /**
 Decrements a range input control's value by the value given by the Step attribute. If the optional parameter is used, it will decrement the input control's step value multiplied by the parameter's value.
@@ -14,20 +238,20 @@ Decrements a range input control's value by the value given by the Step attribut
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/stepDown)
 */
 @send
-external stepDown: (DomTypes.htmlInputElement, ~n: int=?) => unit = "stepDown"
+external stepDown: (t, ~n: int=?) => unit = "stepDown"
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/checkValidity)
 */
 @send
-external checkValidity: DomTypes.htmlInputElement => bool = "checkValidity"
+external checkValidity: t => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/reportValidity)
 */
 @send
-external reportValidity: DomTypes.htmlInputElement => bool = "reportValidity"
+external reportValidity: t => bool = "reportValidity"
 
 /**
 Sets a custom error message that is displayed when a form is submitted.
@@ -35,31 +259,31 @@ Sets a custom error message that is displayed when a form is submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setCustomValidity)
 */
 @send
-external setCustomValidity: (DomTypes.htmlInputElement, string) => unit = "setCustomValidity"
+external setCustomValidity: (t, string) => unit = "setCustomValidity"
 
 /**
 Makes the selection equal to the current object.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/select)
 */
 @send
-external select: DomTypes.htmlInputElement => unit = "select"
+external select: t => unit = "select"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setRangeText)
 */
 @send
-external setRangeText: (DomTypes.htmlInputElement, string) => unit = "setRangeText"
+external setRangeText: (t, string) => unit = "setRangeText"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setRangeText)
 */
 @send
 external setRangeText2: (
-  DomTypes.htmlInputElement,
+  t,
   ~replacement: string,
   ~start: int,
   ~end: int,
-  ~selectionMode: DomTypes.selectionMode=?,
+  ~selectionMode: DOM.selectionMode=?,
 ) => unit = "setRangeText"
 
 /**
@@ -70,15 +294,11 @@ Sets the start and end positions of a selection in a text field.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setSelectionRange)
 */
 @send
-external setSelectionRange: (
-  DomTypes.htmlInputElement,
-  ~start: int,
-  ~end: int,
-  ~direction: string=?,
-) => unit = "setSelectionRange"
+external setSelectionRange: (t, ~start: int, ~end: int, ~direction: string=?) => unit =
+  "setSelectionRange"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/showPicker)
 */
 @send
-external showPicker: DomTypes.htmlInputElement => unit = "showPicker"
+external showPicker: t => unit = "showPicker"

--- a/src/DOM/HTMLLabelElement.res
+++ b/src/DOM/HTMLLabelElement.res
@@ -1,1 +1,25 @@
-include HTMLElement.Impl({type t = DomTypes.htmlLabelElement})
+/**
+Gives access to properties specific to <label> elements. It inherits methods and properties from the base HTMLElement interface.
+[See HTMLLabelElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLabelElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLabelElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    Sets or retrieves the object to which the given label object is assigned.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLabelElement/htmlFor)
+    */
+  mutable htmlFor: string,
+  /**
+    Returns the form control that is associated with this element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLabelElement/control)
+    */
+  control: Null.t<DOMTree.htmlElement>,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLLegendElement.res
+++ b/src/DOM/HTMLLegendElement.res
@@ -1,1 +1,14 @@
-include HTMLElement.Impl({type t = DomTypes.htmlLegendElement})
+/**
+The HTMLLegendElement is an interface allowing to access properties of the <legend> elements. It inherits properties and methods from the HTMLElement interface.
+[See HTMLLegendElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLegendElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLegendElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLMeterElement.res
+++ b/src/DOM/HTMLMeterElement.res
@@ -1,1 +1,38 @@
-include HTMLElement.Impl({type t = DomTypes.htmlMeterElement})
+/**
+The HTML <meter> elements expose the HTMLMeterElement interface, which provides special properties and methods (beyond the HTMLElement object interface they also have available to them by inheritance) for manipulating the layout and presentation of <meter> elements.
+[See HTMLMeterElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/value)
+    */
+  mutable value: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/min)
+    */
+  mutable min: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/max)
+    */
+  mutable max: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/low)
+    */
+  mutable low: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/high)
+    */
+  mutable high: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/optimum)
+    */
+  mutable optimum: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/labels)
+    */
+  labels: DOM.nodeList<HTMLLabelElement.t>,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLObjectElement.res
+++ b/src/DOM/HTMLObjectElement.res
@@ -1,20 +1,84 @@
-include HTMLElement.Impl({type t = DomTypes.htmlObjectElement})
+/**
+Provides special properties and methods (beyond those on the HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of <object> element, representing external resources.
+[See HTMLObjectElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Sets or retrieves the WebApiURL that references the data of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/data)
+    */
+  mutable data: string,
+  /**
+    Sets or retrieves the MIME type of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/type)
+    */
+  @as("type")
+  mutable type_: string,
+  /**
+    Sets or retrieves the name of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/name)
+    */
+  mutable name: string,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    Sets or retrieves the width of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/width)
+    */
+  mutable width: string,
+  /**
+    Sets or retrieves the height of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/height)
+    */
+  mutable height: string,
+  /**
+    Retrieves the document object of the page or frame.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/contentDocument)
+    */
+  contentDocument: Null.t<DOM.document>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/contentWindow)
+    */
+  contentWindow: Null.t<DOM.window>,
+  /**
+    Returns whether an element will successfully validate based on forms validation rules and constraints.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/willValidate)
+    */
+  willValidate: bool,
+  /**
+    Returns a  ValidityState object that represents the validity states of an element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/validity)
+    */
+  validity: DOM.validityState,
+  /**
+    Returns the error message that would be displayed if the user submits the form, or an empty string if no error message. It also triggers the standard error message, such as "this is a required field". The result is that the user sees validation messages without actually submitting.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/validationMessage)
+    */
+  validationMessage: string,
+}
+
+include HTMLElement.Impl({type t = t})
 
 @send
-external getSVGDocument: DomTypes.htmlObjectElement => DOM.document = "getSVGDocument"
+external getSVGDocument: t => DOM.document = "getSVGDocument"
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/checkValidity)
 */
 @send
-external checkValidity: DomTypes.htmlObjectElement => bool = "checkValidity"
+external checkValidity: t => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/reportValidity)
 */
 @send
-external reportValidity: DomTypes.htmlObjectElement => bool = "reportValidity"
+external reportValidity: t => bool = "reportValidity"
 
 /**
 Sets a custom error message that is displayed when a form is submitted.
@@ -22,4 +86,4 @@ Sets a custom error message that is displayed when a form is submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/setCustomValidity)
 */
 @send
-external setCustomValidity: (DomTypes.htmlObjectElement, string) => unit = "setCustomValidity"
+external setCustomValidity: (t, string) => unit = "setCustomValidity"

--- a/src/DOM/HTMLOptGroupElement.res
+++ b/src/DOM/HTMLOptGroupElement.res
@@ -1,1 +1,19 @@
-include HTMLElement.Impl({type t = DomTypes.htmlOptGroupElement})
+/**
+Provides special properties and methods (beyond the regular HTMLElement object interface they also have available to them by inheritance) for manipulating the layout and presentation of <optgroup> elements.
+[See HTMLOptGroupElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptGroupElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptGroupElement/disabled)
+    */
+  mutable disabled: bool,
+  /**
+    Sets or retrieves a value that you can use to implement your own label functionality for the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptGroupElement/label)
+    */
+  mutable label: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLOptionElement.res
+++ b/src/DOM/HTMLOptionElement.res
@@ -1,1 +1,49 @@
-include HTMLElement.Impl({type t = DomTypes.htmlOptionElement})
+/**
+<option> elements and inherits all classes and methods of the HTMLElement interface.
+[See HTMLOptionElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/disabled)
+    */
+  mutable disabled: bool,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    Sets or retrieves a value that you can use to implement your own label functionality for the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/label)
+    */
+  mutable label: string,
+  /**
+    Sets or retrieves the status of an option.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/defaultSelected)
+    */
+  mutable defaultSelected: bool,
+  /**
+    Sets or retrieves whether the option in the list box is the default item.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/selected)
+    */
+  mutable selected: bool,
+  /**
+    Sets or retrieves the value which is returned to the server when the form control is submitted.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/value)
+    */
+  mutable value: string,
+  /**
+    Sets or retrieves the text string specified by the option tag.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/text)
+    */
+  mutable text: string,
+  /**
+    Sets or retrieves the ordinal position of an option in a list box.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionElement/index)
+    */
+  index: int,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLOptionsCollection.res
+++ b/src/DOM/HTMLOptionsCollection.res
@@ -1,5 +1,21 @@
 /**
-Inserts element before the DomTypes.node given by before.
+HTMLOptionsCollection is an interface representing a collection of HTML option elements (in document order) and offers methods and properties for traversing the list as well as optionally altering its items. This type is returned solely by the "options" property of select.
+[See HTMLOptionsCollection on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionsCollection)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...HTMLCollection.t<HTMLOptionElement.t>,
+  /**
+    Returns the index of the first selected item, if any, or -1 if there is no selected item.
+
+Can be set, to change the selection.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionsCollection/selectedIndex)
+    */
+  mutable selectedIndex: int,
+}
+
+/**
+Inserts element before the DOMTree.node given by before.
 
 The before argument can be a number, in which case element is inserted before the item with that number, or an element from the collection, in which case element is inserted before that element.
 
@@ -9,12 +25,11 @@ This method will throw a "HierarchyRequestError" DOMException if element is an a
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionsCollection/add)
 */
 @send
-external add: (DomTypes.htmlOptionsCollection, ~element: unknown, ~before: unknown=?) => unit =
-  "add"
+external add: (t, ~element: unknown, ~before: unknown=?) => unit = "add"
 
 /**
 Removes the item with index index from the collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionsCollection/remove)
 */
 @send
-external remove: (DomTypes.htmlOptionsCollection, int) => unit = "remove"
+external remove: (t, int) => unit = "remove"

--- a/src/DOM/HTMLOutputElement.res
+++ b/src/DOM/HTMLOutputElement.res
@@ -1,19 +1,73 @@
-include HTMLElement.Impl({type t = DomTypes.htmlOutputElement})
+/**
+Provides properties and methods (beyond those inherited from HTMLElement) for manipulating the layout and presentation of <output> elements.
+[See HTMLOutputElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/htmlFor)
+    */
+  htmlFor: DOM.domTokenList,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/name)
+    */
+  mutable name: string,
+  /**
+    Returns the string "output".
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/type)
+    */
+  @as("type")
+  type_: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/defaultValue)
+    */
+  mutable defaultValue: string,
+  /**
+    Returns the element's current value.
+
+Can be set, to change the value.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/value)
+    */
+  mutable value: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/willValidate)
+    */
+  willValidate: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/validity)
+    */
+  validity: DOM.validityState,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/validationMessage)
+    */
+  validationMessage: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/labels)
+    */
+  labels: DOM.nodeList<HTMLLabelElement.t>,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/checkValidity)
 */
 @send
-external checkValidity: DomTypes.htmlOutputElement => bool = "checkValidity"
+external checkValidity: t => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/reportValidity)
 */
 @send
-external reportValidity: DomTypes.htmlOutputElement => bool = "reportValidity"
+external reportValidity: t => bool = "reportValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/setCustomValidity)
 */
 @send
-external setCustomValidity: (DomTypes.htmlOutputElement, string) => unit = "setCustomValidity"
+external setCustomValidity: (t, string) => unit = "setCustomValidity"

--- a/src/DOM/HTMLProgressElement.res
+++ b/src/DOM/HTMLProgressElement.res
@@ -1,1 +1,29 @@
-include HTMLElement.Impl({type t = DomTypes.htmlProgressElement})
+/**
+Provides special properties and methods (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of <progress> elements.
+[See HTMLProgressElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLProgressElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Sets or gets the current value of a progress element. The value must be a non-negative number between 0 and the max value.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLProgressElement/value)
+    */
+  mutable value: float,
+  /**
+    Defines the maximum, or "done" value for a progress element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLProgressElement/max)
+    */
+  mutable max: float,
+  /**
+    Returns the quotient of value/max when the value attribute is set (determinate progress bar), or -1 when the value attribute is missing (indeterminate progress bar).
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLProgressElement/position)
+    */
+  position: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLProgressElement/labels)
+    */
+  labels: DOM.nodeList<HTMLLabelElement.t>,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLSelectElement.res
+++ b/src/DOM/HTMLSelectElement.res
@@ -1,11 +1,100 @@
 /**
+A <select> HTML Element. These elements also share all of the properties and methods of other HTML elements via the HTMLElement interface.
+[See HTMLSelectElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/disabled)
+    */
+  mutable disabled: bool,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    Sets or retrieves the Boolean value indicating whether multiple items can be selected from a list.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/multiple)
+    */
+  mutable multiple: bool,
+  /**
+    Sets or retrieves the name of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/name)
+    */
+  mutable name: string,
+  /**
+    When present, marks an element that can't be submitted without a value.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/required)
+    */
+  mutable required: bool,
+  /**
+    Sets or retrieves the number of rows in the list box.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/size)
+    */
+  mutable size: int,
+  /**
+    Retrieves the type of select control based on the value of the MULTIPLE attribute.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/type)
+    */
+  @as("type")
+  type_: string,
+  /**
+    Returns an HTMLOptionsCollection of the list of options.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/options)
+    */
+  options: HTMLOptionsCollection.t,
+  /**
+    Sets or retrieves the number of objects in a collection.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/length)
+    */
+  mutable length: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/selectedOptions)
+    */
+  selectedOptions: HTMLCollection.t<HTMLOptionElement.t>,
+  /**
+    Sets or retrieves the index of the selected option in a select object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/selectedIndex)
+    */
+  mutable selectedIndex: int,
+  /**
+    Sets or retrieves the value which is returned to the server when the form control is submitted.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/value)
+    */
+  mutable value: string,
+  /**
+    Returns whether an element will successfully validate based on forms validation rules and constraints.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/willValidate)
+    */
+  willValidate: bool,
+  /**
+    Returns a  ValidityState object that represents the validity states of an element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/validity)
+    */
+  validity: DOM.validityState,
+  /**
+    Returns the error message that would be displayed if the user submits the form, or an empty string if no error message. It also triggers the standard error message, such as "this is a required field". The result is that the user sees validation messages without actually submitting.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/validationMessage)
+    */
+  validationMessage: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/labels)
+    */
+  labels: DOM.nodeList<HTMLLabelElement.t>,
+}
+
+include HTMLElement.Impl({type t = t})
+
+/**
 Retrieves a select object or an object from an options collection.
 @param name Variant of type Number or String that specifies the object or collection to retrieve. If this parameter is an integer, it is the zero-based index of the object. If this parameter is a string, all objects with matching name or id properties are retrieved, and a collection is returned if more than one match is made.
 @param index Variant of type Number that specifies the zero-based index of the object to retrieve when a collection is returned.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/item)
 */
 @send
-external item: (DomTypes.htmlSelectElement, int) => DomTypes.htmlOptionElement = "item"
+external item: (t, int) => HTMLOptionElement.t = "item"
 
 /**
 Retrieves a select object or an object from an options collection.
@@ -13,7 +102,7 @@ Retrieves a select object or an object from an options collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/namedItem)
 */
 @send
-external namedItem: (DomTypes.htmlSelectElement, string) => DomTypes.htmlOptionElement = "namedItem"
+external namedItem: (t, string) => HTMLOptionElement.t = "namedItem"
 
 /**
 Adds an element to the areas, controlRange, or options collection.
@@ -22,7 +111,7 @@ Adds an element to the areas, controlRange, or options collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/add)
 */
 @send
-external add: (DomTypes.htmlSelectElement, ~element: unknown, ~before: unknown=?) => unit = "add"
+external add: (t, ~element: unknown, ~before: unknown=?) => unit = "add"
 
 /**
 Removes an element from the collection.
@@ -30,7 +119,7 @@ Removes an element from the collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/remove)
 */
 @send
-external removeH: DomTypes.htmlSelectElement => unit = "remove"
+external removeH: t => unit = "remove"
 
 /**
 Removes an element from the collection.
@@ -38,20 +127,20 @@ Removes an element from the collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/remove)
 */
 @send
-external removeH2: (DomTypes.htmlSelectElement, int) => unit = "remove"
+external removeH2: (t, int) => unit = "remove"
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/checkValidity)
 */
 @send
-external checkValidity: DomTypes.htmlSelectElement => bool = "checkValidity"
+external checkValidity: t => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/reportValidity)
 */
 @send
-external reportValidity: DomTypes.htmlSelectElement => bool = "reportValidity"
+external reportValidity: t => bool = "reportValidity"
 
 /**
 Sets a custom error message that is displayed when a form is submitted.
@@ -59,12 +148,10 @@ Sets a custom error message that is displayed when a form is submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/setCustomValidity)
 */
 @send
-external setCustomValidity: (DomTypes.htmlSelectElement, string) => unit = "setCustomValidity"
+external setCustomValidity: (t, string) => unit = "setCustomValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/showPicker)
 */
 @send
-external showPicker: DomTypes.htmlSelectElement => unit = "showPicker"
-
-include HTMLElement.Impl({type t = DomTypes.htmlSelectElement})
+external showPicker: t => unit = "showPicker"

--- a/src/DOM/HTMLTableCaptionElement.res
+++ b/src/DOM/HTMLTableCaptionElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTableCaptionElement})
+/**
+Special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating table caption elements.
+[See HTMLTableCaptionElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableCaptionElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLTableCellElement.res
+++ b/src/DOM/HTMLTableCellElement.res
@@ -1,1 +1,40 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTableCellElement})
+/**
+Provides special properties and methods (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of table cells, either header or data cells, in an HTML document.
+[See HTMLTableCellElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableCellElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Sets or retrieves the number columns in the table that the object should span.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableCellElement/colSpan)
+    */
+  mutable colSpan: int,
+  /**
+    Sets or retrieves how many rows in a table the cell should span.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableCellElement/rowSpan)
+    */
+  mutable rowSpan: int,
+  /**
+    Sets or retrieves a list of header cells that provide information for the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableCellElement/headers)
+    */
+  mutable headers: string,
+  /**
+    Retrieves the position of the object in the cells collection of a row.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableCellElement/cellIndex)
+    */
+  cellIndex: int,
+  /**
+    Sets or retrieves the group of cells in a table to which the object's information applies.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableCellElement/scope)
+    */
+  mutable scope: string,
+  /**
+    Sets or retrieves abbreviated text for the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableCellElement/abbr)
+    */
+  mutable abbr: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLTableElement.res
+++ b/src/DOM/HTMLTableElement.res
@@ -1,54 +1,87 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTableElement})
+/**
+Provides special properties and methods (beyond the regular HTMLElement object interface it also has available to it by inheritance) for manipulating the layout and presentation of tables in an HTML document.
+[See HTMLTableElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type rec t = {
+  ...DOMTree.htmlElement,
+  /**
+    Retrieves the caption object of a table.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/caption)
+    */
+  mutable caption: Null.t<HTMLTableCaptionElement.t>,
+  /**
+    Retrieves the tHead object of the table.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/tHead)
+    */
+  mutable tHead: Null.t<HTMLTableSectionElement.t>,
+  /**
+    Retrieves the tFoot object of the table.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/tFoot)
+    */
+  mutable tFoot: Null.t<HTMLTableSectionElement.t>,
+  /**
+    Retrieves a collection of all tBody objects in the table. Objects in this collection are in source order.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/tBodies)
+    */
+  tBodies: HTMLCollection.t<HTMLTableSectionElement.t>,
+  /**
+    Sets or retrieves the number of horizontal rows contained in the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/rows)
+    */
+  rows: HTMLCollection.t<HTMLTableRowElement.t>,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Creates an empty caption element in the table.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/createCaption)
 */
 @send
-external createCaption: DomTypes.htmlTableElement => DomTypes.htmlTableCaptionElement =
-  "createCaption"
+external createCaption: t => HTMLTableCaptionElement.t = "createCaption"
 
 /**
 Deletes the caption element and its contents from the table.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteCaption)
 */
 @send
-external deleteCaption: DomTypes.htmlTableElement => unit = "deleteCaption"
+external deleteCaption: t => unit = "deleteCaption"
 
 /**
 Returns the tHead element object if successful, or null otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/createTHead)
 */
 @send
-external createTHead: DomTypes.htmlTableElement => DomTypes.htmlTableSectionElement = "createTHead"
+external createTHead: t => HTMLTableSectionElement.t = "createTHead"
 
 /**
 Deletes the tHead element and its contents from the table.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteTHead)
 */
 @send
-external deleteTHead: DomTypes.htmlTableElement => unit = "deleteTHead"
+external deleteTHead: t => unit = "deleteTHead"
 
 /**
 Creates an empty tFoot element in the table.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/createTFoot)
 */
 @send
-external createTFoot: DomTypes.htmlTableElement => DomTypes.htmlTableSectionElement = "createTFoot"
+external createTFoot: t => HTMLTableSectionElement.t = "createTFoot"
 
 /**
 Deletes the tFoot element and its contents from the table.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteTFoot)
 */
 @send
-external deleteTFoot: DomTypes.htmlTableElement => unit = "deleteTFoot"
+external deleteTFoot: t => unit = "deleteTFoot"
 
 /**
 Creates an empty tBody element in the table.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/createTBody)
 */
 @send
-external createTBody: DomTypes.htmlTableElement => DomTypes.htmlTableSectionElement = "createTBody"
+external createTBody: t => HTMLTableSectionElement.t = "createTBody"
 
 /**
 Creates a new row (tr) in the table, and adds the row to the rows collection.
@@ -56,8 +89,7 @@ Creates a new row (tr) in the table, and adds the row to the rows collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/insertRow)
 */
 @send
-external insertRow: (DomTypes.htmlTableElement, ~index: int=?) => DomTypes.htmlTableRowElement =
-  "insertRow"
+external insertRow: (t, ~index: int=?) => HTMLTableRowElement.t = "insertRow"
 
 /**
 Removes the specified row (tr) from the element and from the rows collection.
@@ -65,4 +97,4 @@ Removes the specified row (tr) from the element and from the rows collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteRow)
 */
 @send
-external deleteRow: (DomTypes.htmlTableElement, int) => unit = "deleteRow"
+external deleteRow: (t, int) => unit = "deleteRow"

--- a/src/DOM/HTMLTableRowElement.res
+++ b/src/DOM/HTMLTableRowElement.res
@@ -1,4 +1,27 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTableRowElement})
+/**
+Provides special properties and methods (beyond the HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of rows in an HTML table.
+[See HTMLTableRowElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableRowElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+  /**
+    Retrieves the position of the object in the rows collection for the table.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableRowElement/rowIndex)
+    */
+  rowIndex: int,
+  /**
+    Retrieves the position of the object in the collection.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableRowElement/sectionRowIndex)
+    */
+  sectionRowIndex: int,
+  /**
+    Retrieves a collection of all cells in the table row.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableRowElement/cells)
+    */
+  cells: HTMLCollection.t<HTMLTableCellElement.t>,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Creates a new cell in the table row, and adds the cell to the cells collection.
@@ -6,10 +29,7 @@ Creates a new cell in the table row, and adds the cell to the cells collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableRowElement/insertCell)
 */
 @send
-external insertCell: (
-  DomTypes.htmlTableRowElement,
-  ~index: int=?,
-) => DomTypes.htmlTableCellElement = "insertCell"
+external insertCell: (t, ~index: int=?) => HTMLTableCellElement.t = "insertCell"
 
 /**
 Removes the specified cell from the table row, as well as from the cells collection.
@@ -17,4 +37,4 @@ Removes the specified cell from the table row, as well as from the cells collect
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableRowElement/deleteCell)
 */
 @send
-external deleteCell: (DomTypes.htmlTableRowElement, int) => unit = "deleteCell"
+external deleteCell: (t, int) => unit = "deleteCell"

--- a/src/DOM/HTMLTableSectionElement.res
+++ b/src/DOM/HTMLTableSectionElement.res
@@ -1,4 +1,17 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTableSectionElement})
+/**
+Provides special properties and methods (beyond the HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of sections, that is headers, footers and bodies, in an HTML table.
+[See HTMLTableSectionElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableSectionElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+  /**
+    Sets or retrieves the number of horizontal rows contained in the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableSectionElement/rows)
+    */
+  rows: HTMLCollection.t<HTMLTableRowElement.t>,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Creates a new row (tr) in the table, and adds the row to the rows collection.
@@ -6,10 +19,7 @@ Creates a new row (tr) in the table, and adds the row to the rows collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableSectionElement/insertRow)
 */
 @send
-external insertRow: (
-  DomTypes.htmlTableSectionElement,
-  ~index: int=?,
-) => DomTypes.htmlTableRowElement = "insertRow"
+external insertRow: (t, ~index: int=?) => HTMLTableRowElement.t = "insertRow"
 
 /**
 Removes the specified row (tr) from the element and from the rows collection.
@@ -17,4 +27,4 @@ Removes the specified row (tr) from the element and from the rows collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableSectionElement/deleteRow)
 */
 @send
-external deleteRow: (DomTypes.htmlTableSectionElement, int) => unit = "deleteRow"
+external deleteRow: (t, int) => unit = "deleteRow"

--- a/src/DOM/HTMLTemplateElement.res
+++ b/src/DOM/HTMLTemplateElement.res
@@ -1,1 +1,31 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTemplateElement})
+/**
+Enables access to the contents of an HTML <template> element.
+[See HTMLTemplateElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Returns the template contents (a DocumentFragment).
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/content)
+    */
+  content: DOMTree.documentFragment,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/shadowRootMode)
+    */
+  mutable shadowRootMode: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/shadowRootDelegatesFocus)
+    */
+  mutable shadowRootDelegatesFocus: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/shadowRootClonable)
+    */
+  mutable shadowRootClonable: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTemplateElement/shadowRootSerializable)
+    */
+  mutable shadowRootSerializable: bool,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLTextAreaElement.res
+++ b/src/DOM/HTMLTextAreaElement.res
@@ -1,17 +1,136 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTextAreaElement})
+/**
+Provides special properties and methods for manipulating the layout and presentation of <textarea> elements.
+[See HTMLTextAreaElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/autocomplete)
+    */
+  mutable autocomplete: string,
+  /**
+    Sets or retrieves the width of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/cols)
+    */
+  mutable cols: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/disabled)
+    */
+  mutable disabled: bool,
+  /**
+    Retrieves a reference to the form that the object is embedded in.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/form)
+    */
+  form: Null.t<DOMTree.htmlFormElement>,
+  /**
+    Sets or retrieves the maximum number of characters that the user can enter in a text control.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/maxLength)
+    */
+  mutable maxLength: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/minLength)
+    */
+  mutable minLength: int,
+  /**
+    Sets or retrieves the name of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/name)
+    */
+  mutable name: string,
+  /**
+    Gets or sets a text string that is displayed in an input field as a hint or prompt to users as the format or type of information they need to enter.The text appears in an input field until the user puts focus on the field.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/placeholder)
+    */
+  mutable placeholder: string,
+  /**
+    Sets or retrieves the value indicated whether the content of the object is read-only.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/readOnly)
+    */
+  mutable readOnly: bool,
+  /**
+    When present, marks an element that can't be submitted without a value.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/required)
+    */
+  mutable required: bool,
+  /**
+    Sets or retrieves the number of horizontal rows contained in the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/rows)
+    */
+  mutable rows: int,
+  /**
+    Sets or retrieves how to handle wordwrapping in the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/wrap)
+    */
+  mutable wrap: string,
+  /**
+    Retrieves the type of control.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/type)
+    */
+  @as("type")
+  type_: string,
+  /**
+    Sets or retrieves the initial contents of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/defaultValue)
+    */
+  mutable defaultValue: string,
+  /**
+    Retrieves or sets the text in the entry field of the textArea element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/value)
+    */
+  mutable value: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/textLength)
+    */
+  textLength: int,
+  /**
+    Returns whether an element will successfully validate based on forms validation rules and constraints.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/willValidate)
+    */
+  willValidate: bool,
+  /**
+    Returns a  ValidityState object that represents the validity states of an element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/validity)
+    */
+  validity: DOM.validityState,
+  /**
+    Returns the error message that would be displayed if the user submits the form, or an empty string if no error message. It also triggers the standard error message, such as "this is a required field". The result is that the user sees validation messages without actually submitting.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/validationMessage)
+    */
+  validationMessage: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/labels)
+    */
+  labels: DOM.nodeList<HTMLLabelElement.t>,
+  /**
+    Gets or sets the starting position or offset of a text selection.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/selectionStart)
+    */
+  mutable selectionStart: int,
+  /**
+    Gets or sets the end position or offset of a text selection.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/selectionEnd)
+    */
+  mutable selectionEnd: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/selectionDirection)
+    */
+  mutable selectionDirection: string,
+}
+
+include HTMLElement.Impl({type t = t})
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/checkValidity)
 */
 @send
-external checkValidity: DomTypes.htmlTextAreaElement => bool = "checkValidity"
+external checkValidity: t => bool = "checkValidity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/reportValidity)
 */
 @send
-external reportValidity: DomTypes.htmlTextAreaElement => bool = "reportValidity"
+external reportValidity: t => bool = "reportValidity"
 
 /**
 Sets a custom error message that is displayed when a form is submitted.
@@ -19,31 +138,31 @@ Sets a custom error message that is displayed when a form is submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/setCustomValidity)
 */
 @send
-external setCustomValidity: (DomTypes.htmlTextAreaElement, string) => unit = "setCustomValidity"
+external setCustomValidity: (t, string) => unit = "setCustomValidity"
 
 /**
 Highlights the input area of a form element.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/select)
 */
 @send
-external select: DomTypes.htmlTextAreaElement => unit = "select"
+external select: t => unit = "select"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/setRangeText)
 */
 @send
-external setRangeText: (DomTypes.htmlTextAreaElement, string) => unit = "setRangeText"
+external setRangeText: (t, string) => unit = "setRangeText"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/setRangeText)
 */
 @send
 external setRangeText2: (
-  DomTypes.htmlTextAreaElement,
+  t,
   ~replacement: string,
   ~start: int,
   ~end: int,
-  ~selectionMode: DomTypes.selectionMode=?,
+  ~selectionMode: DOM.selectionMode=?,
 ) => unit = "setRangeText"
 
 /**
@@ -54,9 +173,5 @@ Sets the start and end positions of a selection in a text field.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/setSelectionRange)
 */
 @send
-external setSelectionRange: (
-  DomTypes.htmlTextAreaElement,
-  ~start: int,
-  ~end: int,
-  ~direction: string=?,
-) => unit = "setSelectionRange"
+external setSelectionRange: (t, ~start: int, ~end: int, ~direction: string=?) => unit =
+  "setSelectionRange"


### PR DESCRIPTION
Tracking issue: #342

## Summary

- define form-control interface records in their owning HTML modules
- define table and template interface records locally
- update those modules to use the new local types instead of broad `DomTypes` element aliases

## Temporary state

- the old aggregate HTML definitions remain in `DOM`/`DomTypes` during the incremental migration
- #310 removes those aggregate copies after every dependent interface has moved
- these modules remain in the broad DOM source folder until the follow-up Option 5 folder/feature stack moves them into the HTML folder feature

## Review focus

- completeness and type relationships for forms, controls, tables, and templates
- public signature equivalence with the former aggregate definitions

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`