### PR TITLE
refactor: define HTML media interfaces locally

### DIFF
--- a/src/DOM/DomHTMLMediaElement.res
+++ b/src/DOM/DomHTMLMediaElement.res
@@ -1,11 +1,152 @@
+type mediaProvider = unknown
+
+type canPlayTypeResult =
+  | @as("maybe") Maybe
+  | @as("probably") Probably
+
+/**
+Adds to HTMLElement the properties and methods needed to support basic media-related capabilities that are common to audio and video.
+[See HTMLMediaElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    Returns an object representing the current error state of the audio or video element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/error)
+    */
+  error: Null.t<MediaError.t>,
+  /**
+    The address or WebApiURL of the a media resource that is to be considered.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/src)
+    */
+  mutable src: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/srcObject)
+    */
+  mutable srcObject: Null.t<mediaProvider>,
+  /**
+    Gets the address or WebApiURL of the current media resource that is selected by IHTMLMediaElement.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/currentSrc)
+    */
+  currentSrc: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/crossOrigin)
+    */
+  mutable crossOrigin: Null.t<string>,
+  /**
+    Gets the current network activity for the element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/networkState)
+    */
+  networkState: int,
+  /**
+    Gets or sets a value indicating what data should be preloaded, if any.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preload)
+    */
+  mutable preload: string,
+  /**
+    Gets a collection of buffered time ranges.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/buffered)
+    */
+  buffered: TimeRanges.t,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/readyState)
+    */
+  readyState: int,
+  /**
+    Gets or sets the current playback position, in seconds.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/currentTime)
+    */
+  mutable currentTime: float,
+  /**
+    Returns the duration in seconds of the current media resource. A NaN value is returned if duration is not available, or Infinity if the media resource is streaming.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/duration)
+    */
+  duration: float,
+  /**
+    Gets a flag that specifies whether playback is paused.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/paused)
+    */
+  paused: bool,
+  /**
+    Gets or sets the default playback rate when the user is not using fast forward or reverse for a video or audio resource.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultPlaybackRate)
+    */
+  mutable defaultPlaybackRate: float,
+  /**
+    Gets or sets the current rate of speed for the media resource to play. This speed is expressed as a multiple of the normal speed of the media resource.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/playbackRate)
+    */
+  mutable playbackRate: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preservesPitch)
+    */
+  mutable preservesPitch: bool,
+  /**
+    Returns a TimeRanges object that represents the ranges of the current media resource that can be seeked.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekable)
+    */
+  seekable: TimeRanges.t,
+  /**
+    Gets information about whether the playback has ended or not.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended)
+    */
+  ended: bool,
+  /**
+    Gets or sets a value that indicates whether to start playing the media automatically.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/autoplay)
+    */
+  mutable autoplay: bool,
+  /**
+    Gets or sets a flag to specify whether playback should restart after it completes.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/loop)
+    */
+  mutable loop: bool,
+  /**
+    Gets or sets a flag that indicates whether the client provides a set of controls for the media (in case the developer does not include controls for the player).
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controls)
+    */
+  mutable controls: bool,
+  /**
+    Gets or sets the volume level for audio portions of the media element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/volume)
+    */
+  mutable volume: float,
+  /**
+    Gets or sets a flag that indicates whether the audio (either audio or the audio track on video media) is muted.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/muted)
+    */
+  mutable muted: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultMuted)
+    */
+  mutable defaultMuted: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/textTracks)
+    */
+  textTracks: TextTrackList.t,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/sinkId)
+    */
+  sinkId: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/remote)
+    */
+  remote: RemotePlaybackTypes.remotePlayback,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/disableRemotePlayback)
+    */
+  mutable disableRemotePlayback: bool,
+}
+
 module Impl = (
   T: {
     type t
   },
 ) => {
-  include HTMLElement.Impl({type t = DomTypes.htmlMediaElement})
+  include HTMLElement.Impl({type t = T.t})
 
-  external asHTMLMediaElement: T.t => DomTypes.htmlMediaElement = "%identity"
+  external asHTMLMediaElement: T.t => t = "%identity"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/addTextTrack)
@@ -23,7 +164,7 @@ Returns a string that specifies whether the client can play a given media resour
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/canPlayType)
 */
   @send
-  external canPlayType: (T.t, string) => DomTypes.canPlayTypeResult = "canPlayType"
+  external canPlayType: (T.t, string) => canPlayTypeResult = "canPlayType"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/fastSeek)
@@ -59,4 +200,4 @@ Loads and starts playback of a media resource.
   external setSinkId: (T.t, string) => promise<unit> = "setSinkId"
 }
 
-include Impl({type t = DomTypes.htmlMediaElement})
+include Impl({type t = t})

--- a/src/DOM/HTMLAudioElement.res
+++ b/src/DOM/HTMLAudioElement.res
@@ -1,1 +1,9 @@
-include DomHTMLMediaElement.Impl({type t = DomTypes.htmlAudioElement})
+/**
+Provides access to the properties of <audio> elements, as well as methods to manipulate them. It derives from the HTMLMediaElement interface.
+[See HTMLAudioElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLAudioElement)
+*/
+type t = private {
+  ...DomHTMLMediaElement.t,
+}
+
+include DomHTMLMediaElement.Impl({type t = t})

--- a/src/DOM/HTMLTrackElement.res
+++ b/src/DOM/HTMLTrackElement.res
@@ -1,1 +1,14 @@
-include HTMLElement.Impl({type t = DomTypes.htmlTrackElement})
+/**
+The HTMLTrackElement
+[See HTMLTrackElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTrackElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DOMTree.htmlElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTrackElement/src)
+    */
+  mutable src: string,
+}
+
+include HTMLElement.Impl({type t = t})

--- a/src/DOM/HTMLVideoElement.res
+++ b/src/DOM/HTMLVideoElement.res
@@ -1,32 +1,78 @@
-include DomHTMLMediaElement.Impl({type t = DomTypes.htmlVideoElement})
+type videoFrameCallbackMetadata = {
+  mutable presentationTime: float,
+  mutable expectedDisplayTime: float,
+  mutable width: int,
+  mutable height: int,
+  mutable mediaTime: float,
+  mutable presentedFrames: int,
+  mutable processingDuration?: float,
+  mutable captureTime?: float,
+  mutable receiveTime?: float,
+  mutable rtpTimestamp?: int,
+}
+
+/**
+Provides special properties and methods for manipulating video objects. It also inherits properties and methods of HTMLMediaElement and HTMLElement.
+[See HTMLVideoElement on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement)
+TODO: mark as private once mutating fields of private records is allowed
+*/
+type t = {
+  ...DomHTMLMediaElement.t,
+  /**
+    Gets or sets the width of the video element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/width)
+    */
+  mutable width: int,
+  /**
+    Gets or sets the height of the video element.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/height)
+    */
+  mutable height: int,
+  /**
+    Gets the intrinsic width of a video in CSS pixels, or zero if the dimensions are not known.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/videoWidth)
+    */
+  videoWidth: int,
+  /**
+    Gets the intrinsic height of a video in CSS pixels, or zero if the dimensions are not known.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/videoHeight)
+    */
+  videoHeight: int,
+  /**
+    Gets or sets a WebApiURL of an image to display, for example, like a movie poster. This can be a still frame from the video, or another image if no video data is available.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/poster)
+    */
+  mutable poster: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/disablePictureInPicture)
+    */
+  mutable disablePictureInPicture: bool,
+}
+
+include DomHTMLMediaElement.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/getVideoPlaybackQuality)
 */
 @send
-external getVideoPlaybackQuality: DomTypes.htmlVideoElement => DomTypes.videoPlaybackQuality =
-  "getVideoPlaybackQuality"
+external getVideoPlaybackQuality: t => VideoPlaybackQuality.t = "getVideoPlaybackQuality"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/requestPictureInPicture)
 */
 @send
-external requestPictureInPicture: DomTypes.htmlVideoElement => promise<
-  PictureInPictureTypes.pictureInPictureWindow,
-> = "requestPictureInPicture"
+external requestPictureInPicture: t => promise<PictureInPictureTypes.pictureInPictureWindow> =
+  "requestPictureInPicture"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback)
 */
 @send
-external requestVideoFrameCallback: (
-  DomTypes.htmlVideoElement,
-  (float, DomTypes.videoFrameCallbackMetadata) => unit,
-) => int = "requestVideoFrameCallback"
+external requestVideoFrameCallback: (t, (float, videoFrameCallbackMetadata) => unit) => int =
+  "requestVideoFrameCallback"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/cancelVideoFrameCallback)
 */
 @send
-external cancelVideoFrameCallback: (DomTypes.htmlVideoElement, int) => unit =
-  "cancelVideoFrameCallback"
+external cancelVideoFrameCallback: (t, int) => unit = "cancelVideoFrameCallback"

--- a/src/DOM/MediaError.res
+++ b/src/DOM/MediaError.res
@@ -2,7 +2,7 @@
 An error which occurred while handling media in an HTML media element based on HTMLMediaElement, such as <audio> or <video>.
 [See MediaError on MDN](https://developer.mozilla.org/docs/Web/API/MediaError)
 */
-type t = {
+type t = private {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaError/code)
     */

--- a/src/DOM/MediaError.res
+++ b/src/DOM/MediaError.res
@@ -1,0 +1,14 @@
+/**
+An error which occurred while handling media in an HTML media element based on HTMLMediaElement, such as <audio> or <video>.
+[See MediaError on MDN](https://developer.mozilla.org/docs/Web/API/MediaError)
+*/
+type t = {
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaError/code)
+    */
+  code: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaError/message)
+    */
+  message: string,
+}

--- a/src/DOM/TextTrackList.res
+++ b/src/DOM/TextTrackList.res
@@ -1,7 +1,17 @@
-include EventTarget.Impl({type t = DomTypes.textTrackList})
+/**
+[See TextTrackList on MDN](https://developer.mozilla.org/docs/Web/API/TextTrackList)
+*/
+type t = private {
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TextTrackList/length)
+    */
+  length: int,
+}
+
+include EventTarget.Impl({type t = t})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TextTrackList/getTrackById)
 */
 @send
-external getTrackById: (DomTypes.textTrackList, string) => WebVttTypes.textTrack = "getTrackById"
+external getTrackById: (t, string) => WebVttTypes.textTrack = "getTrackById"

--- a/src/DOM/TimeRanges.res
+++ b/src/DOM/TimeRanges.res
@@ -1,11 +1,23 @@
 /**
+Used to represent a set of time ranges, primarily for the purpose of tracking which portions of media have been buffered when loading it for use by the <audio> and <video> elements.
+[See TimeRanges on MDN](https://developer.mozilla.org/docs/Web/API/TimeRanges)
+*/
+type t = private {
+  /**
+    Returns the number of ranges in the object.
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TimeRanges/length)
+    */
+  length: int,
+}
+
+/**
 Returns the time for the start of the range with the given index.
 
 Throws an "IndexSizeError" DOMException if the index is out of range.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TimeRanges/start)
 */
 @send
-external start: (DomTypes.timeRanges, int) => float = "start"
+external start: (t, int) => float = "start"
 
 /**
 Returns the time for the end of the range with the given index.
@@ -14,4 +26,4 @@ Throws an "IndexSizeError" DOMException if the index is out of range.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TimeRanges/end)
 */
 @send
-external end: (DomTypes.timeRanges, int) => float = "end"
+external end: (t, int) => float = "end"

--- a/src/DOM/VideoPlaybackQuality.res
+++ b/src/DOM/VideoPlaybackQuality.res
@@ -1,0 +1,18 @@
+/**
+Returned by the HTMLVideoElement.getVideoPlaybackQuality() method and contains metrics that can be used to determine the playback quality of a video.
+[See VideoPlaybackQuality on MDN](https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality)
+*/
+type t = {
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/creationTime)
+    */
+  creationTime: float,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/droppedVideoFrames)
+    */
+  droppedVideoFrames: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/totalVideoFrames)
+    */
+  totalVideoFrames: int,
+}


### PR DESCRIPTION
Tracking issue: #342

## Summary

- define the shared HTML media-element record in `DomHTMLMediaElement`
- move audio, video, track, time-range, and text-track types beside their APIs
- add the public `MediaError` and `VideoPlaybackQuality` modules
- update media bindings to use the locally owned types

## Temporary state

- the equivalent aggregate media definitions remain in `DOM`/`DomTypes` during this layer
- #310 removes those copies once the remaining consumers have migrated
- the current physical placement under the broad DOM folder is temporary; the follow-up Option 5 stack separates HTML and Media folder features

## Review focus

- inheritance and shared fields in `DomHTMLMediaElement`
- video callback, playback-quality, track, and error signatures

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`