### PR TITLE
refactor: define HTML document interfaces locally

### DIFF
--- a/rescript.json
+++ b/rescript.json
@@ -116,6 +116,7 @@
         "HTMLDataListElement",
         "HTMLDialogElement",
         "HTMLDivElement",
+        "HTML",
         "HTMLElement",
         "HTMLEmbedElement",
         "HTMLFieldSetElement",

--- a/src/DOM/HTML.res
+++ b/src/DOM/HTML.res
@@ -1,0 +1,11 @@
+type shadowRootInit = {
+  mutable mode: DOMTree.shadowRootMode,
+  mutable delegatesFocus?: bool,
+  mutable slotAssignment?: DOMTree.slotAssignmentMode,
+  mutable serializable?: bool,
+}
+
+type getHTMLOptions = {
+  mutable serializableShadowRoots?: bool,
+  mutable shadowRoots?: array<DOMTree.shadowRoot>,
+}

--- a/src/DOM/HTMLBRElement.res
+++ b/src/DOM/HTMLBRElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlbrElement})
+/**
+A HTML line break element (<br>). It inherits from HTMLElement.
+[See HTMLBRElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLBRElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLBaseElement.res
+++ b/src/DOM/HTMLBaseElement.res
@@ -1,1 +1,20 @@
-include HTMLElement.Impl({type t = DomTypes.htmlBaseElement})
+/**
+Contains the base URI for a document. This object inherits all of the properties and methods as described in the HTMLElement interface.
+[See HTMLBaseElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLBaseElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Gets or sets the baseline WebApiURL on which relative links are based.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLBaseElement/href)
+    */
+  mutable href: string,
+  /**
+    Sets or retrieves the window or frame at which to target content.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLBaseElement/target)
+    */
+  mutable target: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLBodyElement.res
+++ b/src/DOM/HTMLBodyElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlBodyElement})
+/**
+Provides special properties (beyond those inherited from the regular HTMLElement interface) for manipulating <body> elements.
+[See HTMLBodyElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLBodyElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLDListElement.res
+++ b/src/DOM/HTMLDListElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmldListElement})
+/**
+Provides special properties (beyond those of the regular HTMLElement interface it also has available to it by inheritance) for manipulating definition list (<dl>) elements.
+[See HTMLDListElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDListElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLDataElement.res
+++ b/src/DOM/HTMLDataElement.res
@@ -1,1 +1,14 @@
-include HTMLElement.Impl({type t = DomTypes.htmlDataElement})
+/**
+Provides special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating <data> elements.
+[See HTMLDataElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDataElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDataElement/value)
+    */
+  mutable value: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLDivElement.res
+++ b/src/DOM/HTMLDivElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlDivElement})
+/**
+Provides special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating <div> elements.
+[See HTMLDivElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDivElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLFrameSetElement.res
+++ b/src/DOM/HTMLFrameSetElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlFrameSetElement})
+/**
+Provides special properties (beyond those of the regular HTMLElement interface they also inherit) for manipulating <frameset> elements.
+[See HTMLFrameSetElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFrameSetElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLHRElement.res
+++ b/src/DOM/HTMLHRElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlhrElement})
+/**
+Provides special properties (beyond those of the HTMLElement interface it also has available to it by inheritance) for manipulating <hr> elements.
+[See HTMLHRElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLHRElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLHeadElement.res
+++ b/src/DOM/HTMLHeadElement.res
@@ -1,1 +1,258 @@
-include HTMLElement.Impl({type t = DomTypes.htmlHeadElement})
+/**
+Contains the descriptive information, or metadata, for a document. This object inherits all of the properties and methods described in the HTMLElement interface.
+[See HTMLHeadElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLHeadElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type rec t = {
+  // Base properties from HTMLElement
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/title)
+    */
+  mutable title: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/lang)
+    */
+  mutable lang: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/translate)
+    */
+  mutable translate: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/dir)
+    */
+  mutable dir: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
+    */
+  mutable hidden: unknown,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
+    */
+  mutable inert: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKey)
+    */
+  mutable accessKey: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKeyLabel)
+    */
+  accessKeyLabel: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/draggable)
+    */
+  mutable draggable: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/spellcheck)
+    */
+  mutable spellcheck: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/autocapitalize)
+    */
+  mutable autocapitalize: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/innerText)
+    */
+  mutable innerText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/outerText)
+    */
+  mutable outerText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/popover)
+    */
+  mutable popover: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetParent)
+    */
+  offsetParent: Null.t<DOMTree.element>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetTop)
+    */
+  offsetTop: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetLeft)
+    */
+  offsetLeft: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth)
+    */
+  offsetWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetHeight)
+    */
+  offsetHeight: int,
+  // End base properties from HTMLElement
+
+  // Base properties from Element
+  /**
+    Returns the namespace.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/namespaceURI)
+    */
+  namespaceURI: Null.t<string>,
+  /**
+    Returns the namespace prefix.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/prefix)
+    */
+  prefix: Null.t<string>,
+  /**
+    Returns the local name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/localName)
+    */
+  localName: string,
+  /**
+    Returns the HTML-uppercased qualified name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/tagName)
+    */
+  tagName: string,
+  /**
+    Returns the value of element's id content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/id)
+    */
+  mutable id: string,
+  /**
+    Returns the value of element's class content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/className)
+    */
+  mutable className: string,
+  /**
+    Allows for manipulation of element's class content attribute as a set of whitespace-separated tokens through a DOMTokenList object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/classList)
+    */
+  classList: DOM.domTokenList,
+  /**
+    Returns the value of element's slot content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/slot)
+    */
+  mutable slot: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/attributes)
+    */
+  attributes: DOM.namedNodeMap,
+  /**
+    Returns element's shadow root, if any, and if shadow root's mode is "open", and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/shadowRoot)
+    */
+  shadowRoot: Null.t<DOMTree.shadowRoot>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/part)
+    */
+  part: DOM.domTokenList,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollTop)
+    */
+  mutable scrollTop: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollLeft)
+    */
+  mutable scrollLeft: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollWidth)
+    */
+  scrollWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollHeight)
+    */
+  scrollHeight: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientTop)
+    */
+  clientTop: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientLeft)
+    */
+  clientLeft: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientWidth)
+    */
+  clientWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientHeight)
+    */
+  clientHeight: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/currentCSSZoom)
+    */
+  currentCSSZoom: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
+    */
+  mutable innerHTML: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
+    */
+  mutable outerHTML: string,
+  // End base properties from Element
+
+  // Base properties from Node
+  /**
+    Returns the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeType)
+    */
+  nodeType: int,
+  /**
+    Returns a string appropriate for the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeName)
+    */
+  nodeName: string,
+  /**
+    Returns node's node document's document base URL.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/baseURI)
+    */
+  baseURI: string,
+  /**
+    Returns true if node is connected and false otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/isConnected)
+    */
+  isConnected: bool,
+  /**
+    Returns the node document. Returns null for documents.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/ownerDocument)
+    */
+  ownerDocument: Null.t<DOM.document>,
+  /**
+    Returns the parent.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentNode)
+    */
+  parentNode: Null.t<DOMTree.node>,
+  /**
+    Returns the parent element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentElement)
+    */
+  parentElement: Null.t<DOMTree.htmlElement>,
+  /**
+    Returns the children.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/childNodes)
+    */
+  childNodes: DOM.nodeList<DOMTree.node>,
+  /**
+    Returns the first child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/firstChild)
+    */
+  firstChild: Null.t<DOMTree.node>,
+  /**
+    Returns the last child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/lastChild)
+    */
+  lastChild: Null.t<DOMTree.node>,
+  /**
+    Returns the previous sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/previousSibling)
+    */
+  previousSibling: Null.t<DOMTree.node>,
+  /**
+    Returns the next sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nextSibling)
+    */
+  nextSibling: Null.t<DOMTree.node>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeValue)
+    */
+  mutable nodeValue: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/textContent)
+    */
+  mutable textContent: Null.t<string>,
+  // End base properties from Node
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLHeadingElement.res
+++ b/src/DOM/HTMLHeadingElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlHeadingElement})
+/**
+The different heading elements. It inherits methods and properties from the HTMLElement interface.
+[See HTMLHeadingElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLHeadingElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLHtmlElement.res
+++ b/src/DOM/HTMLHtmlElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlHtmlElement})
+/**
+Serves as the root node for a given HTML document. This object inherits the properties and methods described in the HTMLElement interface.
+[See HTMLHtmlElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLHtmlElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLLIElement.res
+++ b/src/DOM/HTMLLIElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlliElement})
+/**
+Exposes specific properties and methods (beyond those defined by regular HTMLElement interface it also has available to it by inheritance) for manipulating list elements.
+[See HTMLLIElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLIElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLMapElement.res
+++ b/src/DOM/HTMLMapElement.res
@@ -1,1 +1,20 @@
-include HTMLElement.Impl({type t = DomTypes.htmlMapElement})
+/**
+Provides special properties and methods (beyond those of the regular object HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of map elements.
+[See HTMLMapElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMapElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Sets or retrieves the name of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMapElement/name)
+    */
+  mutable name: string,
+  /**
+    Retrieves a collection of the area objects defined for the given map object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMapElement/areas)
+    */
+  areas: HTMLCollection.t<DOMTree.element>,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLMenuElement.res
+++ b/src/DOM/HTMLMenuElement.res
@@ -1,1 +1,8 @@
-include HTMLElement.Impl({type t = DomTypes.htmlMenuElement})
+/**
+[See HTMLMenuElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMenuElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLModElement.res
+++ b/src/DOM/HTMLModElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlModElement})
+/**
+Provides special properties (beyond the regular methods and properties available through the HTMLElement interface they also have available to them by inheritance) for manipulating modification elements, that is <del> and <ins>.
+[See HTMLModElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLModElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLOListElement.res
+++ b/src/DOM/HTMLOListElement.res
@@ -1,1 +1,24 @@
-include HTMLElement.Impl({type t = DomTypes.htmloListElement})
+/**
+Provides special properties (beyond those defined on the regular HTMLElement interface it also has available to it by inheritance) for manipulating ordered list elements.
+[See HTMLOListElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOListElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOListElement/reversed)
+    */
+  mutable reversed: bool,
+  /**
+    The starting number.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOListElement/start)
+    */
+  mutable start: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOListElement/type)
+    */
+  @as("type")
+  mutable type_: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLParagraphElement.res
+++ b/src/DOM/HTMLParagraphElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlParagraphElement})
+/**
+Provides special properties (beyond those of the regular HTMLElement object interface it inherits) for manipulating <p> elements.
+[See HTMLParagraphElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLParagraphElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLPreElement.res
+++ b/src/DOM/HTMLPreElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlPreElement})
+/**
+Exposes specific properties and methods (beyond those of the HTMLElement interface it also has available to it by inheritance) for manipulating a block of preformatted text (<pre>).
+[See HTMLPreElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLPreElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLQuoteElement.res
+++ b/src/DOM/HTMLQuoteElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlQuoteElement})
+/**
+Provides special properties and methods (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating quoting elements, like <blockquote> and <q>, but not the <cite> element.
+[See HTMLQuoteElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLQuoteElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLSpanElement.res
+++ b/src/DOM/HTMLSpanElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmlSpanElement})
+/**
+A <span> element and derives from the HTMLElement interface, but without implementing any additional properties or methods.
+[See HTMLSpanElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSpanElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLTimeElement.res
+++ b/src/DOM/HTMLTimeElement.res
@@ -1,1 +1,14 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTimeElement})
+/**
+Provides special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating <time> elements.
+[See HTMLTimeElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTimeElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTimeElement/dateTime)
+    */
+  mutable dateTime: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLTitleElement.res
+++ b/src/DOM/HTMLTitleElement.res
@@ -1,1 +1,15 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTitleElement})
+/**
+Contains the title for a document. This element inherits all of the properties and methods of the HTMLElement interface.
+[See HTMLTitleElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTitleElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Retrieves or sets the text of the object as a string.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTitleElement/text)
+    */
+  mutable text: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLUListElement.res
+++ b/src/DOM/HTMLUListElement.res
@@ -1,1 +1,9 @@
-include HTMLElement.Impl({type t = DomTypes.htmluListElement})
+/**
+Provides special properties (beyond those defined on the regular HTMLElement interface it also has available to it by inheritance) for manipulating unordered list elements.
+[See HTMLUListElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLUListElement)
+*/
+type t = private {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLUnknownElement.res
+++ b/src/DOM/HTMLUnknownElement.res
@@ -1,0 +1,9 @@
+/**
+An invalid HTML element and derives from the HTMLElement interface, but without implementing any additional properties or methods.
+[See HTMLUnknownElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLUnknownElement)
+*/
+type t = {
+  ...DOMTree.htmlElement,
+}
+
+include HTMLElement.Impl({type t = t})


### PR DESCRIPTION
Tracking issue: #342

## Summary

- add the public `HTML` module for shared HTML option types
- define document-structure and content-element records in their owning modules
- add the missing `HTMLUnknownElement` interface
- update those modules to use their local interface types

## Temporary state

- the matching aggregate HTML definitions remain in `DOM`/`DomTypes` while later HTML families are migrated
- #310 removes the aggregate copies and the `DomTypes` compatibility module
- the new modules remain in the broad DOM source folder until the follow-up Option 5 stack establishes the HTML folder feature

## Review focus

- ownership of shared options in `HTML`
- completeness and public compatibility of the document/content element interfaces

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`