### PR TITLE
refactor: define SVG interfaces locally

### DIFF
--- a/rescript.json
+++ b/rescript.json
@@ -180,6 +180,7 @@
         "NodeIterator",
         "NodeList",
         "Range",
+        "SVGElement",
         "SVGGraphicsElement",
         "SVGLength",
         "ScreenOrientation",

--- a/src/DOM/SVGElement.res
+++ b/src/DOM/SVGElement.res
@@ -58,6 +58,18 @@ type t = {
   attributeStyleMap: DOM.stylePropertyMap,
 }
 
+module Impl = (
+  T: {
+    type t
+  },
+) => {
+  include Element.Impl({type t = T.t})
+
+  external asSVGElement: T.t => t = "%identity"
+}
+
+include Impl({type t = t})
+
 /**
 SVG elements whose primary purpose is to directly render graphics into a group.
 [See SVGGraphicsElement on MDN](https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement)

--- a/src/DOM/SVGElement.res
+++ b/src/DOM/SVGElement.res
@@ -1,0 +1,103 @@
+/**
+Used for attributes of type SVGPreserveAspectRatio which can be animated.
+[See SVGAnimatedPreserveAspectRatio on MDN](https://developer.mozilla.org/docs/Web/API/SVGAnimatedPreserveAspectRatio)
+*/
+type svgAnimatedPreserveAspectRatio = {}
+
+/**
+Correspond to the <length> basic data type.
+[See SVGLength on MDN](https://developer.mozilla.org/docs/Web/API/SVGLength)
+*/
+@editor.completeFrom(SVGLength)
+type svgLength = private {}
+
+/**
+Used for attributes of basic type <length> which can be animated.
+[See SVGAnimatedLength on MDN](https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength)
+*/
+type svgAnimatedLength = {
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength/baseVal)
+    */
+  baseVal: svgLength,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength/animVal)
+    */
+  animVal: svgLength,
+}
+
+/**
+All of the SVG WebApiDOM interfaces that correspond directly to elements in the SVG language derive from the SVGElement interface.
+[See SVGElement on MDN](https://developer.mozilla.org/docs/Web/API/SVGElement)
+*/
+type t = {
+  ...DOMTree.element,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/dataset)
+    */
+  dataset: DOMStringMap.t,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/nonce)
+    */
+  mutable nonce?: string,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/autofocus)
+    */
+  mutable autofocus: bool,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/tabIndex)
+    */
+  mutable tabIndex: int,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/style)
+    */
+  style: DOM.cssStyleDeclaration,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/attributeStyleMap)
+    */
+  attributeStyleMap: DOM.stylePropertyMap,
+}
+
+/**
+SVG elements whose primary purpose is to directly render graphics into a group.
+[See SVGGraphicsElement on MDN](https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement)
+*/
+@editor.completeFrom(SVGGraphicsElement)
+type svgGraphicsElement = private {
+  ...t,
+}
+
+/**
+Corresponds to the <image> element.
+[See SVGImageElement on MDN](https://developer.mozilla.org/docs/Web/API/SVGImageElement)
+*/
+type svgImageElement = {
+  ...svgGraphicsElement,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGImageElement/x)
+    */
+  x: svgAnimatedLength,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGImageElement/y)
+    */
+  y: svgAnimatedLength,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGImageElement/width)
+    */
+  width: svgAnimatedLength,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGImageElement/height)
+    */
+  height: svgAnimatedLength,
+  /**
+    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGImageElement/preserveAspectRatio)
+    */
+  preserveAspectRatio: svgAnimatedPreserveAspectRatio,
+}
+
+type svgBoundingBoxOptions = {
+  mutable fill?: bool,
+  mutable stroke?: bool,
+  mutable markers?: bool,
+  mutable clipped?: bool,
+}

--- a/src/DOM/SVGGraphicsElement.res
+++ b/src/DOM/SVGGraphicsElement.res
@@ -1,18 +1,18 @@
-include Element.Impl({type t = DomTypes.svgGraphicsElement})
+include Element.Impl({type t = SVGElement.svgGraphicsElement})
 
-external asSVGElement: DomTypes.svgGraphicsElement => DomTypes.svgElement = "%identity"
+external asSVGElement: SVGElement.svgGraphicsElement => SVGElement.t = "%identity"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/getBBox)
 */
 @send
 external getBBox: (
-  DomTypes.svgGraphicsElement,
-  ~options: DomTypes.svgBoundingBoxOptions=?,
+  SVGElement.svgGraphicsElement,
+  ~options: SVGElement.svgBoundingBoxOptions=?,
 ) => DomTypes.domRect = "getBBox"
 
 @send
-external getCTM: DomTypes.svgGraphicsElement => DomTypes.domMatrix = "getCTM"
+external getCTM: SVGElement.svgGraphicsElement => DomTypes.domMatrix = "getCTM"
 
 @send
-external getScreenCTM: DomTypes.svgGraphicsElement => DomTypes.domMatrix = "getScreenCTM"
+external getScreenCTM: SVGElement.svgGraphicsElement => DomTypes.domMatrix = "getScreenCTM"

--- a/src/DOM/SVGGraphicsElement.res
+++ b/src/DOM/SVGGraphicsElement.res
@@ -1,6 +1,4 @@
-include Element.Impl({type t = SVGElement.svgGraphicsElement})
-
-external asSVGElement: SVGElement.svgGraphicsElement => SVGElement.t = "%identity"
+include SVGElement.Impl({type t = SVGElement.svgGraphicsElement})
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/getBBox)

--- a/src/DOM/SVGLength.res
+++ b/src/DOM/SVGLength.res
@@ -1,9 +1,9 @@
 @send
 external newValueSpecifiedUnits: (
-  DomTypes.svgLength,
+  SVGElement.svgLength,
   ~unitType: int,
   ~valueInSpecifiedUnits: float,
 ) => unit = "newValueSpecifiedUnits"
 
 @send
-external convertToSpecifiedUnits: (DomTypes.svgLength, int) => unit = "convertToSpecifiedUnits"
+external convertToSpecifiedUnits: (SVGElement.svgLength, int) => unit = "convertToSpecifiedUnits"

--- a/tests/DOMAPI/SVGElement__test.res
+++ b/tests/DOMAPI/SVGElement__test.res
@@ -1,0 +1,7 @@
+let getViewBox = (element: SVGElement.t) => element->SVGElement.getAttribute("viewBox")
+
+let graphicsElementAsElement = (element: SVGElement.svgGraphicsElement): DOMTree.element =>
+  element->SVGGraphicsElement.asSVGElement->SVGElement.asElement
+
+let getGraphicsViewBox = (element: SVGElement.svgGraphicsElement) =>
+  element->SVGGraphicsElement.getAttribute("viewBox")


### PR DESCRIPTION
Tracking issue: #342

## Summary

- add the public `SVGElement` module
- define SVG element, graphics-element, image-element, animated-length, and bounding-box types locally
- migrate `SVGGraphicsElement` and `SVGLength` to the new SVG-owned types

## Temporary state

- the old aggregate SVG definitions remain in `DOM`/`DomTypes` through this layer
- geometry return types still reference `DomTypes`; #310 migrates those references and deletes the aggregate compatibility types
- the follow-up Option 5 stack moves these modules into the SVG folder feature and supplies the intended DOMNodes and Geometry feature implications

## Review focus

- SVG inheritance and conversion relationships
- geometry signatures and compatibility with the existing public bindings

## Verification

- `npm run build`
- `npm test`
- `npm run format:check`