### PR TITLE
refactor: define HTML link interfaces locally

### DIFF
--- a/src/DOM/HTMLAnchorElement.res
+++ b/src/DOM/HTMLAnchorElement.res
@@ -1,1 +1,375 @@
-include HTMLElement.Impl({type t = DomTypes.htmlAnchorElement})
+/**
+Hyperlink elements and provides special properties and methods (beyond those of the regular HTMLElement object interface that they inherit from) for manipulating the layout and presentation of such elements.
+[See HTMLAnchorElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  // Base properties from HTMLElement
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/title)
+    */
+  mutable title: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/lang)
+    */
+  mutable lang: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/translate)
+    */
+  mutable translate: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/dir)
+    */
+  mutable dir: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
+    */
+  mutable hidden: unknown,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
+    */
+  mutable inert: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKey)
+    */
+  mutable accessKey: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKeyLabel)
+    */
+  accessKeyLabel: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/draggable)
+    */
+  mutable draggable: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/spellcheck)
+    */
+  mutable spellcheck: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/autocapitalize)
+    */
+  mutable autocapitalize: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/innerText)
+    */
+  mutable innerText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/outerText)
+    */
+  mutable outerText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/popover)
+    */
+  mutable popover: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetParent)
+    */
+  offsetParent: Null.t<DOMTree.element>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetTop)
+    */
+  offsetTop: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetLeft)
+    */
+  offsetLeft: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth)
+    */
+  offsetWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetHeight)
+    */
+  offsetHeight: int,
+  // End base properties from HTMLElement
+
+  // Base properties from Element
+  /**
+    Returns the namespace.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/namespaceURI)
+    */
+  namespaceURI: Null.t<string>,
+  /**
+    Returns the namespace prefix.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/prefix)
+    */
+  prefix: Null.t<string>,
+  /**
+    Returns the local name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/localName)
+    */
+  localName: string,
+  /**
+    Returns the HTML-uppercased qualified name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/tagName)
+    */
+  tagName: string,
+  /**
+    Returns the value of element's id content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/id)
+    */
+  mutable id: string,
+  /**
+    Returns the value of element's class content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/className)
+    */
+  mutable className: string,
+  /**
+    Allows for manipulation of element's class content attribute as a set of whitespace-separated tokens through a DOMTokenList object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/classList)
+    */
+  classList: DOM.domTokenList,
+  /**
+    Returns the value of element's slot content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/slot)
+    */
+  mutable slot: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/attributes)
+    */
+  attributes: DOM.namedNodeMap,
+  /**
+    Returns element's shadow root, if any, and if shadow root's mode is "open", and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/shadowRoot)
+    */
+  shadowRoot: Null.t<DOMTree.shadowRoot>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/part)
+    */
+  part: DOM.domTokenList,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollTop)
+    */
+  mutable scrollTop: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollLeft)
+    */
+  mutable scrollLeft: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollWidth)
+    */
+  scrollWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollHeight)
+    */
+  scrollHeight: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientTop)
+    */
+  clientTop: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientLeft)
+    */
+  clientLeft: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientWidth)
+    */
+  clientWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientHeight)
+    */
+  clientHeight: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/currentCSSZoom)
+    */
+  currentCSSZoom: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
+    */
+  mutable innerHTML: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
+    */
+  mutable outerHTML: string,
+  // End base properties from Element
+
+  // Base properties from Node
+  /**
+    Returns the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeType)
+    */
+  nodeType: int,
+  /**
+    Returns a string appropriate for the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeName)
+    */
+  nodeName: string,
+  /**
+    Returns node's node document's document base URL.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/baseURI)
+    */
+  baseURI: string,
+  /**
+    Returns true if node is connected and false otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/isConnected)
+    */
+  isConnected: bool,
+  /**
+    Returns the node document. Returns null for documents.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/ownerDocument)
+    */
+  ownerDocument: Null.t<DOM.document>,
+  /**
+    Returns the parent.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentNode)
+    */
+  parentNode: Null.t<DOMTree.node>,
+  /**
+    Returns the parent element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentElement)
+    */
+  parentElement: Null.t<DOMTree.htmlElement>,
+  /**
+    Returns the children.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/childNodes)
+    */
+  childNodes: DOM.nodeList<DOMTree.node>,
+  /**
+    Returns the first child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/firstChild)
+    */
+  firstChild: Null.t<DOMTree.node>,
+  /**
+    Returns the last child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/lastChild)
+    */
+  lastChild: Null.t<DOMTree.node>,
+  /**
+    Returns the previous sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/previousSibling)
+    */
+  previousSibling: Null.t<DOMTree.node>,
+  /**
+    Returns the next sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nextSibling)
+    */
+  nextSibling: Null.t<DOMTree.node>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeValue)
+    */
+  mutable nodeValue: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/textContent)
+    */
+  mutable textContent: Null.t<string>,
+  // End base properties from Node
+
+  /**
+    Sets or retrieves the window or frame at which to target content.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/target)
+    */
+  mutable target: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/download)
+    */
+  mutable download: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/ping)
+    */
+  mutable ping: string,
+  /**
+    Sets or retrieves the relationship between the object and the destination of the link.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/rel)
+    */
+  mutable rel: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/relList)
+    */
+  relList: DOM.domTokenList,
+  /**
+    Sets or retrieves the language code of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/hreflang)
+    */
+  mutable hreflang: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/type)
+    */
+  @as("type")
+  mutable type_: string,
+  /**
+    Retrieves or sets the text of the object as a string.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/text)
+    */
+  mutable text: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/referrerPolicy)
+    */
+  mutable referrerPolicy: string,
+  /**
+    Returns the hyperlink's URL.
+
+Can be set, to change the URL.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/href)
+    */
+  mutable href: string,
+  /**
+    Returns the hyperlink's WebApiURL's origin.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/origin)
+    */
+  origin: string,
+  /**
+    Returns the hyperlink's WebApiURL's scheme.
+
+Can be set, to change the WebApiURL's scheme.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/protocol)
+    */
+  mutable protocol: string,
+  /**
+    Returns the hyperlink's WebApiURL's username.
+
+Can be set, to change the WebApiURL's username.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/username)
+    */
+  mutable username: string,
+  /**
+    Returns the hyperlink's WebApiURL's password.
+
+Can be set, to change the WebApiURL's password.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/password)
+    */
+  mutable password: string,
+  /**
+    Returns the hyperlink's WebApiURL's host and port (if different from the default port for the scheme).
+
+Can be set, to change the WebApiURL's host and port.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/host)
+    */
+  mutable host: string,
+  /**
+    Returns the hyperlink's WebApiURL's host.
+
+Can be set, to change the WebApiURL's host.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/hostname)
+    */
+  mutable hostname: string,
+  /**
+    Returns the hyperlink's WebApiURL's port.
+
+Can be set, to change the WebApiURL's port.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/port)
+    */
+  mutable port: string,
+  /**
+    Returns the hyperlink's WebApiURL's path.
+
+Can be set, to change the WebApiURL's path.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/pathname)
+    */
+  mutable pathname: string,
+  /**
+    Returns the hyperlink's WebApiURL's query (includes leading "?" if non-empty).
+
+Can be set, to change the WebApiURL's query (ignores leading "?").
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/search)
+    */
+  mutable search: string,
+  /**
+    Returns the hyperlink's WebApiURL's fragment (includes leading "#" if non-empty).
+
+Can be set, to change the WebApiURL's fragment (ignores leading "#").
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/hash)
+    */
+  mutable hash: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLAreaElement.res
+++ b/src/DOM/HTMLAreaElement.res
@@ -1,1 +1,355 @@
-include HTMLElement.Impl({type t = DomTypes.htmlAreaElement})
+/**
+Provides special properties and methods (beyond those of the regular object HTMLElement interface it also has available to it by inheritance) for manipulating the layout and presentation of <area> elements.
+[See HTMLAreaElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  // Base properties from HTMLElement
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/title)
+    */
+  mutable title: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/lang)
+    */
+  mutable lang: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/translate)
+    */
+  mutable translate: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/dir)
+    */
+  mutable dir: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
+    */
+  mutable hidden: unknown,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
+    */
+  mutable inert: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKey)
+    */
+  mutable accessKey: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKeyLabel)
+    */
+  accessKeyLabel: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/draggable)
+    */
+  mutable draggable: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/spellcheck)
+    */
+  mutable spellcheck: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/autocapitalize)
+    */
+  mutable autocapitalize: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/innerText)
+    */
+  mutable innerText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/outerText)
+    */
+  mutable outerText: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/popover)
+    */
+  mutable popover: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetParent)
+    */
+  offsetParent: Null.t<DOMTree.element>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetTop)
+    */
+  offsetTop: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetLeft)
+    */
+  offsetLeft: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth)
+    */
+  offsetWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetHeight)
+    */
+  offsetHeight: int,
+  // End base properties from HTMLElement
+
+  // Base properties from Element
+  /**
+    Returns the namespace.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/namespaceURI)
+    */
+  namespaceURI: Null.t<string>,
+  /**
+    Returns the namespace prefix.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/prefix)
+    */
+  prefix: Null.t<string>,
+  /**
+    Returns the local name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/localName)
+    */
+  localName: string,
+  /**
+    Returns the HTML-uppercased qualified name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/tagName)
+    */
+  tagName: string,
+  /**
+    Returns the value of element's id content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/id)
+    */
+  mutable id: string,
+  /**
+    Returns the value of element's class content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/className)
+    */
+  mutable className: string,
+  /**
+    Allows for manipulation of element's class content attribute as a set of whitespace-separated tokens through a DOMTokenList object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/classList)
+    */
+  classList: DOM.domTokenList,
+  /**
+    Returns the value of element's slot content attribute. Can be set to change it.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/slot)
+    */
+  mutable slot: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/attributes)
+    */
+  attributes: DOM.namedNodeMap,
+  /**
+    Returns element's shadow root, if any, and if shadow root's mode is "open", and null otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/shadowRoot)
+    */
+  shadowRoot: Null.t<DOMTree.shadowRoot>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/part)
+    */
+  part: DOM.domTokenList,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollTop)
+    */
+  mutable scrollTop: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollLeft)
+    */
+  mutable scrollLeft: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollWidth)
+    */
+  scrollWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/scrollHeight)
+    */
+  scrollHeight: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientTop)
+    */
+  clientTop: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientLeft)
+    */
+  clientLeft: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientWidth)
+    */
+  clientWidth: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/clientHeight)
+    */
+  clientHeight: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/currentCSSZoom)
+    */
+  currentCSSZoom: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
+    */
+  mutable innerHTML: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
+    */
+  mutable outerHTML: string,
+  // End base properties from Element
+
+  // Base properties from Node
+  /**
+    Returns the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeType)
+    */
+  nodeType: int,
+  /**
+    Returns a string appropriate for the type of node.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeName)
+    */
+  nodeName: string,
+  /**
+    Returns node's node document's document base URL.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/baseURI)
+    */
+  baseURI: string,
+  /**
+    Returns true if node is connected and false otherwise.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/isConnected)
+    */
+  isConnected: bool,
+  /**
+    Returns the node document. Returns null for documents.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/ownerDocument)
+    */
+  ownerDocument: Null.t<DOM.document>,
+  /**
+    Returns the parent.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentNode)
+    */
+  parentNode: Null.t<DOMTree.node>,
+  /**
+    Returns the parent element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/parentElement)
+    */
+  parentElement: Null.t<DOMTree.htmlElement>,
+  /**
+    Returns the children.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/childNodes)
+    */
+  childNodes: DOM.nodeList<DOMTree.node>,
+  /**
+    Returns the first child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/firstChild)
+    */
+  firstChild: Null.t<DOMTree.node>,
+  /**
+    Returns the last child.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/lastChild)
+    */
+  lastChild: Null.t<DOMTree.node>,
+  /**
+    Returns the previous sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/previousSibling)
+    */
+  previousSibling: Null.t<DOMTree.node>,
+  /**
+    Returns the next sibling.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nextSibling)
+    */
+  nextSibling: Null.t<DOMTree.node>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/nodeValue)
+    */
+  mutable nodeValue: Null.t<string>,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/textContent)
+    */
+  mutable textContent: Null.t<string>,
+  // End base properties from Node
+
+  /**
+    Sets or retrieves the window or frame at which to target content.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/target)
+    */
+  mutable target: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/ping)
+    */
+  mutable ping: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/rel)
+    */
+  mutable rel: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/relList)
+    */
+  relList: DOM.domTokenList,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/referrerPolicy)
+    */
+  mutable referrerPolicy: string,
+  /**
+    Returns the hyperlink's URL.
+
+Can be set, to change the URL.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/href)
+    */
+  mutable href: string,
+  /**
+    Returns the hyperlink's WebApiURL's origin.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/origin)
+    */
+  origin: string,
+  /**
+    Returns the hyperlink's WebApiURL's scheme.
+
+Can be set, to change the WebApiURL's scheme.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/protocol)
+    */
+  mutable protocol: string,
+  /**
+    Returns the hyperlink's WebApiURL's username.
+
+Can be set, to change the WebApiURL's username.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/username)
+    */
+  mutable username: string,
+  /**
+    Returns the hyperlink's WebApiURL's password.
+
+Can be set, to change the WebApiURL's password.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/password)
+    */
+  mutable password: string,
+  /**
+    Returns the hyperlink's WebApiURL's host and port (if different from the default port for the scheme).
+
+Can be set, to change the WebApiURL's host and port.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/host)
+    */
+  mutable host: string,
+  /**
+    Returns the hyperlink's WebApiURL's host.
+
+Can be set, to change the WebApiURL's host.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/hostname)
+    */
+  mutable hostname: string,
+  /**
+    Returns the hyperlink's WebApiURL's port.
+
+Can be set, to change the WebApiURL's port.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/port)
+    */
+  mutable port: string,
+  /**
+    Returns the hyperlink's WebApiURL's path.
+
+Can be set, to change the WebApiURL's path.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/pathname)
+    */
+  mutable pathname: string,
+  /**
+    Returns the hyperlink's WebApiURL's query (includes leading "?" if non-empty).
+
+Can be set, to change the WebApiURL's query (ignores leading "?").
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/search)
+    */
+  mutable search: string,
+  /**
+    Returns the hyperlink's WebApiURL's fragment (includes leading "#" if non-empty).
+
+Can be set, to change the WebApiURL's fragment (ignores leading "#").
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/hash)
+    */
+  mutable hash: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLLinkElement.res
+++ b/src/DOM/HTMLLinkElement.res
@@ -1,1 +1,69 @@
-include HTMLElement.Impl({type t = DomTypes.htmlLinkElement})
+/**
+Reference information for external resources and the relationship of those resources to a document and vice-versa. This object inherits all of the properties and methods of the HTMLElement interface.
+[See HTMLLinkElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Sets or retrieves a destination WebApiURL or an anchor point.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/href)
+    */
+  mutable href: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/crossOrigin)
+    */
+  mutable crossOrigin: Null.t<string>,
+  /**
+    Sets or retrieves the relationship between the object and the destination of the link.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/rel)
+    */
+  mutable rel: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/as)
+    */
+  @as("as")
+  mutable as_: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/relList)
+    */
+  relList: DOM.domTokenList,
+  /**
+    Sets or retrieves the media type.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/media)
+    */
+  mutable media: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/integrity)
+    */
+  mutable integrity: string,
+  /**
+    Sets or retrieves the language code of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/hreflang)
+    */
+  mutable hreflang: string,
+  /**
+    Sets or retrieves the MIME type of the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/type)
+    */
+  @as("type")
+  mutable type_: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/referrerPolicy)
+    */
+  mutable referrerPolicy: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/disabled)
+    */
+  mutable disabled: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/fetchPriority)
+    */
+  mutable fetchPriority: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/sheet)
+    */
+  sheet: Null.t<DOM.cssStyleSheet>,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLMetaElement.res
+++ b/src/DOM/HTMLMetaElement.res
@@ -1,1 +1,29 @@
-include HTMLElement.Impl({type t = DomTypes.htmlMetaElement})
+/**
+Contains descriptive metadata about a document. It inherits all of the properties and methods described in the HTMLElement interface.
+[See HTMLMetaElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMetaElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Sets or retrieves the value specified in the content attribute of the meta object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMetaElement/name)
+    */
+  mutable name: string,
+  /**
+    Gets or sets information used to bind the value of a content attribute of a meta element to an HTTP response header.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMetaElement/httpEquiv)
+    */
+  mutable httpEquiv: string,
+  /**
+    Gets or sets meta-information to associate with httpEquiv or name.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMetaElement/content)
+    */
+  mutable content: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMetaElement/media)
+    */
+  mutable media: string,
+}
+
+include HTMLElement.Impl({type t = t})


### PR DESCRIPTION
Tracking issue: #342

## Summary

- define anchor and area interface records in their owning modules
- define link and metadata element records locally
- update their bindings to use the module-owned types
- keep link extraction separate from the larger embedded-resource layer

## Temporary state

- the former aggregate link-element definitions remain in `DOM`/`DomTypes` until the compatibility-removal boundary
- #310 removes those aggregate copies after all dependent HTML interfaces have migrated
- final HTML source-folder ownership is deferred to the follow-up Option 5 stack

## Review focus

- URL-related fields and inheritance for anchor and area elements
- link and metadata signature equivalence with the former aggregate types

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`