### PR TITLE
chore: verify commit signing

### DIFF
--- a/COMMIT_SIGNING_TEST.md
+++ b/COMMIT_SIGNING_TEST.md
@@ -1,0 +1,3 @@
+# Commit signing verification
+
+This temporary file verifies that commits created by Josh Vlk are signed and recognized by GitHub.


### PR DESCRIPTION
## What changed

- Added a temporary Markdown marker used only to create a test commit.
- Signed the commit with the workstation's ED25519 SSH key.

## Why

Local commits from Josh Vlk were appearing as unverified on GitHub. This draft PR provides a minimal end-to-end verification of the corrected signing setup.

## Root cause

Git had no commit-signing configuration, and the active local SSH public key was not registered with GitHub as a signing key.

## Impact

There is no runtime, build, or dependency impact. The marker file can be removed after the signing result has been confirmed.

## Validation

- `git verify-commit HEAD` reports a good SSH signature for `josh@vlkpack.com`.
- GitHub reports commit `0aca96843b1fe8551f6638437f7d060f30abcec5` as verified with reason `valid`.