### PR TITLE
fix(webapi): correct binding nullability and exception contracts [Codex]

### DIFF
--- a/src/animation/Animation.res
+++ b/src/animation/Animation.res
@@ -138,12 +138,12 @@ type iterationCompositeOperation =
 type keyframeEffectOptions = {
   ...AnimationEffect.effectTiming,
   mutable composite?: compositeOperation,
-  mutable pseudoElement?: Null.t<string>,
+  mutable pseudoElement?: Nullable.t<string>,
   mutable iterationComposite?: iterationCompositeOperation,
 }
 
 type keyframeAnimationOptions = {
   ...keyframeEffectOptions,
   mutable id?: string,
-  mutable timeline?: Null.t<animationTimeline>,
+  mutable timeline?: Nullable.t<animationTimeline>,
 }

--- a/src/animation/Animation.res
+++ b/src/animation/Animation.res
@@ -87,7 +87,7 @@ external cancel: t => unit = "cancel"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Animation/finish)
 */
-@send
+@throws(JsExn) @send
 external finish: t => unit = "finish"
 
 /**
@@ -99,7 +99,7 @@ external play: t => unit = "play"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Animation/pause)
 */
-@send
+@throws(JsExn) @send
 external pause: t => unit = "pause"
 
 /**

--- a/src/animation/AnimationEffect.res
+++ b/src/animation/AnimationEffect.res
@@ -32,12 +32,12 @@ type getAnimationsOptions = {mutable subtree?: bool}
 
 type computedEffectTiming = {
   ...effectTiming,
-  mutable progress?: Null.t<float>,
-  mutable currentIteration?: Null.t<float>,
+  mutable progress?: Nullable.t<float>,
+  mutable currentIteration?: Nullable.t<float>,
   mutable startTime?: float,
   mutable endTime?: float,
   mutable activeDuration?: float,
-  mutable localTime?: Null.t<float>,
+  mutable localTime?: Nullable.t<float>,
 }
 
 type optionalEffectTiming = {

--- a/src/animation/AnimationEffect.res
+++ b/src/animation/AnimationEffect.res
@@ -67,5 +67,5 @@ external getComputedTiming: t => computedEffectTiming = "getComputedTiming"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnimationEffect/updateTiming)
 */
-@send
+@throws(JsExn) @send
 external updateTiming: (t, ~timing: optionalEffectTiming=?) => unit = "updateTiming"

--- a/src/canvas/CanvasGradient.res
+++ b/src/canvas/CanvasGradient.res
@@ -4,7 +4,7 @@ Adds a color stop with the given color to the gradient at the given offset. 0.0 
 Throws an "IndexSizeError" DOMException if the offset is out of range. Throws a "SyntaxError" DOMException if the color cannot be parsed.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasGradient/addColorStop)
 */
-@send
+@throws(JsExn) @send
 external addColorStop: (CanvasTypes.canvasGradient, ~offset: float, ~color: string) => unit =
   "addColorStop"
 

--- a/src/canvas/CanvasRenderingContext2D.res
+++ b/src/canvas/CanvasRenderingContext2D.res
@@ -77,7 +77,7 @@ external setTransform: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/setTransform)
 */
-@send
+@throws(JsExn) @send
 external setTransform2: (DOM.canvasRenderingContext2D, ~transform: DOM.domMatrix2DInit=?) => unit =
   "setTransform"
 
@@ -90,7 +90,7 @@ external resetTransform: DOM.canvasRenderingContext2D => unit = "resetTransform"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createLinearGradient)
 */
-@send
+@throws(JsExn) @send
 external createLinearGradient: (
   DOM.canvasRenderingContext2D,
   ~x0: float,
@@ -102,7 +102,7 @@ external createLinearGradient: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createRadialGradient)
 */
-@send
+@throws(JsExn) @send
 external createRadialGradient: (
   DOM.canvasRenderingContext2D,
   ~x0: float,
@@ -374,7 +374,7 @@ external measureText: (DOM.canvasRenderingContext2D, string) => CanvasTypes.text
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImage: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLImageElement.t,
@@ -385,7 +385,7 @@ external drawImage: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithSvg: (
   DOM.canvasRenderingContext2D,
   ~image: SVGElement.svgImageElement,
@@ -396,7 +396,7 @@ external drawImageWithSvg: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithVideo: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLVideoElement.t,
@@ -407,7 +407,7 @@ external drawImageWithVideo: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithCanvas: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLCanvasElement.t,
@@ -418,7 +418,7 @@ external drawImageWithCanvas: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithImageBitmap: (
   DOM.canvasRenderingContext2D,
   ~image: CanvasTypes.imageBitmap,
@@ -429,7 +429,7 @@ external drawImageWithImageBitmap: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithOffscreenCanvas: (
   DOM.canvasRenderingContext2D,
   ~image: CanvasTypes.offscreenCanvas,
@@ -440,7 +440,7 @@ external drawImageWithOffscreenCanvas: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithVideoFrame: (
   DOM.canvasRenderingContext2D,
   ~image: DOM.videoFrame,
@@ -451,7 +451,7 @@ external drawImageWithVideoFrame: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithDimensions: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLImageElement.t,
@@ -464,7 +464,7 @@ external drawImageWithDimensions: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithSvgDimensions: (
   DOM.canvasRenderingContext2D,
   ~image: SVGElement.svgImageElement,
@@ -477,7 +477,7 @@ external drawImageWithSvgDimensions: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithVideoDimensions: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLVideoElement.t,
@@ -490,7 +490,7 @@ external drawImageWithVideoDimensions: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithCanvasDimensions: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLCanvasElement.t,
@@ -503,7 +503,7 @@ external drawImageWithCanvasDimensions: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithImageBitmapDimensions: (
   DOM.canvasRenderingContext2D,
   ~image: CanvasTypes.imageBitmap,
@@ -516,7 +516,7 @@ external drawImageWithImageBitmapDimensions: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithOffscreenCanvasDimensions: (
   DOM.canvasRenderingContext2D,
   ~image: CanvasTypes.offscreenCanvas,
@@ -529,7 +529,7 @@ external drawImageWithOffscreenCanvasDimensions: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithVideoFrameDimensions: (
   DOM.canvasRenderingContext2D,
   ~image: DOM.videoFrame,
@@ -542,7 +542,7 @@ external drawImageWithVideoFrameDimensions: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithSubRectangle: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLImageElement.t,
@@ -559,7 +559,7 @@ external drawImageWithSubRectangle: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithSvgSubRectangle: (
   DOM.canvasRenderingContext2D,
   ~image: SVGElement.svgImageElement,
@@ -576,7 +576,7 @@ external drawImageWithSvgSubRectangle: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithVideoSubRectangle: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLVideoElement.t,
@@ -593,7 +593,7 @@ external drawImageWithVideoSubRectangle: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithCanvasSubRectangle: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLCanvasElement.t,
@@ -610,7 +610,7 @@ external drawImageWithCanvasSubRectangle: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithImageBitmapSubRectangle: (
   DOM.canvasRenderingContext2D,
   ~image: CanvasTypes.imageBitmap,
@@ -627,7 +627,7 @@ external drawImageWithImageBitmapSubRectangle: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithOffscreenCanvasSubRectangle: (
   DOM.canvasRenderingContext2D,
   ~image: CanvasTypes.offscreenCanvas,
@@ -644,7 +644,7 @@ external drawImageWithOffscreenCanvasSubRectangle: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawImage)
 */
-@send
+@throws(JsExn) @send
 external drawImageWithVideoFrameSubRectangle: (
   DOM.canvasRenderingContext2D,
   ~image: DOM.videoFrame,
@@ -661,7 +661,7 @@ external drawImageWithVideoFrameSubRectangle: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createImageData)
 */
-@send
+@throws(JsExn) @send
 external createImageData: (
   DOM.canvasRenderingContext2D,
   ~sw: int,
@@ -672,14 +672,14 @@ external createImageData: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createImageData)
 */
-@send
+@throws(JsExn) @send
 external createImageData2: (DOM.canvasRenderingContext2D, DOM.imageData) => DOM.imageData =
   "createImageData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getImageData)
 */
-@send
+@throws(JsExn) @send
 external getImageData: (
   DOM.canvasRenderingContext2D,
   ~sx: int,
@@ -692,7 +692,7 @@ external getImageData: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/putImageData)
 */
-@send
+@throws(JsExn) @send
 external putImageData: (
   DOM.canvasRenderingContext2D,
   ~imagedata: DOM.imageData,
@@ -703,7 +703,7 @@ external putImageData: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/putImageData)
 */
-@send
+@throws(JsExn) @send
 external putImageData2: (
   DOM.canvasRenderingContext2D,
   ~imagedata: DOM.imageData,
@@ -774,7 +774,7 @@ external bezierCurveTo: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/arcTo)
 */
-@send
+@throws(JsExn) @send
 external arcTo: (
   DOM.canvasRenderingContext2D,
   ~x1: float,
@@ -794,7 +794,7 @@ external rect: (DOM.canvasRenderingContext2D, ~x: float, ~y: float, ~w: float, ~
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
 */
-@send
+@throws(JsExn) @send
 external roundRect: (
   DOM.canvasRenderingContext2D,
   ~x: float,
@@ -807,7 +807,7 @@ external roundRect: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
 */
-@send
+@throws(JsExn) @send
 external roundRect2: (
   DOM.canvasRenderingContext2D,
   ~x: float,
@@ -820,7 +820,7 @@ external roundRect2: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
 */
-@send
+@throws(JsExn) @send
 external roundRect3: (
   DOM.canvasRenderingContext2D,
   ~x: float,

--- a/src/canvas/CanvasRenderingContext2D.res
+++ b/src/canvas/CanvasRenderingContext2D.res
@@ -127,72 +127,72 @@ external createConicGradient: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
-@send
+@throws(JsExn) @send
 external createPattern: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLImageElement.t,
   ~repetition: string,
-) => CanvasTypes.canvasPattern = "createPattern"
+) => Null.t<CanvasTypes.canvasPattern> = "createPattern"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
-@send
+@throws(JsExn) @send
 external createPattern2: (
   DOM.canvasRenderingContext2D,
   ~image: SVGElement.svgImageElement,
   ~repetition: string,
-) => CanvasTypes.canvasPattern = "createPattern"
+) => Null.t<CanvasTypes.canvasPattern> = "createPattern"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
-@send
+@throws(JsExn) @send
 external createPattern3: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLVideoElement.t,
   ~repetition: string,
-) => CanvasTypes.canvasPattern = "createPattern"
+) => Null.t<CanvasTypes.canvasPattern> = "createPattern"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
-@send
+@throws(JsExn) @send
 external createPattern4: (
   DOM.canvasRenderingContext2D,
   ~image: HTMLCanvasElement.t,
   ~repetition: string,
-) => CanvasTypes.canvasPattern = "createPattern"
+) => Null.t<CanvasTypes.canvasPattern> = "createPattern"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
-@send
+@throws(JsExn) @send
 external createPattern5: (
   DOM.canvasRenderingContext2D,
   ~image: CanvasTypes.imageBitmap,
   ~repetition: string,
-) => CanvasTypes.canvasPattern = "createPattern"
+) => Null.t<CanvasTypes.canvasPattern> = "createPattern"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
-@send
+@throws(JsExn) @send
 external createPattern6: (
   DOM.canvasRenderingContext2D,
   ~image: CanvasTypes.offscreenCanvas,
   ~repetition: string,
-) => CanvasTypes.canvasPattern = "createPattern"
+) => Null.t<CanvasTypes.canvasPattern> = "createPattern"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createPattern)
 */
-@send
+@throws(JsExn) @send
 external createPattern7: (
   DOM.canvasRenderingContext2D,
   ~image: DOM.videoFrame,
   ~repetition: string,
-) => CanvasTypes.canvasPattern = "createPattern"
+) => Null.t<CanvasTypes.canvasPattern> = "createPattern"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/clearRect)

--- a/src/canvas/HTMLCanvasElement.res
+++ b/src/canvas/HTMLCanvasElement.res
@@ -25,61 +25,61 @@ Creates a CanvasRenderingContext2D object representing a two-dimensional renderi
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#2d)
 */
-@send
+@throws(JsExn) @send
 external getContext2D: (
   t,
   @as("2d") _,
   ~options: CanvasTypes.canvasRenderingContext2DSettings=?,
-) => DOM.canvasRenderingContext2D = "getContext"
+) => Null.t<DOM.canvasRenderingContext2D> = "getContext"
 
 /**
 Returns an object that provides methods and properties for drawing and manipulating images and graphics on a canvas element in a document. A context object includes information about colors, line widths, fonts, and other graphic parameters that can be drawn on a canvas.
 @param contextId The identifier (ID) of the type of canvas to create. Internet Explorer 9 and Internet Explorer 10 support only a 2-D context using canvas.getContext("2d"); IE11 Preview also supports 3-D or WebGL context using canvas.getContext("experimental-webgl");
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/getContext)
 */
-@send
+@throws(JsExn) @send
 external getContextWebGL: (
   t,
   @as("webgl") _,
   ~options: CanvasTypes.webGLContextAttributes=?,
-) => CanvasTypes.webGLRenderingContext = "getContext"
+) => Null.t<CanvasTypes.webGLRenderingContext> = "getContext"
 
 /**
 Returns an object that provides methods and properties for drawing and manipulating images and graphics on a canvas element in a document. A context object includes information about colors, line widths, fonts, and other graphic parameters that can be drawn on a canvas.
 @param contextId The identifier (ID) of the type of canvas to create. Internet Explorer 9 and Internet Explorer 10 support only a 2-D context using canvas.getContext("2d"); IE11 Preview also supports 3-D or WebGL context using canvas.getContext("experimental-webgl");
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/getContext)
 */
-@send
+@throws(JsExn) @send
 external getContextWebGL2: (
   t,
   @as("webgl2") _,
   ~options: CanvasTypes.webGLContextAttributes=?,
-) => CanvasTypes.webGL2RenderingContext = "getContext"
+) => Null.t<CanvasTypes.webGL2RenderingContext> = "getContext"
 
 /**
 Returns an object that provides methods and properties for drawing and manipulating images and graphics on a canvas element in a document. A context object includes information about colors, line widths, fonts, and other graphic parameters that can be drawn on a canvas.
 @param contextId The identifier (ID) of the type of canvas to create. Internet Explorer 9 and Internet Explorer 10 support only a 2-D context using canvas.getContext("2d"); IE11 Preview also supports 3-D or WebGL context using canvas.getContext("experimental-webgl");
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/getContext)
 */
-@send
+@throws(JsExn) @send
 external getContextBitmapRenderer: (
   t,
   @as("bitmaprenderer") _,
   ~options: CanvasTypes.imageBitmapRenderingContextSettings=?,
-) => CanvasTypes.imageBitmapRenderingContext = "getContext"
+) => Null.t<CanvasTypes.imageBitmapRenderingContext> = "getContext"
 
 /**
 Returns the content of the current canvas as an image that you can use as a source for another canvas or an HTML element.
 @param type The standard MIME type for the image format to return. If you do not specify this parameter, the default value is a PNG format image.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/toDataURL)
 */
-@send
+@throws(JsExn) @send
 external toDataURL: (t, ~type_: string=?, ~quality: JSON.t=?) => string = "toDataURL"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/toBlob)
 */
-@send
+@throws(JsExn) @send
 external toBlob: (
   t,
   ~callback: FileTypes.blob => unit,
@@ -90,12 +90,12 @@ external toBlob: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen)
 */
-@send
+@throws(JsExn) @send
 external transferControlToOffscreen: t => CanvasTypes.offscreenCanvas = "transferControlToOffscreen"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/captureStream)
 */
-@send
+@throws(JsExn) @send
 external captureStream: (t, ~frameRequestRate: float=?) => MediaCaptureAndStreamsTypes.mediaStream =
   "captureStream"

--- a/src/canvas/ImageData.res
+++ b/src/canvas/ImageData.res
@@ -1,14 +1,14 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ImageData)
 */
-@new
+@throws(JsExn) @new
 external make: (~sw: int, ~sh: int, ~settings: DOM.imageDataSettings=?) => DOM.imageData =
   "ImageData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ImageData)
 */
-@new
+@throws(JsExn) @new
 external makeWithData: (
   ~data: Uint8ClampedArray.t,
   ~sw: int,

--- a/src/canvas/OffscreenCanvas.res
+++ b/src/canvas/OffscreenCanvas.res
@@ -14,12 +14,12 @@ This specification defines the "2d" context below, which is similar but distinct
 Returns null if the canvas has already been initialized with another context type (e.g., trying to get a "2d" context after getting a "webgl" context).
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/getContext)
 */
-@send
+@throws(JsExn) @send
 external getContext2D: (
   CanvasTypes.offscreenCanvas,
   @as("2d") _,
   ~options: JSON.t=?,
-) => CanvasTypes.offscreenCanvasRenderingContext2D = "getContext"
+) => Null.t<CanvasTypes.offscreenCanvasRenderingContext2D> = "getContext"
 
 /**
 Returns an object that exposes an API for drawing on the OffscreenCanvas object. contextId specifies the desired API: "2d", "bitmaprenderer", "webgl", or "webgl2". options is handled by that API.
@@ -29,12 +29,12 @@ This specification defines the "2d" context below, which is similar but distinct
 Returns null if the canvas has already been initialized with another context type (e.g., trying to get a "2d" context after getting a "webgl" context).
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/getContext)
 */
-@send
+@throws(JsExn) @send
 external getContextWebGL: (
   CanvasTypes.offscreenCanvas,
   @as("webgl") _,
   ~options: CanvasTypes.webGLContextAttributes=?,
-) => CanvasTypes.webGLRenderingContext = "getContext"
+) => Null.t<CanvasTypes.webGLRenderingContext> = "getContext"
 
 /**
 Returns an object that exposes an API for drawing on the OffscreenCanvas object. contextId specifies the desired API: "2d", "bitmaprenderer", "webgl", or "webgl2". options is handled by that API.
@@ -44,12 +44,12 @@ This specification defines the "2d" context below, which is similar but distinct
 Returns null if the canvas has already been initialized with another context type (e.g., trying to get a "2d" context after getting a "webgl" context).
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/getContext)
 */
-@send
+@throws(JsExn) @send
 external getContextWebGL2: (
   CanvasTypes.offscreenCanvas,
   @as("webgl2") _,
   ~options: CanvasTypes.webGLContextAttributes=?,
-) => CanvasTypes.webGL2RenderingContext = "getContext"
+) => Null.t<CanvasTypes.webGL2RenderingContext> = "getContext"
 
 /**
 Returns an object that exposes an API for drawing on the OffscreenCanvas object. contextId specifies the desired API: "2d", "bitmaprenderer", "webgl", or "webgl2". options is handled by that API.
@@ -59,18 +59,18 @@ This specification defines the "2d" context below, which is similar but distinct
 Returns null if the canvas has already been initialized with another context type (e.g., trying to get a "2d" context after getting a "webgl" context).
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/getContext)
 */
-@send
+@throws(JsExn) @send
 external getContextBitmapRenderer: (
   CanvasTypes.offscreenCanvas,
   @as("bitmaprenderer") _,
   ~options: CanvasTypes.imageBitmapRenderingContextSettings=?,
-) => CanvasTypes.imageBitmapRenderingContext = "getContext"
+) => Null.t<CanvasTypes.imageBitmapRenderingContext> = "getContext"
 
 /**
 Returns a newly created ImageBitmap object with the image in the OffscreenCanvas object. The image in the OffscreenCanvas object is replaced with a new blank image.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/transferToImageBitmap)
 */
-@send
+@throws(JsExn) @send
 external transferToImageBitmap: CanvasTypes.offscreenCanvas => CanvasTypes.imageBitmap =
   "transferToImageBitmap"
 

--- a/src/canvas/Path2D.res
+++ b/src/canvas/Path2D.res
@@ -89,7 +89,7 @@ external bezierCurveTo: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/arcTo)
 */
-@send
+@throws(JsExn) @send
 external arcTo: (
   CanvasTypes.path2D,
   ~x1: float,
@@ -108,7 +108,7 @@ external rect: (CanvasTypes.path2D, ~x: float, ~y: float, ~w: float, ~h: float) 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
 */
-@send
+@throws(JsExn) @send
 external roundRect: (
   CanvasTypes.path2D,
   ~x: float,
@@ -121,7 +121,7 @@ external roundRect: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
 */
-@send
+@throws(JsExn) @send
 external roundRect2: (
   CanvasTypes.path2D,
   ~x: float,
@@ -134,7 +134,7 @@ external roundRect2: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
 */
-@send
+@throws(JsExn) @send
 external roundRect3: (
   CanvasTypes.path2D,
   ~x: float,

--- a/src/canvas/VideoFrame.res
+++ b/src/canvas/VideoFrame.res
@@ -207,7 +207,7 @@ external copyTo3: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/VideoFrame/clone)
 */
-@send
+@throws(JsExn) @send
 external clone: DOM.videoFrame => DOM.videoFrame = "clone"
 
 /**

--- a/src/core/DOM.res
+++ b/src/core/DOM.res
@@ -975,10 +975,10 @@ type videoFrameInit = {
 }
 
 type videoColorSpaceInit = {
-  mutable primaries?: Null.t<videoColorPrimaries>,
-  mutable transfer?: Null.t<videoTransferCharacteristics>,
-  mutable matrix?: Null.t<videoMatrixCoefficients>,
-  mutable fullRange?: Null.t<bool>,
+  mutable primaries?: Nullable.t<videoColorPrimaries>,
+  mutable transfer?: Nullable.t<videoTransferCharacteristics>,
+  mutable matrix?: Nullable.t<videoMatrixCoefficients>,
+  mutable fullRange?: Nullable.t<bool>,
 }
 
 type planeLayout = {

--- a/src/crypto/Crypto.res
+++ b/src/crypto/Crypto.res
@@ -1,7 +1,7 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Crypto/getRandomValues)
 */
-@send
+@throws(JsExn) @send
 external getRandomValues: (WebCryptoTypes.crypto, 't) => 't = "getRandomValues"
 
 /**

--- a/src/css-font-loading/FontFace.res
+++ b/src/css-font-loading/FontFace.res
@@ -10,7 +10,7 @@ let fontFace =
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace)
 */
-@new
+@throws(JsExn) @new
 external fromString: (
   ~family: string,
   ~source: string,
@@ -29,7 +29,7 @@ let fontFace =
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace)
 */
-@new
+@throws(JsExn) @new
 external fromDataView: (
   ~family: string,
   ~source: DataView.t,
@@ -48,7 +48,7 @@ let fontFace =
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFace)
 */
-@new
+@throws(JsExn) @new
 external fromArrayBuffer: (
   ~family: string,
   ~source: ArrayBuffer.t,

--- a/src/css-font-loading/FontFaceSet.res
+++ b/src/css-font-loading/FontFaceSet.res
@@ -3,7 +3,7 @@ include EventTarget.Impl({type t = CssFontLoadingTypes.fontFaceSet})
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FontFaceSet/add)
 */
-@send
+@throws(JsExn) @send
 external add: (
   CssFontLoadingTypes.fontFaceSet,
   CssFontLoadingTypes.fontFace,

--- a/src/cssom/CSSRuleList.res
+++ b/src/cssom/CSSRuleList.res
@@ -2,4 +2,4 @@
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSRuleList/item)
 */
 @send
-external item: (StyleSheet.cssRuleList, int) => StyleSheet.cssRule = "item"
+external item: (StyleSheet.cssRuleList, int) => Null.t<StyleSheet.cssRule> = "item"

--- a/src/cssom/CSSStyleDeclaration.res
+++ b/src/cssom/CSSStyleDeclaration.res
@@ -1723,12 +1723,12 @@ external getPropertyPriority: (t, string) => string = "getPropertyPriority"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/setProperty)
 */
-@send
+@throws(JsExn) @send
 external setProperty: (t, ~property: string, ~value: string, ~priority: string=?) => unit =
   "setProperty"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/removeProperty)
 */
-@send
+@throws(JsExn) @send
 external removeProperty: (t, string) => string = "removeProperty"

--- a/src/cssom/CSSStyleValue.res
+++ b/src/cssom/CSSStyleValue.res
@@ -7,11 +7,11 @@ type t = private {}
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSStyleValue/parse_static)
 */
-@scope("CSSStyleValue")
+@throws(JsExn) @scope("CSSStyleValue")
 external parse: (~property: string, ~cssText: string) => t = "parse"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSStyleValue/parseAll_static)
 */
-@scope("CSSStyleValue")
+@throws(JsExn) @scope("CSSStyleValue")
 external parseAll: (~property: string, ~cssText: string) => array<t> = "parseAll"

--- a/src/cssom/MediaList.res
+++ b/src/cssom/MediaList.res
@@ -14,7 +14,7 @@ type t = {
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaList/item)
 */
 @send
-external item: (t, int) => string = "item"
+external item: (t, int) => Null.t<string> = "item"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaList/appendMedium)
@@ -25,5 +25,5 @@ external appendMedium: (t, string) => unit = "appendMedium"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaList/deleteMedium)
 */
-@send
+@throws(JsExn) @send
 external deleteMedium: (t, string) => unit = "deleteMedium"

--- a/src/cssom/StylePropertyMap.res
+++ b/src/cssom/StylePropertyMap.res
@@ -10,43 +10,43 @@ external asStylePropertyMapReadOnly: t => StylePropertyMapReadOnly.t = "%identit
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/getAll)
 */
-@send
+@throws(JsExn) @send
 external getAll: (t, string) => array<CSSStyleValue.t> = "getAll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/has)
 */
-@send
+@throws(JsExn) @send
 external has: (t, string) => bool = "has"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/set)
 */
-@send
+@throws(JsExn) @send
 external set: (t, ~property: string, ~values: CSSStyleValue.t) => unit = "set"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/set)
 */
-@send
+@throws(JsExn) @send
 external set2: (t, ~property: string, ~values: string) => unit = "set"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/append)
 */
-@send
+@throws(JsExn) @send
 external append: (t, ~property: string, ~values: CSSStyleValue.t) => unit = "append"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/append)
 */
-@send
+@throws(JsExn) @send
 external append2: (t, ~property: string, ~values: string) => unit = "append"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMap/delete)
 */
-@send
+@throws(JsExn) @send
 external delete: (t, string) => unit = "delete"
 
 /**

--- a/src/cssom/StylePropertyMapReadOnly.res
+++ b/src/cssom/StylePropertyMapReadOnly.res
@@ -12,11 +12,11 @@ type t = private {
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/getAll)
 */
-@send
+@throws(JsExn) @send
 external getAll: (t, string) => array<CSSStyleValue.t> = "getAll"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/has)
 */
-@send
+@throws(JsExn) @send
 external has: (t, string) => bool = "has"

--- a/src/cssom/StyleSheet.res
+++ b/src/cssom/StyleSheet.res
@@ -130,7 +130,7 @@ external asStyleSheet: cssStyleSheet => t = "%identity"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/insertRule)
 */
-@send
+@throws(JsExn) @send
 external insertRule: (cssStyleSheet, ~rule: string, ~index: int=?) => int = "insertRule"
 
 /**
@@ -148,5 +148,5 @@ external replace: (cssStyleSheet, string) => promise<cssStyleSheet> = "replace"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replaceSync)
 */
-@send
+@throws(JsExn) @send
 external replaceSync: (cssStyleSheet, string) => unit = "replaceSync"

--- a/src/cssom/StyleSheetList.res
+++ b/src/cssom/StyleSheetList.res
@@ -14,4 +14,4 @@ type t = private {
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/StyleSheetList/item)
 */
 @send
-external item: (t, int) => StyleSheet.cssStyleSheet = "item"
+external item: (t, int) => Null.t<StyleSheet.cssStyleSheet> = "item"

--- a/src/device/ScreenOrientation.res
+++ b/src/device/ScreenOrientation.res
@@ -3,5 +3,5 @@ include EventTarget.Impl({type t = DOM.screenOrientation})
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ScreenOrientation/unlock)
 */
-@send
+@throws(JsExn) @send
 external unlock: DOM.screenOrientation => unit = "unlock"

--- a/src/dom-nodes/CaretPosition.res
+++ b/src/dom-nodes/CaretPosition.res
@@ -1,2 +1,2 @@
 @send
-external getClientRect: DOM.caretPosition => DOM.domRect = "getClientRect"
+external getClientRect: DOM.caretPosition => Null.t<DOM.domRect> = "getClientRect"

--- a/src/dom-nodes/CharacterData.res
+++ b/src/dom-nodes/CharacterData.res
@@ -110,7 +110,7 @@ Inserts nodes just after node, while replacing strings in nodes with equivalent 
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/after)
 */
-  @send
+  @throws(JsExn) @send
   external after: (T.t, DOMTree.node) => unit = "after"
 
   /**
@@ -119,7 +119,7 @@ Inserts nodes just after node, while replacing strings in nodes with equivalent 
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/after)
 */
-  @send
+  @throws(JsExn) @send
   external after2: (T.t, string) => unit = "after"
 
   /**
@@ -134,7 +134,7 @@ Inserts nodes just before node, while replacing strings in nodes with equivalent
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/before)
 */
-  @send
+  @throws(JsExn) @send
   external before: (T.t, DOMTree.node) => unit = "before"
 
   /**
@@ -143,19 +143,19 @@ Inserts nodes just before node, while replacing strings in nodes with equivalent
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/before)
 */
-  @send
+  @throws(JsExn) @send
   external before2: (T.t, string) => unit = "before"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/deleteData)
 */
-  @send
+  @throws(JsExn) @send
   external deleteData: (T.t, ~offset: int, ~count: int) => unit = "deleteData"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/insertData)
 */
-  @send
+  @throws(JsExn) @send
   external insertData: (T.t, ~offset: int, ~data: string) => unit = "insertData"
 
   /**
@@ -168,7 +168,7 @@ Removes node.
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceData)
 */
-  @send
+  @throws(JsExn) @send
   external replaceData: (T.t, ~offset: int, ~count: int, ~data: string) => unit = "replaceData"
 
   /**
@@ -177,7 +177,7 @@ Replaces node with nodes, while replacing strings in nodes with equivalent Text 
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
 */
-  @send
+  @throws(JsExn) @send
   external replaceWith: (T.t, DOMTree.node) => unit = "replaceWith"
 
   /**
@@ -186,13 +186,13 @@ Replaces node with nodes, while replacing strings in nodes with equivalent Text 
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
 */
-  @send
+  @throws(JsExn) @send
   external replaceWith2: (T.t, string) => unit = "replaceWith"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/substringData)
 */
-  @send
+  @throws(JsExn) @send
   external substringData: (T.t, ~offset: int, ~count: int) => string = "substringData"
 }
 

--- a/src/dom-nodes/DOMImplementation.res
+++ b/src/dom-nodes/DOMImplementation.res
@@ -116,7 +116,7 @@ external createDocumentType: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMImplementation/createDocument)
 */
-@send
+@throws(JsExn) @send
 external createDocument: (
   t,
   ~namespace: string,

--- a/src/dom-nodes/DOMTree.res
+++ b/src/dom-nodes/DOMTree.res
@@ -257,10 +257,12 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   /**
     Returns the child elements.
@@ -665,6 +667,7 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ShadowRoot/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     Retrieves a collection of styleSheet objects representing the style sheets that correspond to each instance of a link or style object in the document.
@@ -674,6 +677,7 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/adoptedStyleSheets)
     */
+  @throws(JsExn)
   mutable adoptedStyleSheets: array<StyleSheet.cssStyleSheet>,
   /**
     Returns document's fullscreen element.
@@ -798,10 +802,12 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 
@@ -895,7 +901,7 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
     */
-  mutable hidden: unknown,
+  mutable hidden: Null.t<unknown>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
@@ -1020,7 +1026,7 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
     */
-  mutable hidden: unknown,
+  mutable hidden: Null.t<unknown>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
@@ -1172,10 +1178,12 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 
@@ -1402,10 +1410,12 @@ and htmlSlotElement = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 
@@ -1499,7 +1509,7 @@ and htmlSlotElement = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
     */
-  mutable hidden: unknown,
+  mutable hidden: Null.t<unknown>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */

--- a/src/dom-nodes/DOMTree.res
+++ b/src/dom-nodes/DOMTree.res
@@ -899,10 +899,6 @@ TODO: mark as private once mutating fields of private records is allowed
     */
   mutable dir: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: Null.t<unknown>,
-  /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
   mutable inert: bool,
@@ -1023,10 +1019,6 @@ TODO: mark as private once mutating fields of private records is allowed
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/dir)
     */
   mutable dir: string,
-  /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: Null.t<unknown>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
@@ -1506,10 +1498,6 @@ and htmlSlotElement = {
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/dir)
     */
   mutable dir: string,
-  /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: Null.t<unknown>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */

--- a/src/dom-nodes/DocumentFragment.res
+++ b/src/dom-nodes/DocumentFragment.res
@@ -23,7 +23,7 @@ Inserts nodes after the last child of node, while replacing strings in nodes wit
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/append)
 */
-  @send
+  @throws(JsExn) @send
   external append: (T.t, DOMTree.node) => unit = "append"
 
   /**
@@ -32,7 +32,7 @@ Inserts nodes after the last child of node, while replacing strings in nodes wit
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/append)
 */
-  @send
+  @throws(JsExn) @send
   external append2: (T.t, string) => unit = "append"
 
   /**
@@ -40,7 +40,7 @@ Returns the first element within node's descendants whose ID is elementId.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/getElementById)
 */
   @send
-  external getElementById: (T.t, string) => null<DOMTree.element> = "getElementById"
+  external getElementById: (T.t, string) => Null.t<DOMTree.element> = "getElementById"
 
   /**
 Inserts nodes before the first child of node, while replacing strings in nodes with equivalent Text nodes.
@@ -48,7 +48,7 @@ Inserts nodes before the first child of node, while replacing strings in nodes w
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/prepend)
 */
-  @send
+  @throws(JsExn) @send
   external prepend: (T.t, DOMTree.node) => unit = "prepend"
 
   /**
@@ -57,21 +57,21 @@ Inserts nodes before the first child of node, while replacing strings in nodes w
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/prepend)
 */
-  @send
+  @throws(JsExn) @send
   external prepend2: (T.t, string) => unit = "prepend"
 
   /**
 Returns the first element that is a descendant of node that matches selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/querySelector)
 */
-  @send
+  @throws(JsExn) @send
   external querySelector: (T.t, string) => Null.t<DOMTree.element> = "querySelector"
 
   /**
 Returns all element descendants of node that match selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/querySelectorAll)
 */
-  @send
+  @throws(JsExn) @send
   external querySelectorAll: (T.t, string) => DOM.nodeList<DOMTree.element> = "querySelectorAll"
 
   /**
@@ -80,7 +80,7 @@ Replace all children of node with nodes, while replacing strings in nodes with e
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/replaceChildren)
 */
-  @send
+  @throws(JsExn) @send
   external replaceChildren: (T.t, DOMTree.node) => unit = "replaceChildren"
 
   /**
@@ -89,7 +89,7 @@ Replace all children of node with nodes, while replacing strings in nodes with e
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DocumentFragment/replaceChildren)
 */
-  @send
+  @throws(JsExn) @send
   external replaceChildren2: (T.t, string) => unit = "replaceChildren"
 }
 

--- a/src/dom-nodes/Element.res
+++ b/src/dom-nodes/Element.res
@@ -17,7 +17,7 @@ Inserts nodes just after node, while replacing strings in nodes with equivalent 
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/after)
 */
-  @send
+  @throws(JsExn) @send
   external after: (T.t, DOMTree.node) => unit = "after"
 
   /**
@@ -26,7 +26,7 @@ Inserts nodes just after node, while replacing strings in nodes with equivalent 
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/after)
 */
-  @send
+  @throws(JsExn) @send
   external after2: (T.t, string) => unit = "after"
 
   /**
@@ -51,7 +51,7 @@ Inserts nodes after the last child of node, while replacing strings in nodes wit
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/append)
 */
-  @send
+  @throws(JsExn) @send
   external append: (T.t, DOMTree.node) => unit = "append"
 
   /**
@@ -60,14 +60,14 @@ Inserts nodes after the last child of node, while replacing strings in nodes wit
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/append)
 */
-  @send
+  @throws(JsExn) @send
   external append2: (T.t, string) => unit = "append"
 
   /**
 Creates a shadow root for element and returns it.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/attachShadow)
 */
-  @send
+  @throws(JsExn) @send
   external attachShadow: (T.t, HTML.shadowRootInit) => DOMTree.shadowRoot = "attachShadow"
 
   /**
@@ -76,7 +76,7 @@ Inserts nodes just before node, while replacing strings in nodes with equivalent
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/before)
 */
-  @send
+  @throws(JsExn) @send
   external before: (T.t, DOMTree.node) => unit = "before"
 
   /**
@@ -85,7 +85,7 @@ Inserts nodes just before node, while replacing strings in nodes with equivalent
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/before)
 */
-  @send
+  @throws(JsExn) @send
   external before2: (T.t, string) => unit = "before"
 
   /**
@@ -99,8 +99,8 @@ Throws a "HierarchyRequestError" DOMException if the constraints of the node tre
 Returns the first (starting at element) inclusive ancestor that matches selectors, and null otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/closest)
 */
-  @send
-  external closest: (T.t, string) => 'e = "closest"
+  @throws(JsExn) @send
+  external closest: (T.t, string) => Null.t<'e> = "closest"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/computedStyleMap)
@@ -111,7 +111,7 @@ Returns the first (starting at element) inclusive ancestor that matches selector
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getAnimations)
 */
-  @send
+  @throws(JsExn) @send
   external getAnimations: (
     T.t,
     ~options: AnimationEffect.getAnimationsOptions=?,
@@ -122,7 +122,7 @@ Returns element's first attribute whose qualified name is qualifiedName, and nul
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getAttribute)
 */
   @send
-  external getAttribute: (T.t, string) => null<string> = "getAttribute"
+  external getAttribute: (T.t, string) => Null.t<string> = "getAttribute"
 
   /**
 Returns the qualified names of all element's attributes. Can contain duplicates.
@@ -135,13 +135,13 @@ Returns the qualified names of all element's attributes. Can contain duplicates.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getAttributeNode)
 */
   @send
-  external getAttributeNode: (T.t, string) => Attr.t = "getAttributeNode"
+  external getAttributeNode: (T.t, string) => Null.t<Attr.t> = "getAttributeNode"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getAttributeNodeNS)
 */
   @send
-  external getAttributeNodeNS: (T.t, ~namespace: string, ~localName: string) => Attr.t =
+  external getAttributeNodeNS: (T.t, ~namespace: string, ~localName: string) => Null.t<Attr.t> =
     "getAttributeNodeNS"
 
   /**
@@ -149,7 +149,7 @@ Returns element's attribute whose namespace is namespace and local name is local
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/getAttributeNS)
 */
   @send
-  external getAttributeNS: (T.t, ~namespace: string, ~localName: string) => string =
+  external getAttributeNS: (T.t, ~namespace: string, ~localName: string) => Null.t<string> =
     "getAttributeNS"
 
   /**
@@ -230,12 +230,12 @@ Returns true if element has attributes, and false otherwise.
     T.t,
     ~where: DOM.insertPosition,
     ~element: DOMTree.element,
-  ) => DOMTree.element = "insertAdjacentElement"
+  ) => Null.t<DOMTree.element> = "insertAdjacentElement"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentHTML)
 */
-  @send
+  @throws(JsExn) @send
   external insertAdjacentHTML: (T.t, ~position: DOM.insertPosition, ~string: string) => unit =
     "insertAdjacentHTML"
 
@@ -250,7 +250,7 @@ Returns true if element has attributes, and false otherwise.
 Returns true if matching selectors against element's root yields element, and false otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/matches)
 */
-  @send
+  @throws(JsExn) @send
   external matches: (T.t, string) => bool = "matches"
 
   /**
@@ -259,7 +259,7 @@ Inserts nodes before the first child of node, while replacing strings in nodes w
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/prepend)
 */
-  @send
+  @throws(JsExn) @send
   external prepend: (T.t, DOMTree.node) => unit = "prepend"
 
   /**
@@ -268,27 +268,27 @@ Inserts nodes before the first child of node, while replacing strings in nodes w
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/prepend)
 */
-  @send
+  @throws(JsExn) @send
   external prepend2: (T.t, string) => unit = "prepend"
 
   /**
 Returns the first element that is a descendant of node that matches selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/querySelector)
 */
-  @send
+  @throws(JsExn) @send
   external querySelector: (T.t, string) => Null.t<DOMTree.element> = "querySelector"
 
   /**
 Returns all element descendants of node that match selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/querySelectorAll)
 */
-  @send
+  @throws(JsExn) @send
   external querySelectorAll: (T.t, string) => DOM.nodeList<DOMTree.element> = "querySelectorAll"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/releasePointerCapture)
 */
-  @send
+  @throws(JsExn) @send
   external releasePointerCapture: (T.t, int) => unit = "releasePointerCapture"
 
   /**
@@ -308,7 +308,7 @@ Removes element's first attribute whose qualified name is qualifiedName.
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/removeAttributeNode)
 */
-  @send
+  @throws(JsExn) @send
   external removeAttributeNode: (T.t, Attr.t) => Attr.t = "removeAttributeNode"
 
   /**
@@ -325,7 +325,7 @@ Replace all children of node with nodes, while replacing strings in nodes with e
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
 */
-  @send
+  @throws(JsExn) @send
   external replaceChildren: (T.t, DOMTree.node) => unit = "replaceChildren"
 
   /**
@@ -334,7 +334,7 @@ Replace all children of node with nodes, while replacing strings in nodes with e
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
 */
-  @send
+  @throws(JsExn) @send
   external replaceChildren2: (T.t, string) => unit = "replaceChildren"
 
   /**
@@ -343,7 +343,7 @@ Replaces node with nodes, while replacing strings in nodes with equivalent Text 
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
 */
-  @send
+  @throws(JsExn) @send
   external replaceWith: (T.t, DOMTree.node) => unit = "replaceWith"
 
   /**
@@ -352,7 +352,7 @@ Replaces node with nodes, while replacing strings in nodes with equivalent Text 
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
 */
-  @send
+  @throws(JsExn) @send
   external replaceWith2: (T.t, string) => unit = "replaceWith"
 
   /**
@@ -454,26 +454,26 @@ element->Element.scrollIntoViewWithOptions({ behavior: DOMAPI.Smooth })
 Sets the value of element's first attribute whose qualified name is qualifiedName to value.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/setAttribute)
 */
-  @send
+  @throws(JsExn) @send
   external setAttribute: (T.t, ~qualifiedName: string, ~value: string) => unit = "setAttribute"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNode)
 */
   @send
-  external setAttributeNode: (T.t, Attr.t) => Attr.t = "setAttributeNode"
+  external setAttributeNode: (T.t, Attr.t) => Null.t<Attr.t> = "setAttributeNode"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNodeNS)
 */
   @send
-  external setAttributeNodeNS: (T.t, Attr.t) => Attr.t = "setAttributeNodeNS"
+  external setAttributeNodeNS: (T.t, Attr.t) => Null.t<Attr.t> = "setAttributeNodeNS"
 
   /**
 Sets the value of element's attribute whose namespace is namespace and local name is localName to value.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNS)
-*/
-  @send
+  */
+  @throws(JsExn) @send
   external setAttributeNS: (
     DOMTree.element,
     ~namespace: string,
@@ -484,13 +484,13 @@ Sets the value of element's attribute whose namespace is namespace and local nam
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/setHTMLUnsafe)
 */
-  @send
+  @throws(JsExn) @send
   external setHTMLUnsafe: (T.t, string) => unit = "setHTMLUnsafe"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/setPointerCapture)
 */
-  @send
+  @throws(JsExn) @send
   external setPointerCapture: (T.t, int) => unit = "setPointerCapture"
 
   /**
@@ -499,7 +499,7 @@ If force is not given, "toggles" qualifiedName, removing it if it is present and
 Returns true if qualifiedName is now present, and false otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/toggleAttribute)
 */
-  @send
+  @throws(JsExn) @send
   external toggleAttribute: (T.t, ~qualifiedName: string, ~force: bool=?) => bool =
     "toggleAttribute"
 }

--- a/src/dom-nodes/ElementInternals.res
+++ b/src/dom-nodes/ElementInternals.res
@@ -8,7 +8,7 @@ Sets both the state and submission value of internals's target element to value.
 If value is null, the element won't participate in form submission.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ElementInternals/setFormValue)
 */
-@send
+@throws(JsExn) @send
 external setFormValue: (DOMTree.elementInternals, ~value: unknown, ~state: unknown=?) => unit =
   "setFormValue"
 
@@ -16,7 +16,7 @@ external setFormValue: (DOMTree.elementInternals, ~value: unknown, ~state: unkno
 Marks internals's target element as suffering from the constraints indicated by the flags argument, and sets the element's validation message to message. If anchor is specified, the user agent might use it to indicate problems with the constraints of internals's target element when the form owner is validated interactively or reportValidity() is called.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ElementInternals/setValidity)
 */
-@send
+@throws(JsExn) @send
 external setValidity: (
   DOMTree.elementInternals,
   ~flags: DOM.validityStateFlags=?,
@@ -28,12 +28,12 @@ external setValidity: (
 Returns true if internals's target element has no validity problems; false otherwise. Fires an invalid event at the element in the latter case.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ElementInternals/checkValidity)
 */
-@send
+@throws(JsExn) @send
 external checkValidity: DOMTree.elementInternals => bool = "checkValidity"
 
 /**
 Returns true if internals's target element has no validity problems; otherwise, returns false, fires an invalid event at the element, and (if the event isn't canceled) reports the problem to the user.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ElementInternals/reportValidity)
 */
-@send
+@throws(JsExn) @send
 external reportValidity: DOMTree.elementInternals => bool = "reportValidity"

--- a/src/dom-nodes/HTMLCollection.res
+++ b/src/dom-nodes/HTMLCollection.res
@@ -15,11 +15,11 @@ Retrieves an object from various collections.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/item)
 */
 @send
-external item: (t<'item>, int) => 'item = "item"
+external item: (t<'item>, int) => Null.t<'item> = "item"
 
 /**
 Retrieves a select object or an object from an options collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/namedItem)
 */
 @send
-external namedItem: (t<'item>, string) => 'item = "namedItem"
+external namedItem: (t<'item>, string) => Null.t<'item> = "namedItem"

--- a/src/dom-nodes/NamedNodeMap.res
+++ b/src/dom-nodes/NamedNodeMap.res
@@ -2,42 +2,45 @@
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/item)
 */
 @send
-external item: (DOM.namedNodeMap, int) => Attr.t = "item"
+external item: (DOM.namedNodeMap, int) => Null.t<Attr.t> = "item"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/getNamedItem)
 */
 @send
-external getNamedItem: (DOM.namedNodeMap, string) => Attr.t = "getNamedItem"
+external getNamedItem: (DOM.namedNodeMap, string) => Null.t<Attr.t> = "getNamedItem"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/getNamedItemNS)
 */
 @send
-external getNamedItemNS: (DOM.namedNodeMap, ~namespace: string, ~localName: string) => Attr.t =
-  "getNamedItemNS"
+external getNamedItemNS: (
+  DOM.namedNodeMap,
+  ~namespace: string,
+  ~localName: string,
+) => Null.t<Attr.t> = "getNamedItemNS"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/setNamedItem)
 */
-@send
-external setNamedItem: (DOM.namedNodeMap, Attr.t) => Attr.t = "setNamedItem"
+@throws(JsExn) @send
+external setNamedItem: (DOM.namedNodeMap, Attr.t) => Null.t<Attr.t> = "setNamedItem"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/setNamedItemNS)
 */
-@send
-external setNamedItemNS: (DOM.namedNodeMap, Attr.t) => Attr.t = "setNamedItemNS"
+@throws(JsExn) @send
+external setNamedItemNS: (DOM.namedNodeMap, Attr.t) => Null.t<Attr.t> = "setNamedItemNS"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/removeNamedItem)
 */
-@send
+@throws(JsExn) @send
 external removeNamedItem: (DOM.namedNodeMap, string) => Attr.t = "removeNamedItem"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/removeNamedItemNS)
 */
-@send
+@throws(JsExn) @send
 external removeNamedItemNS: (DOM.namedNodeMap, ~namespace: string, ~localName: string) => Attr.t =
   "removeNamedItemNS"

--- a/src/dom-nodes/Node.res
+++ b/src/dom-nodes/Node.res
@@ -72,13 +72,13 @@ Returns true if other is an inclusive descendant of node, and false otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/lookupPrefix)
 */
   @send
-  external lookupPrefix: (T.t, string) => string = "lookupPrefix"
+  external lookupPrefix: (T.t, string) => Null.t<string> = "lookupPrefix"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/lookupNamespaceURI)
 */
   @send
-  external lookupNamespaceURI: (T.t, string) => string = "lookupNamespaceURI"
+  external lookupNamespaceURI: (T.t, string) => Null.t<string> = "lookupNamespaceURI"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/isDefaultNamespace)
@@ -89,25 +89,25 @@ Returns true if other is an inclusive descendant of node, and false otherwise.
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/insertBefore)
 */
-  @send
+  @throws(JsExn) @send
   external insertBefore: (T.t, 't, ~child: DOMTree.node) => 't = "insertBefore"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/appendChild)
 */
-  @send
+  @throws(JsExn) @send
   external appendChild: (T.t, 't) => 't = "appendChild"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/replaceChild)
 */
-  @send
+  @throws(JsExn) @send
   external replaceChild: (T.t, ~node: DOMTree.node, 't) => 't = "replaceChild"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Node/removeChild)
 */
-  @send
+  @throws(JsExn) @send
   external removeChild: (T.t, 't) => 't = "removeChild"
 }
 

--- a/src/dom-nodes/NodeIterator.res
+++ b/src/dom-nodes/NodeIterator.res
@@ -29,10 +29,10 @@ type t = private {
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/nextNode)
 */
 @send
-external nextNode: t => DOMTree.node = "nextNode"
+external nextNode: t => Null.t<DOMTree.node> = "nextNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeIterator/previousNode)
 */
 @send
-external previousNode: t => DOMTree.node = "previousNode"
+external previousNode: t => Null.t<DOMTree.node> = "previousNode"

--- a/src/dom-nodes/NodeList.res
+++ b/src/dom-nodes/NodeList.res
@@ -3,4 +3,4 @@ Returns the node with index index from the collection. The nodes are sorted in t
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/NodeList/item)
 */
 @send
-external item: (DOM.nodeList<'tNode>, int) => 'tNode = "item"
+external item: (DOM.nodeList<'tNode>, int) => Null.t<'tNode> = "item"

--- a/src/dom-nodes/Range.res
+++ b/src/dom-nodes/Range.res
@@ -23,7 +23,7 @@ external setStart: (t, ~node: DOMTree.node, ~offset: int) => unit = "setStart"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/setEnd)
 */
-@send
+@throws(JsExn) @send
 external setEnd: (t, ~node: DOMTree.node, ~offset: int) => unit = "setEnd"
 
 /**
@@ -71,7 +71,7 @@ external selectNodeContents: (t, DOMTree.node) => unit = "selectNodeContents"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/compareBoundaryPoints)
 */
-@send
+@throws(JsExn) @send
 external compareBoundaryPoints: (t, ~how: int, ~sourceRange: t) => int = "compareBoundaryPoints"
 
 /**
@@ -101,7 +101,7 @@ external insertNode: (t, DOMTree.node) => unit = "insertNode"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/surroundContents)
 */
-@send
+@throws(JsExn) @send
 external surroundContents: (t, DOMTree.node) => unit = "surroundContents"
 
 /**
@@ -151,6 +151,6 @@ external getBoundingClientRect: t => DOM.domRect = "getBoundingClientRect"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Range/createContextualFragment)
 */
-@send
+@throws(JsExn) @send
 external createContextualFragment: (t, string) => DOMTree.documentFragment =
   "createContextualFragment"

--- a/src/dom-nodes/Selection.res
+++ b/src/dom-nodes/Selection.res
@@ -101,7 +101,7 @@ external extend: (t, ~node: DOMTree.node, ~offset: int=?) => unit = "extend"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Selection/setBaseAndExtent)
 */
-@send
+@throws(JsExn) @send
 external setBaseAndExtent: (
   t,
   ~anchorNode: DOMTree.node,

--- a/src/dom-nodes/ShadowRoot.res
+++ b/src/dom-nodes/ShadowRoot.res
@@ -13,7 +13,7 @@ external getAnimations: DOMTree.shadowRoot => array<Animation.t> = "getAnimation
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ShadowRoot/setHTMLUnsafe)
 */
-@send
+@throws(JsExn) @send
 external setHTMLUnsafe: (DOMTree.shadowRoot, string) => unit = "setHTMLUnsafe"
 
 /**

--- a/src/dom-nodes/Text.res
+++ b/src/dom-nodes/Text.res
@@ -27,5 +27,5 @@ external make: (~data: string=?) => t = "Text"
 Splits data at the given offset and returns the remainder as Text node.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Text/splitText)
 */
-@send
+@throws(JsExn) @send
 external splitText: (t, int) => t = "splitText"

--- a/src/dom-nodes/TreeWalker.res
+++ b/src/dom-nodes/TreeWalker.res
@@ -26,40 +26,40 @@ type t = {
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/parentNode)
 */
 @send
-external parentNode: t => DOMTree.node = "parentNode"
+external parentNode: t => Null.t<DOMTree.node> = "parentNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/firstChild)
 */
 @send
-external firstChild: t => DOMTree.node = "firstChild"
+external firstChild: t => Null.t<DOMTree.node> = "firstChild"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/lastChild)
 */
 @send
-external lastChild: t => DOMTree.node = "lastChild"
+external lastChild: t => Null.t<DOMTree.node> = "lastChild"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/previousSibling)
 */
 @send
-external previousSibling: t => DOMTree.node = "previousSibling"
+external previousSibling: t => Null.t<DOMTree.node> = "previousSibling"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/nextSibling)
 */
 @send
-external nextSibling: t => DOMTree.node = "nextSibling"
+external nextSibling: t => Null.t<DOMTree.node> = "nextSibling"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/previousNode)
 */
 @send
-external previousNode: t => DOMTree.node = "previousNode"
+external previousNode: t => Null.t<DOMTree.node> = "previousNode"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TreeWalker/nextNode)
 */
 @send
-external nextNode: t => DOMTree.node = "nextNode"
+external nextNode: t => Null.t<DOMTree.node> = "nextNode"

--- a/src/dom-platform/DOMStringList.res
+++ b/src/dom-platform/DOMStringList.res
@@ -5,7 +5,7 @@ Returns the string with index index from strings.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMStringList/item)
 */
 @send
-external item: (t, int) => string = "item"
+external item: (t, int) => Null.t<string> = "item"
 
 /**
 Returns true if strings contains string, and false otherwise.

--- a/src/dom-platform/DOMTokenList.res
+++ b/src/dom-platform/DOMTokenList.res
@@ -3,7 +3,7 @@ Returns the token with index index.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMTokenList/item)
 */
 @send
-external item: (DOM.domTokenList, int) => string = "item"
+external item: (DOM.domTokenList, int) => Null.t<string> = "item"
 
 /**
 Returns true if token is present, and false otherwise.
@@ -20,7 +20,7 @@ Throws a "SyntaxError" DOMException if one of the arguments is the empty string.
 Throws an "InvalidCharacterError" DOMException if one of the arguments contains any ASCII whitespace.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMTokenList/add)
 */
-@send
+@throws(JsExn) @send
 external add: (DOM.domTokenList, string) => unit = "add"
 
 /**
@@ -31,7 +31,7 @@ Throws a "SyntaxError" DOMException if one of the arguments is the empty string.
 Throws an "InvalidCharacterError" DOMException if one of the arguments contains any ASCII whitespace.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMTokenList/remove)
 */
-@send
+@throws(JsExn) @send
 external remove: (DOM.domTokenList, string) => unit = "remove"
 
 /**
@@ -44,7 +44,7 @@ Throws a "SyntaxError" DOMException if token is empty.
 Throws an "InvalidCharacterError" DOMException if token contains any spaces.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMTokenList/toggle)
 */
-@send
+@throws(JsExn) @send
 external toggle: (DOM.domTokenList, ~token: string, ~force: bool=?) => bool = "toggle"
 
 /**
@@ -57,7 +57,7 @@ Throws a "SyntaxError" DOMException if one of the arguments is the empty string.
 Throws an "InvalidCharacterError" DOMException if one of the arguments contains any ASCII whitespace.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMTokenList/replace)
 */
-@send
+@throws(JsExn) @send
 external replace: (DOM.domTokenList, ~token: string, ~newToken: string) => bool = "replace"
 
 /**
@@ -66,5 +66,5 @@ Returns true if token is in the associated attribute's supported tokens. Returns
 Throws a TypeError if the associated attribute has no supported tokens defined.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMTokenList/supports)
 */
-@send
+@throws(JsExn) @send
 external supports: (DOM.domTokenList, string) => bool = "supports"

--- a/src/event/AbortSignal.res
+++ b/src/event/AbortSignal.res
@@ -21,5 +21,5 @@ external any: array<DOM.abortSignal> => DOM.abortSignal = "any"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AbortSignal/throwIfAborted)
 */
-@send
+@throws(JsExn) @send
 external throwIfAborted: DOM.abortSignal => unit = "throwIfAborted"

--- a/src/event/EventTarget.res
+++ b/src/event/EventTarget.res
@@ -84,7 +84,7 @@ Removes the event listener in target's event listener list with the same type, c
 Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent)
 */
-  @send
+  @throws(JsExn) @send
   external dispatchEvent: (T.t, DOM.event) => bool = "dispatchEvent"
 }
 

--- a/src/fetch/FetchTypes.res
+++ b/src/fetch/FetchTypes.res
@@ -231,7 +231,7 @@ type requestInit = {
   /**
     A BodyInit object or null to set request's body.
     */
-  mutable body?: bodyInit,
+  mutable body?: Nullable.t<bodyInit>,
   /**
     A string whose value is a same-origin WebApiURL, "about:client", or the empty string, to set request's referrer.
     */
@@ -267,12 +267,12 @@ type requestInit = {
   /**
     An AbortSignal to set request's signal.
     */
-  mutable signal?: Null.t<DOM.abortSignal>,
+  mutable signal?: Nullable.t<DOM.abortSignal>,
   mutable priority?: requestPriority,
   /**
     Can only be null. Used to disassociate request from any Window.
     */
-  mutable window?: Null.t<unit>,
+  mutable window?: Nullable.t<unit>,
 }
 
 type responseInit = {

--- a/src/fetch/FormData.res
+++ b/src/fetch/FormData.res
@@ -7,7 +7,7 @@ type formDataEntryValue = FormDataEntryValue.t
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData)
 */
-@new
+@throws(JsExn) @new
 external make: (~form: 'form=?, ~submitter: 'submitter=?) => t = "FormData"
 
 /**
@@ -32,7 +32,7 @@ external delete: (t, string) => unit = "delete"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/get)
 */
 @send
-external get: (t, string) => null<formDataEntryValue> = "get"
+external get: (t, string) => Null.t<formDataEntryValue> = "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FormData/getAll)

--- a/src/fetch/Headers.res
+++ b/src/fetch/Headers.res
@@ -37,8 +37,8 @@ external delete: (FetchTypes.headers, string) => unit = "delete"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/get)
 */
-@send
-external get: (FetchTypes.headers, string) => null<string> = "get"
+@throws(JsExn) @send
+external get: (FetchTypes.headers, string) => Null.t<string> = "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie)
@@ -49,11 +49,11 @@ external getSetCookie: FetchTypes.headers => array<string> = "getSetCookie"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/has)
 */
-@send
+@throws(JsExn) @send
 external has: (FetchTypes.headers, string) => bool = "has"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Headers/set)
 */
-@send
+@throws(JsExn) @send
 external set: (FetchTypes.headers, ~name: string, ~value: string) => unit = "set"

--- a/src/fetch/Request.res
+++ b/src/fetch/Request.res
@@ -9,13 +9,13 @@ type headersInit = HeadersInit.t
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
 */
-@new
+@throws(JsExn) @new
 external fromURL: (string, ~init: requestInit=?) => t = "Request"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request)
 */
-@new
+@throws(JsExn) @new
 external fromRequest: (t, ~init: requestInit=?) => t = "Request"
 
 /**
@@ -57,5 +57,5 @@ external text: t => promise<string> = "text"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Request/clone)
 */
-@send
+@throws(JsExn) @send
 external clone: t => t = "clone"

--- a/src/fetch/Response.res
+++ b/src/fetch/Response.res
@@ -111,17 +111,17 @@ external error: unit => t = "error"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/redirect_static)
 */
-@scope("Response")
+@throws(JsExn) @scope("Response")
 external redirect: (~url: string, ~status: int=?) => t = "redirect"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/json_static)
 */
-@scope("Response")
+@throws(JsExn) @scope("Response")
 external jsonR: (~data: JSON.t, ~init: responseInit=?) => t = "json"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Response/clone)
 */
-@send
+@throws(JsExn) @send
 external clone: t => t = "clone"

--- a/src/file/FileList.res
+++ b/src/file/FileList.res
@@ -13,4 +13,4 @@ for i in 0 to fileList.length - 1 {
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileList/item)
 */
 @send
-external item: (DOM.fileList, int) => FileTypes.file = "item"
+external item: (DOM.fileList, int) => Null.t<FileTypes.file> = "item"

--- a/src/file/FileSystemDirectoryEntry.res
+++ b/src/file/FileSystemDirectoryEntry.res
@@ -3,7 +3,7 @@ external asFileSystemEntry: FileAndDirectoryEntriesTypes.fileSystemDirectoryEntr
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemEntry/getParent)
 */
-@send
+@throws(JsExn) @send
 external getParent: (
   FileAndDirectoryEntriesTypes.fileSystemDirectoryEntry,
   ~successCallback: FileAndDirectoryEntriesTypes.fileSystemEntryCallback=?,
@@ -20,7 +20,7 @@ external createReader: FileAndDirectoryEntriesTypes.fileSystemDirectoryEntry => 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry/getFile)
 */
-@send
+@throws(JsExn) @send
 external getFile: (
   FileAndDirectoryEntriesTypes.fileSystemDirectoryEntry,
   ~path: string=?,
@@ -32,7 +32,7 @@ external getFile: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry/getDirectory)
 */
-@send
+@throws(JsExn) @send
 external getDirectory: (
   FileAndDirectoryEntriesTypes.fileSystemDirectoryEntry,
   ~path: string=?,

--- a/src/file/FileSystemDirectoryHandle.res
+++ b/src/file/FileSystemDirectoryHandle.res
@@ -46,4 +46,4 @@ external removeEntry: (
 external resolve: (
   FileTypes.fileSystemDirectoryHandle,
   FileTypes.fileSystemHandle,
-) => promise<array<string>> = "resolve"
+) => promise<Null.t<array<string>>> = "resolve"

--- a/src/file/FileSystemEntry.res
+++ b/src/file/FileSystemEntry.res
@@ -1,7 +1,7 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/FileSystemEntry/getParent)
 */
-@send
+@throws(JsExn) @send
 external getParent: (
   FileAndDirectoryEntriesTypes.fileSystemEntry,
   ~successCallback: FileAndDirectoryEntriesTypes.fileSystemEntryCallback=?,

--- a/src/file/FileSystemWritableFileStream.res
+++ b/src/file/FileSystemWritableFileStream.res
@@ -16,7 +16,7 @@ external close: FileTypes.fileSystemWritableFileStream => promise<unit> = "close
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter)
 */
-@send
+@throws(JsExn) @send
 external getWriter: FileTypes.fileSystemWritableFileStream => FileTypes.writableStreamDefaultWriter<
   'w,
 > = "getWriter"

--- a/src/file/FileTypes.res
+++ b/src/file/FileTypes.res
@@ -218,7 +218,7 @@ type fileSystemCreateWritableOptions = {mutable keepExistingData?: bool}
 
 type writeParams = {
   @as("type") mutable type_: writeCommandType,
-  mutable size?: Null.t<int>,
-  mutable position?: Null.t<int>,
-  mutable data?: Null.t<unknown>,
+  mutable size?: Nullable.t<int>,
+  mutable position?: Nullable.t<int>,
+  mutable data?: Nullable.t<unknown>,
 }

--- a/src/file/ReadableStream.res
+++ b/src/file/ReadableStream.res
@@ -31,7 +31,7 @@ let streamWithStrategy =
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream)
 */
-@new
+@throws(JsExn) @new
 external fromUnderlyingSource: (
   FileTypes.underlyingSource<'t>,
   ~strategy: FileTypes.queuingStrategy<'t>=?,
@@ -46,7 +46,7 @@ external cancel: (t<'r>, ~reason: JSON.t=?) => promise<unit> = "cancel"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader)
 */
-@send
+@throws(JsExn) @send
 external getReader: (
   t<'r>,
   ~options: FileTypes.readableStreamGetReaderOptions=?,
@@ -55,7 +55,7 @@ external getReader: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeThrough)
 */
-@send
+@throws(JsExn) @send
 external pipeThrough: (
   t<'r>,
   ~transform: FileTypes.readableWritablePair<'t, 'r>,
@@ -75,5 +75,5 @@ external pipeTo: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee)
 */
-@send
+@throws(JsExn) @send
 external tee: t<'r> => array<t<unit>> = "tee"

--- a/src/file/WritableStream.res
+++ b/src/file/WritableStream.res
@@ -1,7 +1,7 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~underlyingSink: FileTypes.underlyingSink<'w>=?,
   ~strategy: FileTypes.queuingStrategy<'w>=?,
@@ -22,6 +22,6 @@ external close: FileTypes.writableStream<'w> => promise<unit> = "close"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter)
 */
-@send
+@throws(JsExn) @send
 external getWriter: FileTypes.writableStream<'w> => FileTypes.writableStreamDefaultWriter<'w> =
   "getWriter"

--- a/src/geometry/DOMMatrix.res
+++ b/src/geometry/DOMMatrix.res
@@ -23,7 +23,7 @@ let matrix = DOMMatrix.fromString("matrix(1, 0, 0, 1, 0, 0)")
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMMatrix)
 */
-@new
+@throws(JsExn) @new
 external fromString: string => DOM.domMatrix = "DOMMatrix"
 
 /**
@@ -37,17 +37,17 @@ let matrix = DOMMatrix.fromArray([1., 0., 0., 1., 0., 0.])
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMMatrix)
 */
-@new
+@throws(JsExn) @new
 external fromArray: array<float> => DOM.domMatrix = "DOMMatrix"
 
 external asDOMMatrixReadOnly: DOM.domMatrix => DOM.domMatrixReadOnly = "%identity"
 @scope("DOMMatrix")
 external fromMatrix: (~other: DOM.domMatrixInit=?) => DOM.domMatrixReadOnly = "fromMatrix"
 
-@scope("DOMMatrix")
+@throws(JsExn) @scope("DOMMatrix")
 external fromFloat32Array: array<float> => DOM.domMatrixReadOnly = "fromFloat32Array"
 
-@scope("DOMMatrix")
+@throws(JsExn) @scope("DOMMatrix")
 external fromFloat64Array: Float64Array.t => DOM.domMatrixReadOnly = "fromFloat64Array"
 
 /**
@@ -134,10 +134,10 @@ external toJSON: DOM.domMatrix => Dict.t<string> = "toJSON"
 @scope("DOMMatrix")
 external fromMatrixD: (~other: DOM.domMatrixInit=?) => DOM.domMatrix = "fromMatrix"
 
-@scope("DOMMatrix")
+@throws(JsExn) @scope("DOMMatrix")
 external fromFloat32ArrayD: array<float> => DOM.domMatrix = "fromFloat32Array"
 
-@scope("DOMMatrix")
+@throws(JsExn) @scope("DOMMatrix")
 external fromFloat64ArrayD: Float64Array.t => DOM.domMatrix = "fromFloat64Array"
 
 @send
@@ -202,5 +202,5 @@ external skewYSelf: (DOM.domMatrix, ~sy: float=?) => DOM.domMatrix = "skewYSelf"
 @send
 external invertSelf: DOM.domMatrix => DOM.domMatrix = "invertSelf"
 
-@send
+@throws(JsExn) @send
 external setMatrixValue: (DOM.domMatrix, string) => DOM.domMatrix = "setMatrixValue"

--- a/src/geometry/DOMMatrixReadOnly.res
+++ b/src/geometry/DOMMatrixReadOnly.res
@@ -23,7 +23,7 @@ let matrix = DOMMatrixReadOnly.fromString("matrix(1, 0, 0, 1, 0, 0)")
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly)
 */
-@new
+@throws(JsExn) @new
 external fromString: string => DOM.domMatrixReadOnly = "DOMMatrixReadOnly"
 
 /**
@@ -37,16 +37,16 @@ let matrix = DOMMatrixReadOnly.fromArray([1., 0., 0., 1., 0., 0.])
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly)
 */
-@new
+@throws(JsExn) @new
 external fromArray: array<float> => DOM.domMatrixReadOnly = "DOMMatrixReadOnly"
 
 @scope("DOMMatrixReadOnly")
 external fromMatrix: (~other: DOM.domMatrixInit=?) => DOM.domMatrixReadOnly = "fromMatrix"
 
-@scope("DOMMatrixReadOnly")
+@throws(JsExn) @scope("DOMMatrixReadOnly")
 external fromFloat32Array: array<float> => DOM.domMatrixReadOnly = "fromFloat32Array"
 
-@scope("DOMMatrixReadOnly")
+@throws(JsExn) @scope("DOMMatrixReadOnly")
 external fromFloat64Array: Float64Array.t => DOM.domMatrixReadOnly = "fromFloat64Array"
 
 /**

--- a/src/geometry/DOMRectList.res
+++ b/src/geometry/DOMRectList.res
@@ -1,2 +1,2 @@
 @send
-external item: (DOM.domRectList, int) => DOM.domRect = "item"
+external item: (DOM.domRectList, int) => Null.t<DOM.domRect> = "item"

--- a/src/html/HTMLAnchorElement.res
+++ b/src/html/HTMLAnchorElement.res
@@ -176,10 +176,12 @@ type t = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 

--- a/src/html/HTMLAnchorElement.res
+++ b/src/html/HTMLAnchorElement.res
@@ -22,10 +22,6 @@ type t = {
     */
   mutable dir: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: unknown,
-  /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
   mutable inert: bool,

--- a/src/html/HTMLAreaElement.res
+++ b/src/html/HTMLAreaElement.res
@@ -176,10 +176,12 @@ type t = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 

--- a/src/html/HTMLAreaElement.res
+++ b/src/html/HTMLAreaElement.res
@@ -22,10 +22,6 @@ type t = {
     */
   mutable dir: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: unknown,
-  /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
   mutable inert: bool,

--- a/src/html/HTMLDialogElement.res
+++ b/src/html/HTMLDialogElement.res
@@ -21,13 +21,13 @@ include HTMLElement.Impl({type t = t})
 Displays the dialog element.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/show)
 */
-@send
+@throws(JsExn) @send
 external show: t => unit = "show"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/showModal)
 */
-@send
+@throws(JsExn) @send
 external showModal: t => unit = "showModal"
 
 /**

--- a/src/html/HTMLElement.res
+++ b/src/html/HTMLElement.res
@@ -1,3 +1,29 @@
+/**
+Represents the observable states of `HTMLElement.hidden`.
+
+- `Visible` means the element is not hidden.
+- `Hidden` means the element is hidden.
+- `HiddenUntilFound` means the element can be revealed by find-in-page or fragment navigation.
+
+[Read more in the HTML Standard](https://html.spec.whatwg.org/multipage/interaction.html#dom-hidden)
+*/
+type hiddenState =
+  | @as(false) Visible
+  | @as(true) Hidden
+  | @as("until-found") HiddenUntilFound
+
+/**
+Represents every value accepted by the native `HTMLElement.hidden` setter.
+
+Prefer `setHidden` for normal use. Use this type with `setHiddenRaw` only when Web IDL coercion behavior is required.
+*/
+@unboxed
+type hiddenInput =
+  | Boolean(bool)
+  | Number(float)
+  | String(string)
+  | @as(null) Null
+
 type t = DOMTree.htmlElement = private {
   ...DOMTree.htmlElement,
 }
@@ -10,6 +36,57 @@ module Impl = (
   include Element.Impl({type t = T.t})
 
   external asHTMLElement: T.t => DOMTree.htmlElement = "%identity"
+
+  /**
+Returns the element's current hidden state.
+
+```rescript
+let description = switch element->HTMLElement.hidden {
+| HTMLElement.Visible => "visible"
+| HTMLElement.Hidden => "hidden"
+| HTMLElement.HiddenUntilFound => "hidden until found"
+}
+```
+
+This getter never returns `null`.
+
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
+*/
+  @get
+  external hidden: T.t => hiddenState = "hidden"
+
+  /**
+Sets the element's semantic hidden state.
+
+```rescript
+element->HTMLElement.setHidden(HTMLElement.Hidden)
+element->HTMLElement.setHidden(HTMLElement.HiddenUntilFound)
+element->HTMLElement.setHidden(HTMLElement.Visible)
+```
+
+[Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
+*/
+  @set
+  external setHidden: (T.t, hiddenState) => unit = "hidden"
+
+  /**
+Sets the native property using its complete Web IDL input contract.
+
+```rescript
+// `null` removes the hidden attribute.
+element->HTMLElement.setHiddenRaw(HTMLElement.Null)
+
+// Arbitrary native setter inputs remain available.
+element->HTMLElement.setHiddenRaw(HTMLElement.Number(0.))
+element->HTMLElement.setHiddenRaw(HTMLElement.String("until-found"))
+```
+
+Prefer `setHidden` unless the browser's coercion behavior is specifically required.
+
+[Read more in the HTML Standard](https://html.spec.whatwg.org/multipage/interaction.html#dom-hidden)
+*/
+  @set
+  external setHiddenRaw: (T.t, hiddenInput) => unit = "hidden"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/attachInternals)

--- a/src/html/HTMLElement.res
+++ b/src/html/HTMLElement.res
@@ -14,7 +14,7 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/attachInternals)
 */
-  @send
+  @throws(JsExn) @send
   external attachInternals: T.t => DOMTree.elementInternals = "attachInternals"
 
   /**
@@ -38,19 +38,19 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidePopover)
 */
-  @send
+  @throws(JsExn) @send
   external hidePopover: T.t => unit = "hidePopover"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/showPopover)
 */
-  @send
+  @throws(JsExn) @send
   external showPopover: T.t => unit = "showPopover"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
 */
-  @send
+  @throws(JsExn) @send
   external togglePopover: (T.t, ~force: bool=?) => bool = "togglePopover"
 }
 

--- a/src/html/HTMLElement.res
+++ b/src/html/HTMLElement.res
@@ -23,6 +23,7 @@ type hiddenInput =
   | Number(float)
   | String(string)
   | @as(null) Null
+  | @as(undefined) Undefined
 
 type t = DOMTree.htmlElement = private {
   ...DOMTree.htmlElement,
@@ -73,8 +74,9 @@ element->HTMLElement.setHidden(HTMLElement.Visible)
 Sets the native property using its complete Web IDL input contract.
 
 ```rescript
-// `null` removes the hidden attribute.
+// `null` and `undefined` remove the hidden attribute.
 element->HTMLElement.setHiddenRaw(HTMLElement.Null)
+element->HTMLElement.setHiddenRaw(HTMLElement.Undefined)
 
 // Arbitrary native setter inputs remain available.
 element->HTMLElement.setHiddenRaw(HTMLElement.Number(0.))

--- a/src/html/HTMLElement.res
+++ b/src/html/HTMLElement.res
@@ -12,19 +12,6 @@ type hiddenState =
   | @as(true) Hidden
   | @as("until-found") HiddenUntilFound
 
-/**
-Represents every value accepted by the native `HTMLElement.hidden` setter.
-
-Prefer `setHidden` for normal use. Use this type with `setHiddenRaw` only when Web IDL coercion behavior is required.
-*/
-@unboxed
-type hiddenInput =
-  | Boolean(bool)
-  | Number(float)
-  | String(string)
-  | @as(null) Null
-  | @as(undefined) Undefined
-
 type t = DOMTree.htmlElement = private {
   ...DOMTree.htmlElement,
 }
@@ -65,30 +52,15 @@ element->HTMLElement.setHidden(HTMLElement.HiddenUntilFound)
 element->HTMLElement.setHidden(HTMLElement.Visible)
 ```
 
+The browser also accepts values such as numbers, arbitrary strings, `null`, and
+`undefined`, but coerces each of them to one of these three states. This binding
+intentionally accepts only `hiddenState` so callers express the resulting state
+rather than relying on coercion.
+
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
 */
   @set
   external setHidden: (T.t, hiddenState) => unit = "hidden"
-
-  /**
-Sets the native property using its complete Web IDL input contract.
-
-```rescript
-// `null` and `undefined` remove the hidden attribute.
-element->HTMLElement.setHiddenRaw(HTMLElement.Null)
-element->HTMLElement.setHiddenRaw(HTMLElement.Undefined)
-
-// Arbitrary native setter inputs remain available.
-element->HTMLElement.setHiddenRaw(HTMLElement.Number(0.))
-element->HTMLElement.setHiddenRaw(HTMLElement.String("until-found"))
-```
-
-Prefer `setHidden` unless the browser's coercion behavior is specifically required.
-
-[Read more in the HTML Standard](https://html.spec.whatwg.org/multipage/interaction.html#dom-hidden)
-*/
-  @set
-  external setHiddenRaw: (T.t, hiddenInput) => unit = "hidden"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/attachInternals)

--- a/src/html/HTMLEmbedElement.res
+++ b/src/html/HTMLEmbedElement.res
@@ -176,10 +176,12 @@ type t = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 
@@ -274,4 +276,4 @@ type t = {
 include HTMLElement.Impl({type t = t})
 
 @send
-external getSVGDocument: t => DOM.document = "getSVGDocument"
+external getSVGDocument: t => Null.t<DOM.document> = "getSVGDocument"

--- a/src/html/HTMLEmbedElement.res
+++ b/src/html/HTMLEmbedElement.res
@@ -22,10 +22,6 @@ type t = {
     */
   mutable dir: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: unknown,
-  /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
   mutable inert: bool,

--- a/src/html/HTMLFormControlsCollection.res
+++ b/src/html/HTMLFormControlsCollection.res
@@ -10,11 +10,12 @@ Retrieves an object from various collections.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/item)
 */
 @send
-external item: (DOMTree.htmlFormControlsCollection, int) => DOMTree.element = "item"
+external item: (DOMTree.htmlFormControlsCollection, int) => Null.t<DOMTree.element> = "item"
 
 /**
 Retrieves a select object or an object from an options collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLCollection/namedItem)
 */
 @send
-external namedItem: (DOMTree.htmlFormControlsCollection, string) => DOMTree.element = "namedItem"
+external namedItem: (DOMTree.htmlFormControlsCollection, string) => Null.t<DOMTree.element> =
+  "namedItem"

--- a/src/html/HTMLFormElement.res
+++ b/src/html/HTMLFormElement.res
@@ -8,13 +8,13 @@ include HTMLElement.Impl({type t = t})
 Fires when a FORM is about to be submitted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/submit)
 */
-@send
+@throws(JsExn) @send
 external submit: DOMTree.htmlFormElement => unit = "submit"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/requestSubmit)
 */
-@send
+@throws(JsExn) @send
 external requestSubmit: (DOMTree.htmlFormElement, ~submitter: DOMTree.htmlElement=?) => unit =
   "requestSubmit"
 

--- a/src/html/HTMLHeadElement.res
+++ b/src/html/HTMLHeadElement.res
@@ -176,10 +176,12 @@ type rec t = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 

--- a/src/html/HTMLHeadElement.res
+++ b/src/html/HTMLHeadElement.res
@@ -22,10 +22,6 @@ type rec t = {
     */
   mutable dir: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: unknown,
-  /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
   mutable inert: bool,

--- a/src/html/HTMLIFrameElement.res
+++ b/src/html/HTMLIFrameElement.res
@@ -14,6 +14,7 @@ type t = {
     Sets or retrives the content of the page that is to contain.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/srcdoc)
     */
+  @throws(JsExn)
   mutable srcdoc: string,
   /**
     Sets or retrieves the frame name.
@@ -65,4 +66,4 @@ type t = {
 include HTMLElement.Impl({type t = t})
 
 @send
-external getSVGDocument: t => DOM.document = "getSVGDocument"
+external getSVGDocument: t => Null.t<DOM.document> = "getSVGDocument"

--- a/src/html/HTMLImageElement.res
+++ b/src/html/HTMLImageElement.res
@@ -176,10 +176,12 @@ type t = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 

--- a/src/html/HTMLImageElement.res
+++ b/src/html/HTMLImageElement.res
@@ -22,10 +22,6 @@ type t = {
     */
   mutable dir: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: unknown,
-  /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
   mutable inert: bool,

--- a/src/html/HTMLInputElement.res
+++ b/src/html/HTMLInputElement.res
@@ -151,16 +151,19 @@ type t = {
     Returns the value of the data at the cursor's current position.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/value)
     */
+  @throws(JsExn)
   mutable value: string,
   /**
     Returns a Date object representing the form control's value, if applicable; otherwise, returns null. Can be set, to change the value. Throws an "InvalidStateError" DOMException if the control isn't date- or time-based.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/valueAsDate)
     */
+  @throws(JsExn)
   mutable valueAsDate: Null.t<Date.t>,
   /**
     Returns the input field value as a number.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/valueAsNumber)
     */
+  @throws(JsExn)
   mutable valueAsNumber: float,
   /**
     Sets or retrieves the width of the object.
@@ -190,15 +193,18 @@ type t = {
     Gets or sets the starting position or offset of a text selection.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/selectionStart)
     */
+  @throws(JsExn)
   mutable selectionStart: Null.t<int>,
   /**
     Gets or sets the end position or offset of a text selection.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/selectionEnd)
     */
+  @throws(JsExn)
   mutable selectionEnd: Null.t<int>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/selectionDirection)
     */
+  @throws(JsExn)
   mutable selectionDirection: Null.t<string>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory)
@@ -229,7 +235,7 @@ Increments a range input control's value by the value given by the Step attribut
 @param n Value to increment the value by.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/stepUp)
 */
-@send
+@throws(JsExn) @send
 external stepUp: (t, ~n: int=?) => unit = "stepUp"
 
 /**
@@ -237,7 +243,7 @@ Decrements a range input control's value by the value given by the Step attribut
 @param n Value to decrement the value by.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/stepDown)
 */
-@send
+@throws(JsExn) @send
 external stepDown: (t, ~n: int=?) => unit = "stepDown"
 
 /**
@@ -293,12 +299,12 @@ Sets the start and end positions of a selection in a text field.
 @param direction The direction in which the selection is performed.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setSelectionRange)
 */
-@send
+@throws(JsExn) @send
 external setSelectionRange: (t, ~start: int, ~end: int, ~direction: string=?) => unit =
   "setSelectionRange"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/showPicker)
 */
-@send
+@throws(JsExn) @send
 external showPicker: t => unit = "showPicker"

--- a/src/html/HTMLObjectElement.res
+++ b/src/html/HTMLObjectElement.res
@@ -65,7 +65,7 @@ type t = {
 include HTMLElement.Impl({type t = t})
 
 @send
-external getSVGDocument: t => DOM.document = "getSVGDocument"
+external getSVGDocument: t => Null.t<DOM.document> = "getSVGDocument"
 
 /**
 Returns whether a form will validate when it is submitted, without having to submit it.

--- a/src/html/HTMLOptionsCollection.res
+++ b/src/html/HTMLOptionsCollection.res
@@ -24,7 +24,7 @@ If before is omitted, null, or a number out of range, then element will be added
 This method will throw a "HierarchyRequestError" DOMException if element is an ancestor of the element into which it is to be inserted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLOptionsCollection/add)
 */
-@send
+@throws(JsExn) @send
 external add: (t, ~element: unknown, ~before: unknown=?) => unit = "add"
 
 /**

--- a/src/html/HTMLScriptElement.res
+++ b/src/html/HTMLScriptElement.res
@@ -176,10 +176,12 @@ type t = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/innerHTML)
     */
+  @throws(JsExn)
   mutable innerHTML: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Element/outerHTML)
     */
+  @throws(JsExn)
   mutable outerHTML: string,
   // End base properties from Element
 
@@ -258,6 +260,7 @@ type t = {
     Retrieves the WebApiURL to an external file that contains the source code or data.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/src)
     */
+  @throws(JsExn)
   mutable src: string,
   /**
     Sets or retrieves the MIME type for the associated scripting engine.
@@ -286,6 +289,7 @@ type t = {
     Retrieves or sets the text of the object as a string.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/text)
     */
+  @throws(JsExn)
   mutable text: string,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/integrity)

--- a/src/html/HTMLScriptElement.res
+++ b/src/html/HTMLScriptElement.res
@@ -22,10 +22,6 @@ type t = {
     */
   mutable dir: string,
   /**
-    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
-    */
-  mutable hidden: unknown,
-  /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
     */
   mutable inert: bool,

--- a/src/html/HTMLSelectElement.res
+++ b/src/html/HTMLSelectElement.res
@@ -94,7 +94,7 @@ Retrieves a select object or an object from an options collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/item)
 */
 @send
-external item: (t, int) => HTMLOptionElement.t = "item"
+external item: (t, int) => Null.t<HTMLOptionElement.t> = "item"
 
 /**
 Retrieves a select object or an object from an options collection.
@@ -102,7 +102,7 @@ Retrieves a select object or an object from an options collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/namedItem)
 */
 @send
-external namedItem: (t, string) => HTMLOptionElement.t = "namedItem"
+external namedItem: (t, string) => Null.t<HTMLOptionElement.t> = "namedItem"
 
 /**
 Adds an element to the areas, controlRange, or options collection.
@@ -110,7 +110,7 @@ Adds an element to the areas, controlRange, or options collection.
 @param before Variant of type Object that specifies an element to insert before, or null to append the object to the collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/add)
 */
-@send
+@throws(JsExn) @send
 external add: (t, ~element: unknown, ~before: unknown=?) => unit = "add"
 
 /**
@@ -153,5 +153,5 @@ external setCustomValidity: (t, string) => unit = "setCustomValidity"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/showPicker)
 */
-@send
+@throws(JsExn) @send
 external showPicker: t => unit = "showPicker"

--- a/src/html/HTMLSlotElement.res
+++ b/src/html/HTMLSlotElement.res
@@ -24,11 +24,11 @@ external assignedElements: (t, ~options: DOM.assignedNodesOptions=?) => array<DO
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assign)
 */
-@send
+@throws(JsExn) @send
 external assign: (t, DOMTree.element) => unit = "assign"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assign)
 */
-@send
+@throws(JsExn) @send
 external assign2: (t, Text.t) => unit = "assign"

--- a/src/html/HTMLTableElement.res
+++ b/src/html/HTMLTableElement.res
@@ -88,7 +88,7 @@ Creates a new row (tr) in the table, and adds the row to the rows collection.
 @param index Number that specifies where to insert the row in the rows collection. The default value is -1, which appends the new row to the end of the rows collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/insertRow)
 */
-@send
+@throws(JsExn) @send
 external insertRow: (t, ~index: int=?) => HTMLTableRowElement.t = "insertRow"
 
 /**
@@ -96,5 +96,5 @@ Removes the specified row (tr) from the element and from the rows collection.
 @param index Number that specifies the zero-based position in the rows collection of the row to remove.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableElement/deleteRow)
 */
-@send
+@throws(JsExn) @send
 external deleteRow: (t, int) => unit = "deleteRow"

--- a/src/html/HTMLTableRowElement.res
+++ b/src/html/HTMLTableRowElement.res
@@ -28,7 +28,7 @@ Creates a new cell in the table row, and adds the cell to the cells collection.
 @param index Number that specifies where to insert the cell in the tr. The default value is -1, which appends the new cell to the end of the cells collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableRowElement/insertCell)
 */
-@send
+@throws(JsExn) @send
 external insertCell: (t, ~index: int=?) => HTMLTableCellElement.t = "insertCell"
 
 /**
@@ -36,5 +36,5 @@ Removes the specified cell from the table row, as well as from the cells collect
 @param index Number that specifies the zero-based position of the cell to remove from the table row. If no value is provided, the last cell in the cells collection is deleted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableRowElement/deleteCell)
 */
-@send
+@throws(JsExn) @send
 external deleteCell: (t, int) => unit = "deleteCell"

--- a/src/html/HTMLTableSectionElement.res
+++ b/src/html/HTMLTableSectionElement.res
@@ -18,7 +18,7 @@ Creates a new row (tr) in the table, and adds the row to the rows collection.
 @param index Number that specifies where to insert the row in the rows collection. The default value is -1, which appends the new row to the end of the rows collection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableSectionElement/insertRow)
 */
-@send
+@throws(JsExn) @send
 external insertRow: (t, ~index: int=?) => HTMLTableRowElement.t = "insertRow"
 
 /**
@@ -26,5 +26,5 @@ Removes the specified row (tr) from the element and from the rows collection.
 @param index Number that specifies the zero-based position in the rows collection of the row to remove.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLTableSectionElement/deleteRow)
 */
-@send
+@throws(JsExn) @send
 external deleteRow: (t, int) => unit = "deleteRow"

--- a/src/media/BaseEncryptedMediaExtensions.res
+++ b/src/media/BaseEncryptedMediaExtensions.res
@@ -82,7 +82,7 @@ type mediaKeySession = private {
 
 type mediaKeySystemMediaCapability = {
   mutable contentType?: string,
-  mutable encryptionScheme?: Null.t<string>,
+  mutable encryptionScheme?: Nullable.t<string>,
   mutable robustness?: string,
 }
 

--- a/src/media/DomHTMLMediaElement.res
+++ b/src/media/DomHTMLMediaElement.res
@@ -72,11 +72,13 @@ type t = {
     Gets or sets the default playback rate when the user is not using fast forward or reverse for a video or audio resource.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/defaultPlaybackRate)
     */
+  @throws(JsExn)
   mutable defaultPlaybackRate: float,
   /**
     Gets or sets the current rate of speed for the media resource to play. This speed is expressed as a multiple of the normal speed of the media resource.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/playbackRate)
     */
+  @throws(JsExn)
   mutable playbackRate: float,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preservesPitch)
@@ -111,6 +113,7 @@ type t = {
     Gets or sets the volume level for audio portions of the media element.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/volume)
     */
+  @throws(JsExn)
   mutable volume: float,
   /**
     Gets or sets a flag that indicates whether the audio (either audio or the audio track on video media) is muted.

--- a/src/media/MediaCapabilitiesTypes.res
+++ b/src/media/MediaCapabilitiesTypes.res
@@ -68,7 +68,8 @@ type mediaCapabilitiesInfo = {
 
 type mediaCapabilitiesDecodingInfo = {
   ...mediaCapabilitiesInfo,
-  mutable configuration?: mediaDecodingConfiguration,
+  mutable keySystemAccess: Null.t<BaseEncryptedMediaExtensions.mediaKeySystemAccess>,
+  mutable configuration: mediaDecodingConfiguration,
 }
 
 type mediaEncodingConfiguration = {
@@ -78,5 +79,5 @@ type mediaEncodingConfiguration = {
 
 type mediaCapabilitiesEncodingInfo = {
   ...mediaCapabilitiesInfo,
-  mutable configuration?: mediaEncodingConfiguration,
+  mutable configuration: mediaEncodingConfiguration,
 }

--- a/src/media/MediaSession.res
+++ b/src/media/MediaSession.res
@@ -18,7 +18,7 @@ external setActionHandler: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaSession/setPositionState)
 */
-@send
+@throws(JsExn) @send
 external setPositionState: (t, ~state: mediaPositionState=?) => unit = "setPositionState"
 
 module MediaMetadata = MediaMetadata

--- a/src/media/MediaStream.res
+++ b/src/media/MediaStream.res
@@ -68,7 +68,7 @@ external getTracks: t => array<MediaStreamTrack.t> = "getTracks"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/getTrackById)
 */
 @send
-external getTrackById: (t, string) => MediaStreamTrack.t = "getTrackById"
+external getTrackById: (t, string) => Null.t<MediaStreamTrack.t> = "getTrackById"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStream/addTrack)

--- a/src/media/TextTrack.res
+++ b/src/media/TextTrack.res
@@ -4,12 +4,12 @@ include EventTarget.Impl({type t = WebVttTypes.textTrack})
 Adds the given cue to textTrack's text track list of cues.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TextTrack/addCue)
 */
-@send
+@throws(JsExn) @send
 external addCue: (WebVttTypes.textTrack, WebVttTypes.textTrackCue) => unit = "addCue"
 
 /**
 Removes the given cue from textTrack's text track list of cues.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TextTrack/removeCue)
 */
-@send
+@throws(JsExn) @send
 external removeCue: (WebVttTypes.textTrack, WebVttTypes.textTrackCue) => unit = "removeCue"

--- a/src/media/TextTrackCueList.res
+++ b/src/media/TextTrackCueList.res
@@ -5,5 +5,5 @@ Returns null if none of the cues have the given identifier or if the argument is
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TextTrackCueList/getCueById)
 */
 @send
-external getCueById: (WebVttTypes.textTrackCueList, string) => WebVttTypes.textTrackCue =
+external getCueById: (WebVttTypes.textTrackCueList, string) => Null.t<WebVttTypes.textTrackCue> =
   "getCueById"

--- a/src/media/TextTrackList.res
+++ b/src/media/TextTrackList.res
@@ -14,4 +14,4 @@ include EventTarget.Impl({type t = t})
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TextTrackList/getTrackById)
 */
 @send
-external getTrackById: (t, string) => WebVttTypes.textTrack = "getTrackById"
+external getTrackById: (t, string) => Null.t<WebVttTypes.textTrack> = "getTrackById"

--- a/src/media/TimeRanges.res
+++ b/src/media/TimeRanges.res
@@ -16,7 +16,7 @@ Returns the time for the start of the range with the given index.
 Throws an "IndexSizeError" DOMException if the index is out of range.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TimeRanges/start)
 */
-@send
+@throws(JsExn) @send
 external start: (t, int) => float = "start"
 
 /**
@@ -25,5 +25,5 @@ Returns the time for the end of the range with the given index.
 Throws an "IndexSizeError" DOMException if the index is out of range.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TimeRanges/end)
 */
-@send
+@throws(JsExn) @send
 external end: (t, int) => float = "end"

--- a/src/messaging/MessagePort.res
+++ b/src/messaging/MessagePort.res
@@ -9,7 +9,7 @@ Posts a message through the channel. Objects listed in transfer are transferred,
 Throws a "DataCloneError" DOMException if transfer contains duplicate objects or port, or if message could not be cloned.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessagePort/postMessage)
 */
-@send
+@throws(JsExn) @send
 external postMessage: (t, ~message: JSON.t, ~transfer: array<Dict.t<string>>) => unit =
   "postMessage"
 
@@ -19,7 +19,7 @@ Posts a message through the channel. Objects listed in transfer are transferred,
 Throws a "DataCloneError" DOMException if transfer contains duplicate objects or port, or if message could not be cloned.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MessagePort/postMessage)
 */
-@send
+@throws(JsExn) @send
 external postMessage2: (t, ~message: JSON.t, ~options: structuredSerializeOptions=?) => unit =
   "postMessage"
 

--- a/src/messaging/Notification.res
+++ b/src/messaging/Notification.res
@@ -18,7 +18,7 @@ type notificationEvent = NotificationTypes.notificationEvent = {
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Notification)
 */
-@new
+@throws(JsExn) @new
 external make: (~title: string, ~options: notificationOptions=?) => t = "Notification"
 
 include EventTarget.Impl({type t = t})

--- a/src/messaging/NotificationTypes.res
+++ b/src/messaging/NotificationTypes.res
@@ -80,7 +80,7 @@ type notificationOptions = {
   mutable tag?: string,
   mutable icon?: string,
   mutable badge?: string,
-  mutable silent?: Null.t<bool>,
+  mutable silent?: Nullable.t<bool>,
   mutable requireInteraction?: bool,
   mutable data?: JSON.t,
   mutable actions?: array<notificationAction>,

--- a/src/messaging/PushManager.res
+++ b/src/messaging/PushManager.res
@@ -11,7 +11,7 @@ external subscribe: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushManager/getSubscription)
 */
 @send
-external getSubscription: PushTypes.pushManager => promise<PushTypes.pushSubscription> =
+external getSubscription: PushTypes.pushManager => promise<Null.t<PushTypes.pushSubscription>> =
   "getSubscription"
 
 /**

--- a/src/messaging/PushSubscription.res
+++ b/src/messaging/PushSubscription.res
@@ -2,8 +2,10 @@
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushSubscription/getKey)
 */
 @send
-external getKey: (PushTypes.pushSubscription, PushTypes.pushEncryptionKeyName) => ArrayBuffer.t =
-  "getKey"
+external getKey: (
+  PushTypes.pushSubscription,
+  PushTypes.pushEncryptionKeyName,
+) => Null.t<ArrayBuffer.t> = "getKey"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushSubscription/unsubscribe)

--- a/src/messaging/PushTypes.res
+++ b/src/messaging/PushTypes.res
@@ -34,7 +34,7 @@ type pushSubscriptionOptions = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushSubscriptionOptions/applicationServerKey)
     */
-  applicationServerKey: applicationServerKey,
+  applicationServerKey: Null.t<applicationServerKey>,
 }
 
 /**
@@ -59,7 +59,7 @@ type pushSubscription = private {
 
 type pushSubscriptionOptionsInit = {
   mutable userVisibleOnly?: bool,
-  mutable applicationServerKey?: applicationServerKey,
+  mutable applicationServerKey?: Null.t<applicationServerKey>,
 }
 
 type pushSubscriptionJSONKeys = {
@@ -84,5 +84,5 @@ type pushEvent = private {
   /**
    [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PushEvent/data)
    */
-  data?: pushMessageData,
+  data: Null.t<pushMessageData>,
 }

--- a/src/messaging/PushTypes.res
+++ b/src/messaging/PushTypes.res
@@ -59,7 +59,7 @@ type pushSubscription = private {
 
 type pushSubscriptionOptionsInit = {
   mutable userVisibleOnly?: bool,
-  mutable applicationServerKey?: Null.t<applicationServerKey>,
+  mutable applicationServerKey?: Nullable.t<applicationServerKey>,
 }
 
 type pushSubscriptionJSONKeys = {
@@ -71,7 +71,7 @@ type pushSubscriptionJSONKeys = {
 
 type pushSubscriptionJSON = {
   mutable endpoint?: string,
-  mutable expirationTime?: Null.t<int>,
+  mutable expirationTime?: Nullable.t<int>,
   mutable keys?: pushSubscriptionJSONKeys,
 }
 

--- a/src/messaging/WebSocket.res
+++ b/src/messaging/WebSocket.res
@@ -15,7 +15,7 @@ let socket = WebSocket.fromURL(~url="wss://example.com/socket")
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket)
 */
-@new
+@throws(JsExn) @new
 external fromURL: (~url: string, ~protocols: string=?) => t = "WebSocket"
 
 /**
@@ -33,7 +33,7 @@ let socket =
 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket)
 */
-@new
+@throws(JsExn) @new
 external fromURLWithProtocols: (~url: string, ~protocols: array<string>) => t = "WebSocket"
 
 include EventTarget.Impl({type t = t})
@@ -42,30 +42,33 @@ include EventTarget.Impl({type t = t})
 Closes the WebSocket connection, optionally using code as the the WebSocket connection close code and reason as the the WebSocket connection close reason.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/close)
 */
-@send
+@throws(JsExn) @send
 external close: (t, ~code: int=?, ~reason: string=?) => unit = "close"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
-@send
+@throws(JsExn) @send
 external send: (t, DataView.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
+@throws(JsExn)
 external sendArrayBuffer: (t, ArrayBuffer.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
+@throws(JsExn)
 external sendBlob: (t, Blob.t) => unit = "send"
 
 /**
 Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
 */
+@throws(JsExn)
 external sendString: (t, string) => unit = "send"

--- a/src/messaging/WebSocketsTypes.res
+++ b/src/messaging/WebSocketsTypes.res
@@ -119,6 +119,6 @@ type messageEventInit<'t> = {
   mutable data?: 't,
   mutable origin?: string,
   mutable lastEventId?: string,
-  mutable source?: Null.t<messageEventSource>,
+  mutable source?: Nullable.t<messageEventSource>,
   mutable ports?: array<ChannelMessagingTypes.messagePort>,
 }

--- a/src/navigator/CredentialsContainer.res
+++ b/src/navigator/CredentialsContainer.res
@@ -5,7 +5,7 @@
 external get: (
   CredentialManagementTypes.credentialsContainer,
   ~options: CredentialManagementTypes.credentialRequestOptions=?,
-) => promise<CredentialManagementTypes.credential> = "get"
+) => promise<Null.t<CredentialManagementTypes.credential>> = "get"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/store)
@@ -23,7 +23,7 @@ external store: (
 external create: (
   CredentialManagementTypes.credentialsContainer,
   ~options: CredentialManagementTypes.credentialCreationOptions=?,
-) => promise<CredentialManagementTypes.credential> = "create"
+) => promise<Null.t<CredentialManagementTypes.credential>> = "create"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/preventSilentAccess)

--- a/src/navigator/Navigator.res
+++ b/src/navigator/Navigator.res
@@ -143,8 +143,8 @@ external sendBeacon7: (t, ~url: string, ~data: string=?) => bool = "sendBeacon"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/getGamepads)
 */
-@send
-external getGamepads: t => array<GamepadTypes.gamepad> = "getGamepads"
+@throws(JsExn) @send
+external getGamepads: t => array<Null.t<GamepadTypes.gamepad>> = "getGamepads"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Navigator/requestMediaKeySystemAccess)

--- a/src/observers/IntersectionObserver.res
+++ b/src/observers/IntersectionObserver.res
@@ -1,7 +1,7 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IntersectionObserver)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~callback: IntersectionObserverTypes.intersectionObserverCallback,
   ~options: IntersectionObserverTypes.intersectionObserverInit=?,

--- a/src/observers/IntersectionObserverTypes.res
+++ b/src/observers/IntersectionObserverTypes.res
@@ -12,7 +12,7 @@ type intersectionObserver = private {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/root)
     */
-  root: root,
+  root: Null.t<root>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/rootMargin)
     */
@@ -59,7 +59,7 @@ type intersectionObserverEntry = {
 }
 
 type intersectionObserverInit = {
-  mutable root?: root,
+  mutable root?: Null.t<root>,
   mutable rootMargin?: string,
   mutable threshold?: array<float>,
 }

--- a/src/observers/IntersectionObserverTypes.res
+++ b/src/observers/IntersectionObserverTypes.res
@@ -59,7 +59,7 @@ type intersectionObserverEntry = {
 }
 
 type intersectionObserverInit = {
-  mutable root?: Null.t<root>,
+  mutable root?: Nullable.t<root>,
   mutable rootMargin?: string,
   mutable threshold?: array<float>,
 }

--- a/src/observers/MutationObserver.res
+++ b/src/observers/MutationObserver.res
@@ -78,7 +78,7 @@ external make: mutationObserverCallback => t = "MutationObserver"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MutationObserver/observe)
 */
-@send
+@throws(JsExn) @send
 external observe: (t, ~target: DOMTree.node, ~options: mutationObserverInit=?) => unit = "observe"
 
 /**

--- a/src/performance/Performance.res
+++ b/src/performance/Performance.res
@@ -54,7 +54,7 @@ external setResourceTimingBufferSize: (PerformanceTypes.performance, int) => uni
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/mark)
 */
-@send
+@throws(JsExn) @send
 external mark: (
   PerformanceTypes.performance,
   ~markName: string,
@@ -70,7 +70,7 @@ external clearMarks: (PerformanceTypes.performance, ~markName: string=?) => unit
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/measure)
 */
-@send
+@throws(JsExn) @send
 external measure: (
   PerformanceTypes.performance,
   ~measureName: string,
@@ -81,7 +81,7 @@ external measure: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Performance/measure)
 */
-@send
+@throws(JsExn) @send
 external measure2: (
   PerformanceTypes.performance,
   ~measureName: string,

--- a/src/performance/PerformanceMark.res
+++ b/src/performance/PerformanceMark.res
@@ -1,7 +1,7 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PerformanceMark)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~markName: string,
   ~markOptions: PerformanceTypes.performanceMarkOptions=?,

--- a/src/storage/Cache.res
+++ b/src/storage/Cache.res
@@ -6,7 +6,7 @@ external match: (
   CacheTypes.cache,
   ~request: FetchTypes.request,
   ~options: CacheTypes.cacheQueryOptions=?,
-) => Nullable.t<FetchTypes.response> = "match"
+) => promise<option<FetchTypes.response>> = "match"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/match)
@@ -16,7 +16,7 @@ external match2: (
   CacheTypes.cache,
   ~request: string,
   ~options: CacheTypes.cacheQueryOptions=?,
-) => Nullable.t<FetchTypes.response> = "match"
+) => promise<option<FetchTypes.response>> = "match"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Cache/matchAll)

--- a/src/storage/CacheStorage.res
+++ b/src/storage/CacheStorage.res
@@ -6,7 +6,7 @@ external match: (
   CacheTypes.cacheStorage,
   ~request: FetchTypes.request,
   ~options: CacheTypes.multiCacheQueryOptions=?,
-) => Nullable.t<FetchTypes.response> = "match"
+) => promise<option<FetchTypes.response>> = "match"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CacheStorage/match)
@@ -16,7 +16,7 @@ external match2: (
   CacheTypes.cacheStorage,
   ~request: string,
   ~options: CacheTypes.multiCacheQueryOptions=?,
-) => Nullable.t<FetchTypes.response> = "match"
+) => promise<option<FetchTypes.response>> = "match"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CacheStorage/has)

--- a/src/storage/IDBDatabase.res
+++ b/src/storage/IDBDatabase.res
@@ -4,7 +4,7 @@ include EventTarget.Impl({type t = IndexedDbTypes.idbDatabase})
 Returns a new transaction with the given mode ("readonly" or "readwrite") and scope which can be a single object store name or an array of names.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBDatabase/transaction)
 */
-@send
+@throws(JsExn) @send
 external transaction: (
   IndexedDbTypes.idbDatabase,
   ~storeNames: string,
@@ -16,7 +16,7 @@ external transaction: (
 Returns a new transaction with the given mode ("readonly" or "readwrite") and scope which can be a single object store name or an array of names.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBDatabase/transaction)
 */
-@send
+@throws(JsExn) @send
 external transaction2: (
   IndexedDbTypes.idbDatabase,
   ~storeNames: array<string>,
@@ -37,7 +37,7 @@ Creates a new object store with the given name and options and returns a new IDB
 Throws a "InvalidStateError" DOMException if not called within an upgrade transaction.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBDatabase/createObjectStore)
 */
-@send
+@throws(JsExn) @send
 external createObjectStore: (
   IndexedDbTypes.idbDatabase,
   ~name: string,
@@ -50,5 +50,5 @@ Deletes the object store with the given name.
 Throws a "InvalidStateError" DOMException if not called within an upgrade transaction.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBDatabase/deleteObjectStore)
 */
-@send
+@throws(JsExn) @send
 external deleteObjectStore: (IndexedDbTypes.idbDatabase, string) => unit = "deleteObjectStore"

--- a/src/storage/IDBFactory.res
+++ b/src/storage/IDBFactory.res
@@ -2,7 +2,7 @@
 Attempts to open a connection to the named database with the current version, or 1 if it does not already exist. If the request is successful request's result will be the connection.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBFactory/open)
 */
-@send
+@throws(JsExn) @send
 external open_: (
   IndexedDbTypes.idbFactory,
   ~name: string,
@@ -30,5 +30,5 @@ Compares two values as keys. Returns -1 if key1 precedes key2, 1 if key2 precede
 Throws a "DataError" DOMException if either input is not a valid key.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBFactory/cmp)
 */
-@send
+@throws(JsExn) @send
 external cmp: (IndexedDbTypes.idbFactory, ~first: JSON.t, ~second: JSON.t) => int = "cmp"

--- a/src/storage/IDBIndex.res
+++ b/src/storage/IDBIndex.res
@@ -4,8 +4,9 @@ Retrieves the value of the first record matching the given key or key range in q
 If successful, request's result will be the value, or undefined if there was no matching record.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/get)
 */
-@send
-external get: (IndexedDbTypes.idbIndex, unknown) => IndexedDbTypes.idbRequest<JSON.t> = "get"
+@throws(JsExn) @send
+external get: (IndexedDbTypes.idbIndex, unknown) => IndexedDbTypes.idbRequest<option<JSON.t>> =
+  "get"
 
 /**
 Retrieves the key of the first record matching the given key or key range in query.
@@ -13,8 +14,11 @@ Retrieves the key of the first record matching the given key or key range in que
 If successful, request's result will be the key, or undefined if there was no matching record.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/getKey)
 */
-@send
-external getKey: (IndexedDbTypes.idbIndex, unknown) => IndexedDbTypes.idbRequest<unknown> = "getKey"
+@throws(JsExn) @send
+external getKey: (
+  IndexedDbTypes.idbIndex,
+  unknown,
+) => IndexedDbTypes.idbRequest<option<IndexedDbTypes.idbValidKey>> = "getKey"
 
 /**
 Retrieves the values of the records matching the given key or key range in query (up to count if given).
@@ -22,7 +26,7 @@ Retrieves the values of the records matching the given key or key range in query
 If successful, request's result will be an Array of the values.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/getAll)
 */
-@send
+@throws(JsExn) @send
 external getAll: (
   IndexedDbTypes.idbIndex,
   ~query: unknown=?,
@@ -35,7 +39,7 @@ Retrieves the keys of records matching the given key or key range in query (up t
 If successful, request's result will be an Array of the keys.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/getAllKeys)
 */
-@send
+@throws(JsExn) @send
 external getAllKeys: (
   IndexedDbTypes.idbIndex,
   ~query: unknown=?,
@@ -48,7 +52,7 @@ Retrieves the number of records matching the given key or key range in query.
 If successful, request's result will be the count.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/count)
 */
-@send
+@throws(JsExn) @send
 external count: (IndexedDbTypes.idbIndex, ~query: unknown=?) => IndexedDbTypes.idbRequest<int> =
   "count"
 
@@ -58,12 +62,12 @@ Opens a cursor over the records matching query, ordered by direction. If query i
 If successful, request's result will be an IDBCursorWithValue, or null if there were no matching records.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/openCursor)
 */
-@send
+@throws(JsExn) @send
 external openCursor: (
   IndexedDbTypes.idbIndex,
   ~query: unknown=?,
   ~direction: IndexedDbTypes.idbCursorDirection=?,
-) => IndexedDbTypes.idbRequest<unknown> = "openCursor"
+) => IndexedDbTypes.idbRequest<Null.t<unknown>> = "openCursor"
 
 /**
 Opens a cursor with key only flag set over the records matching query, ordered by direction. If query is null, all records in index are matched.
@@ -71,9 +75,9 @@ Opens a cursor with key only flag set over the records matching query, ordered b
 If successful, request's result will be an IDBCursor, or null if there were no matching records.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/openKeyCursor)
 */
-@send
+@throws(JsExn) @send
 external openKeyCursor: (
   IndexedDbTypes.idbIndex,
   ~query: unknown=?,
   ~direction: IndexedDbTypes.idbCursorDirection=?,
-) => IndexedDbTypes.idbRequest<unknown> = "openKeyCursor"
+) => IndexedDbTypes.idbRequest<Null.t<unknown>> = "openKeyCursor"

--- a/src/storage/IDBObjectStore.res
+++ b/src/storage/IDBObjectStore.res
@@ -8,7 +8,7 @@ If put() is used, any existing record with the key will be replaced. If add() is
 If successful, request's result will be the record's key.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/put)
 */
-@send
+@throws(JsExn) @send
 external put: (
   IndexedDbTypes.idbObjectStore,
   ~value: JSON.t,
@@ -25,7 +25,7 @@ If put() is used, any existing record with the key will be replaced. If add() is
 If successful, request's result will be the record's key.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/add)
 */
-@send
+@throws(JsExn) @send
 external add: (
   IndexedDbTypes.idbObjectStore,
   ~value: JSON.t,
@@ -38,7 +38,7 @@ Deletes records in store with the given key or in the given key range in query.
 If successful, request's result will be undefined.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/delete)
 */
-@send
+@throws(JsExn) @send
 external delete: (IndexedDbTypes.idbObjectStore, unknown) => IndexedDbTypes.idbRequest<unit> =
   "delete"
 
@@ -48,7 +48,7 @@ Deletes all records in store.
 If successful, request's result will be undefined.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/clear)
 */
-@send
+@throws(JsExn) @send
 external clear: IndexedDbTypes.idbObjectStore => IndexedDbTypes.idbRequest<unit> = "clear"
 
 /**
@@ -57,8 +57,11 @@ Retrieves the value of the first record matching the given key or key range in q
 If successful, request's result will be the value, or undefined if there was no matching record.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/get)
 */
-@send
-external get: (IndexedDbTypes.idbObjectStore, unknown) => IndexedDbTypes.idbRequest<JSON.t> = "get"
+@throws(JsExn) @send
+external get: (
+  IndexedDbTypes.idbObjectStore,
+  unknown,
+) => IndexedDbTypes.idbRequest<option<JSON.t>> = "get"
 
 /**
 Retrieves the key of the first record matching the given key or key range in query.
@@ -66,9 +69,11 @@ Retrieves the key of the first record matching the given key or key range in que
 If successful, request's result will be the key, or undefined if there was no matching record.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/getKey)
 */
-@send
-external getKey: (IndexedDbTypes.idbObjectStore, unknown) => IndexedDbTypes.idbRequest<unknown> =
-  "getKey"
+@throws(JsExn) @send
+external getKey: (
+  IndexedDbTypes.idbObjectStore,
+  unknown,
+) => IndexedDbTypes.idbRequest<option<IndexedDbTypes.idbValidKey>> = "getKey"
 
 /**
 Retrieves the values of the records matching the given key or key range in query (up to count if given).
@@ -76,7 +81,7 @@ Retrieves the values of the records matching the given key or key range in query
 If successful, request's result will be an Array of the values.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/getAll)
 */
-@send
+@throws(JsExn) @send
 external getAll: (
   IndexedDbTypes.idbObjectStore,
   ~query: unknown=?,
@@ -89,7 +94,7 @@ Retrieves the keys of records matching the given key or key range in query (up t
 If successful, request's result will be an Array of the keys.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/getAllKeys)
 */
-@send
+@throws(JsExn) @send
 external getAllKeys: (
   IndexedDbTypes.idbObjectStore,
   ~query: unknown=?,
@@ -102,7 +107,7 @@ Retrieves the number of records matching the given key or key range in query.
 If successful, request's result will be the count.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/count)
 */
-@send
+@throws(JsExn) @send
 external count: (
   IndexedDbTypes.idbObjectStore,
   ~query: unknown=?,
@@ -114,12 +119,12 @@ Opens a cursor over the records matching query, ordered by direction. If query i
 If successful, request's result will be an IDBCursorWithValue pointing at the first matching record, or null if there were no matching records.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/openCursor)
 */
-@send
+@throws(JsExn) @send
 external openCursor: (
   IndexedDbTypes.idbObjectStore,
   ~query: unknown=?,
   ~direction: IndexedDbTypes.idbCursorDirection=?,
-) => IndexedDbTypes.idbRequest<unknown> = "openCursor"
+) => IndexedDbTypes.idbRequest<Null.t<unknown>> = "openCursor"
 
 /**
 Opens a cursor with key only flag set over the records matching query, ordered by direction. If query is null, all records in store are matched.
@@ -127,17 +132,17 @@ Opens a cursor with key only flag set over the records matching query, ordered b
 If successful, request's result will be an IDBCursor pointing at the first matching record, or null if there were no matching records.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/openKeyCursor)
 */
-@send
+@throws(JsExn) @send
 external openKeyCursor: (
   IndexedDbTypes.idbObjectStore,
   ~query: unknown=?,
   ~direction: IndexedDbTypes.idbCursorDirection=?,
-) => IndexedDbTypes.idbRequest<unknown> = "openKeyCursor"
+) => IndexedDbTypes.idbRequest<Null.t<unknown>> = "openKeyCursor"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/index)
 */
-@send
+@throws(JsExn) @send
 external index: (IndexedDbTypes.idbObjectStore, string) => IndexedDbTypes.idbIndex = "index"
 
 /**
@@ -146,7 +151,7 @@ Creates a new index in store with the given name, keyPath and options and return
 Throws an "InvalidStateError" DOMException if not called within an upgrade transaction.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/createIndex)
 */
-@send
+@throws(JsExn) @send
 external createIndex: (
   IndexedDbTypes.idbObjectStore,
   ~name: string,
@@ -160,7 +165,7 @@ Creates a new index in store with the given name, keyPath and options and return
 Throws an "InvalidStateError" DOMException if not called within an upgrade transaction.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/createIndex)
 */
-@send
+@throws(JsExn) @send
 external createIndex2: (
   IndexedDbTypes.idbObjectStore,
   ~name: string,
@@ -174,5 +179,5 @@ Deletes the index in store with the given name.
 Throws an "InvalidStateError" DOMException if not called within an upgrade transaction.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/deleteIndex)
 */
-@send
+@throws(JsExn) @send
 external deleteIndex: (IndexedDbTypes.idbObjectStore, string) => unit = "deleteIndex"

--- a/src/storage/IDBTransaction.res
+++ b/src/storage/IDBTransaction.res
@@ -4,19 +4,19 @@ include EventTarget.Impl({type t = IndexedDbTypes.idbTransaction})
 Returns an IDBObjectStore in the transaction's scope.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBTransaction/objectStore)
 */
-@send
+@throws(JsExn) @send
 external objectStore: (IndexedDbTypes.idbTransaction, string) => IndexedDbTypes.idbObjectStore =
   "objectStore"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBTransaction/commit)
 */
-@send
+@throws(JsExn) @send
 external commit: IndexedDbTypes.idbTransaction => unit = "commit"
 
 /**
 Aborts the transaction. All pending requests will fail with a "AbortError" DOMException and all changes made to the database will be reverted.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBTransaction/abort)
 */
-@send
+@throws(JsExn) @send
 external abort: IndexedDbTypes.idbTransaction => unit = "abort"

--- a/src/storage/IndexedDbTypes.res
+++ b/src/storage/IndexedDbTypes.res
@@ -203,7 +203,7 @@ type idbDatabaseInfo = {
 type idbTransactionOptions = {mutable durability?: idbTransactionDurability}
 
 type idbObjectStoreParameters = {
-  mutable keyPath?: Null.t<unknown>,
+  mutable keyPath?: Nullable.t<unknown>,
   mutable autoIncrement?: bool,
 }
 

--- a/src/storage/IndexedDbTypes.res
+++ b/src/storage/IndexedDbTypes.res
@@ -93,17 +93,19 @@ type idbRequest<'t> = {
     When a request is completed, returns the result, or undefined if the request failed. Throws a "InvalidStateError" DOMException if the request is still pending.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBRequest/result)
     */
+  @throws(JsExn)
   result: 't,
   /**
     When a request is completed, returns the error (a DOMException), or null if the request succeeded. Throws a "InvalidStateError" DOMException if the request is still pending.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBRequest/error)
     */
+  @throws(JsExn)
   error: Null.t<DOM.domException>,
   /**
     Returns the IDBObjectStore, IDBIndex, or IDBCursor the request was made against, or null if is was an open request.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBRequest/source)
     */
-  source: unknown,
+  source: Null.t<unknown>,
   /**
     Returns the IDBTransaction the request was made within. If this as an open request, then it returns an upgrade transaction while it is running, or null otherwise.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBRequest/transaction)
@@ -135,12 +137,13 @@ type idbObjectStore = {
     Returns the name of the store.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/name)
     */
+  @throws(JsExn)
   mutable name: string,
   /**
     Returns the key path of the store, or null if none.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
     */
-  keyPath: string,
+  keyPath: Null.t<unknown>,
   /**
     Returns a list of the names of indexes in the store.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/indexNames)
@@ -169,6 +172,7 @@ type idbIndex = {
     Returns the name of the index.
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/name)
     */
+  @throws(JsExn)
   mutable name: string,
   /**
     Returns the IDBObjectStore the index belongs to.
@@ -178,7 +182,7 @@ type idbIndex = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/keyPath)
     */
-  keyPath: string,
+  keyPath: Null.t<unknown>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IDBIndex/multiEntry)
     */

--- a/src/storage/Storage.res
+++ b/src/storage/Storage.res
@@ -20,7 +20,7 @@ Throws a "QuotaExceededError" DOMException exception if the new value couldn't b
 Dispatches a storage event on Window objects holding an equivalent WebApiStorage object.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
 */
-@send
+@throws(JsExn) @send
 external setItem: (WebStorageTypes.storage, ~key: string, ~value: string) => unit = "setItem"
 
 /**

--- a/src/storage/WebStorageTypes.res
+++ b/src/storage/WebStorageTypes.res
@@ -49,9 +49,9 @@ type storageEvent = private {
 
 type storageEventInit = {
   ...Event.eventInit,
-  mutable key?: Null.t<string>,
-  mutable oldValue?: Null.t<string>,
-  mutable newValue?: Null.t<string>,
+  mutable key?: Nullable.t<string>,
+  mutable oldValue?: Nullable.t<string>,
+  mutable newValue?: Nullable.t<string>,
   mutable url?: string,
-  mutable storageArea?: Null.t<storage>,
+  mutable storageArea?: Nullable.t<storage>,
 }

--- a/src/svg/SVGGraphicsElement.res
+++ b/src/svg/SVGGraphicsElement.res
@@ -10,7 +10,7 @@ external getBBox: (
 ) => DOM.domRect = "getBBox"
 
 @send
-external getCTM: SVGElement.svgGraphicsElement => DOM.domMatrix = "getCTM"
+external getCTM: SVGElement.svgGraphicsElement => Null.t<DOM.domMatrix> = "getCTM"
 
 @send
-external getScreenCTM: SVGElement.svgGraphicsElement => DOM.domMatrix = "getScreenCTM"
+external getScreenCTM: SVGElement.svgGraphicsElement => Null.t<DOM.domMatrix> = "getScreenCTM"

--- a/src/svg/SVGLength.res
+++ b/src/svg/SVGLength.res
@@ -1,9 +1,9 @@
-@send
+@throws(JsExn) @send
 external newValueSpecifiedUnits: (
   SVGElement.svgLength,
   ~unitType: int,
   ~valueInSpecifiedUnits: float,
 ) => unit = "newValueSpecifiedUnits"
 
-@send
+@throws(JsExn) @send
 external convertToSpecifiedUnits: (SVGElement.svgLength, int) => unit = "convertToSpecifiedUnits"

--- a/src/ui-events/DataTransferItem.res
+++ b/src/ui-events/DataTransferItem.res
@@ -10,11 +10,12 @@ Returns a WebApiFile object, if the drag data item kind is File.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransferItem/getAsFile)
 */
 @send
-external getAsFile: UiEventsTypes.dataTransferItem => FileTypes.file = "getAsFile"
+external getAsFile: UiEventsTypes.dataTransferItem => Null.t<FileTypes.file> = "getAsFile"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry)
 */
 @send
-external webkitGetAsEntry: UiEventsTypes.dataTransferItem => FileAndDirectoryEntriesTypes.fileSystemEntry =
-  "webkitGetAsEntry"
+external webkitGetAsEntry: UiEventsTypes.dataTransferItem => Null.t<
+  FileAndDirectoryEntriesTypes.fileSystemEntry,
+> = "webkitGetAsEntry"

--- a/src/ui-events/DataTransferItemList.res
+++ b/src/ui-events/DataTransferItemList.res
@@ -2,28 +2,28 @@
 Adds a new entry for the given data to the drag data store. If the data is plain text then a type string has to be provided also.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransferItemList/add)
 */
-@send
+@throws(JsExn) @send
 external add: (
   UiEventsTypes.dataTransferItemList,
   ~data: string,
   ~type_: string,
-) => UiEventsTypes.dataTransferItem = "add"
+) => Null.t<UiEventsTypes.dataTransferItem> = "add"
 
 /**
 Adds a new entry for the given data to the drag data store. If the data is plain text then a type string has to be provided also.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransferItemList/add)
 */
-@send
+@throws(JsExn) @send
 external addFile: (
   UiEventsTypes.dataTransferItemList,
   FileTypes.file,
-) => UiEventsTypes.dataTransferItem = "add"
+) => Null.t<UiEventsTypes.dataTransferItem> = "add"
 
 /**
 Removes the indexth entry in the drag data store.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DataTransferItemList/remove)
 */
-@send
+@throws(JsExn) @send
 external remove: (UiEventsTypes.dataTransferItemList, int) => unit = "remove"
 
 /**

--- a/src/ui-events/TouchList.res
+++ b/src/ui-events/TouchList.res
@@ -2,4 +2,4 @@
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/TouchList/item)
 */
 @send
-external item: (UiEventsTypes.touchList, int) => UiEventsTypes.touch = "item"
+external item: (UiEventsTypes.touchList, int) => Null.t<UiEventsTypes.touch> = "item"

--- a/src/ui-events/UiEventsTypes.res
+++ b/src/ui-events/UiEventsTypes.res
@@ -472,7 +472,7 @@ type pointerEvent = private {
 
 type uiEventInit = {
   ...Event.eventInit,
-  mutable view?: Null.t<DOM.window>,
+  mutable view?: Nullable.t<DOM.window>,
   mutable detail?: int,
   mutable which?: int,
 }
@@ -503,14 +503,14 @@ type mouseEventInit = {
   mutable clientY?: int,
   mutable button?: int,
   mutable buttons?: int,
-  mutable relatedTarget?: Null.t<DOM.eventTarget>,
+  mutable relatedTarget?: Nullable.t<DOM.eventTarget>,
   mutable movementX?: float,
   mutable movementY?: float,
 }
 
 type focusEventInit = {
   ...uiEventInit,
-  mutable relatedTarget?: Null.t<DOM.eventTarget>,
+  mutable relatedTarget?: Nullable.t<DOM.eventTarget>,
 }
 
 type compositionEventInit = {
@@ -539,10 +539,10 @@ type keyboardEventInit = {
 
 type inputEventInit = {
   ...uiEventInit,
-  mutable data?: Null.t<string>,
+  mutable data?: Nullable.t<string>,
   mutable isComposing?: bool,
   mutable inputType?: string,
-  mutable dataTransfer?: Null.t<dataTransfer>,
+  mutable dataTransfer?: Nullable.t<dataTransfer>,
   mutable targetRanges?: array<StaticRange.t>,
 }
 

--- a/src/url/URL.res
+++ b/src/url/URL.res
@@ -1,14 +1,14 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL)
 */
-@new
+@throws(JsExn) @new
 external make: (~url: string, ~base: string=?) => UrlTypes.url = "URL"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL/parse_static)
 */
 @scope("URL")
-external parse: (~url: string, ~base: string=?) => UrlTypes.url = "parse"
+external parse: (~url: string, ~base: string=?) => Null.t<UrlTypes.url> = "parse"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URL/canParse_static)

--- a/src/url/URLSearchParams.res
+++ b/src/url/URLSearchParams.res
@@ -53,7 +53,7 @@ Returns the first value associated to the given search parameter.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/URLSearchParams/get)
 */
 @send
-external get: (t, string) => null<string> = "get"
+external get: (t, string) => Null.t<string> = "get"
 
 /**
 Returns all the values association with a given search parameter.

--- a/src/web-audio/AudioBuffer.res
+++ b/src/web-audio/AudioBuffer.res
@@ -1,19 +1,19 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioBuffer)
 */
-@new
+@throws(JsExn) @new
 external make: WebAudioTypes.audioBufferOptions => WebAudioTypes.audioBuffer = "AudioBuffer"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioBuffer/getChannelData)
 */
-@send
+@throws(JsExn) @send
 external getChannelData: (WebAudioTypes.audioBuffer, int) => array<float> = "getChannelData"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioBuffer/copyFromChannel)
 */
-@send
+@throws(JsExn) @send
 external copyFromChannel: (
   WebAudioTypes.audioBuffer,
   ~destination: array<float>,
@@ -24,7 +24,7 @@ external copyFromChannel: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioBuffer/copyToChannel)
 */
-@send
+@throws(JsExn) @send
 external copyToChannel: (
   WebAudioTypes.audioBuffer,
   ~source: array<float>,

--- a/src/web-audio/AudioBufferSourceNode.res
+++ b/src/web-audio/AudioBufferSourceNode.res
@@ -12,7 +12,7 @@ external make: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/start)
 */
-@send
+@throws(JsExn) @send
 external startA: (
   WebAudioTypes.audioBufferSourceNode,
   ~when_: float=?,

--- a/src/web-audio/AudioContext.res
+++ b/src/web-audio/AudioContext.res
@@ -3,7 +3,7 @@ include BaseAudioContext.Impl({type t = WebAudioTypes.audioContext})
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioContext)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~contextOptions: WebAudioTypes.audioContextOptions=?,
 ) => WebAudioTypes.audioContext = "AudioContext"

--- a/src/web-audio/AudioNode.res
+++ b/src/web-audio/AudioNode.res
@@ -10,7 +10,7 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/connect)
 */
-  @send
+  @throws(JsExn) @send
   external connect: (
     T.t,
     ~destinationNode: WebAudioTypes.audioNode,
@@ -21,39 +21,39 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/connect)
 */
-  @send
+  @throws(JsExn) @send
   external connect2: (T.t, ~destinationParam: WebAudioTypes.audioParam, ~output: int=?) => unit =
     "connect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
-  @send
+  @throws(JsExn) @send
   external disconnect: T.t => unit = "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
-  @send
+  @throws(JsExn) @send
   external disconnect2: (T.t, int) => unit = "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
-  @send
+  @throws(JsExn) @send
   external disconnect3: (T.t, WebAudioTypes.audioNode) => unit = "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
-  @send
+  @throws(JsExn) @send
   external disconnect4: (T.t, ~destinationNode: WebAudioTypes.audioNode, ~output: int) => unit =
     "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
-  @send
+  @throws(JsExn) @send
   external disconnect5: (
     T.t,
     ~destinationNode: WebAudioTypes.audioNode,
@@ -64,13 +64,13 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
-  @send
+  @throws(JsExn) @send
   external disconnect6: (T.t, WebAudioTypes.audioParam) => unit = "disconnect"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect)
 */
-  @send
+  @throws(JsExn) @send
   external disconnect7: (T.t, ~destinationParam: WebAudioTypes.audioParam, ~output: int) => unit =
     "disconnect"
 }

--- a/src/web-audio/AudioParam.res
+++ b/src/web-audio/AudioParam.res
@@ -1,7 +1,7 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioParam/setValueAtTime)
 */
-@send
+@throws(JsExn) @send
 external setValueAtTime: (
   WebAudioTypes.audioParam,
   ~value: float,
@@ -42,7 +42,7 @@ external setTargetAtTime: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioParam/setValueCurveAtTime)
 */
-@send
+@throws(JsExn) @send
 external setValueCurveAtTime: (
   WebAudioTypes.audioParam,
   ~values: array<float>,

--- a/src/web-audio/AudioScheduledSourceNode.res
+++ b/src/web-audio/AudioScheduledSourceNode.res
@@ -10,13 +10,13 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/start)
 */
-  @send
+  @throws(JsExn) @send
   external start: (T.t, ~when_: float=?) => unit = "start"
 
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/stop)
 */
-  @send
+  @throws(JsExn) @send
   external stop: (T.t, ~when_: float=?) => unit = "stop"
 }
 

--- a/src/web-audio/AudioWorkletNode.res
+++ b/src/web-audio/AudioWorkletNode.res
@@ -3,7 +3,7 @@ include AudioNode.Impl({type t = WebAudioTypes.audioWorkletNode})
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioWorkletNode)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~context: WebAudioTypes.baseAudioContext,
   ~name: string,

--- a/src/web-audio/BaseAudioContext.res
+++ b/src/web-audio/BaseAudioContext.res
@@ -22,7 +22,7 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBuffer)
 */
-  @send
+  @throws(JsExn) @send
   external createBuffer: (
     T.t,
     ~numberOfChannels: int,
@@ -86,7 +86,7 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createIIRFilter)
 */
-  @send
+  @throws(JsExn) @send
   external createIIRFilter: (
     T.t,
     ~feedforward: array<float>,
@@ -108,7 +108,7 @@ module Impl = (
   /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPeriodicWave)
 */
-  @send
+  @throws(JsExn) @send
   external createPeriodicWave: (
     T.t,
     ~real: array<float>,

--- a/src/web-audio/BiquadFilterNode.res
+++ b/src/web-audio/BiquadFilterNode.res
@@ -12,7 +12,7 @@ external make: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/BiquadFilterNode/getFrequencyResponse)
 */
-@send
+@throws(JsExn) @send
 external getFrequencyResponse: (
   WebAudioTypes.biquadFilterNode,
   ~frequencyHz: array<float>,

--- a/src/web-audio/ChannelMergerNode.res
+++ b/src/web-audio/ChannelMergerNode.res
@@ -3,7 +3,7 @@ include AudioNode.Impl({type t = WebAudioTypes.channelMergerNode})
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ChannelMergerNode)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~context: WebAudioTypes.baseAudioContext,
   ~options: WebAudioTypes.channelMergerOptions=?,

--- a/src/web-audio/ConvolverNode.res
+++ b/src/web-audio/ConvolverNode.res
@@ -3,7 +3,7 @@ include AudioNode.Impl({type t = WebAudioTypes.convolverNode})
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ConvolverNode)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~context: WebAudioTypes.baseAudioContext,
   ~options: WebAudioTypes.convolverOptions=?,

--- a/src/web-audio/IIRFilterNode.res
+++ b/src/web-audio/IIRFilterNode.res
@@ -12,7 +12,7 @@ external make: (
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/IIRFilterNode/getFrequencyResponse)
 */
-@send
+@throws(JsExn) @send
 external getFrequencyResponse: (
   WebAudioTypes.iirFilterNode,
   ~frequencyHz: array<float>,

--- a/src/web-audio/MediaStreamAudioSourceNode.res
+++ b/src/web-audio/MediaStreamAudioSourceNode.res
@@ -3,7 +3,7 @@ include AudioNode.Impl({type t = WebAudioTypes.mediaStreamAudioSourceNode})
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioSourceNode)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~context: WebAudioTypes.audioContext,
   ~options: WebAudioTypes.mediaStreamAudioSourceOptions,

--- a/src/web-audio/PannerNode.res
+++ b/src/web-audio/PannerNode.res
@@ -3,7 +3,7 @@ include AudioNode.Impl({type t = WebAudioTypes.pannerNode})
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PannerNode)
 */
-@new
+@throws(JsExn) @new
 external make: (
   ~context: WebAudioTypes.baseAudioContext,
   ~options: WebAudioTypes.pannerOptions=?,

--- a/src/web-audio/WebAudioTypes.res
+++ b/src/web-audio/WebAudioTypes.res
@@ -408,6 +408,7 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/buffer)
     */
+  @throws(JsExn)
   mutable buffer: Null.t<audioBuffer>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/playbackRate)
@@ -576,6 +577,7 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ConvolverNode/buffer)
     */
+  @throws(JsExn)
   mutable buffer: Null.t<audioBuffer>,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ConvolverNode/normalize)
@@ -873,14 +875,17 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PannerNode/refDistance)
     */
+  @throws(JsExn)
   mutable refDistance: float,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PannerNode/maxDistance)
     */
+  @throws(JsExn)
   mutable maxDistance: float,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PannerNode/rolloffFactor)
     */
+  @throws(JsExn)
   mutable rolloffFactor: float,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PannerNode/coneInnerAngle)
@@ -893,6 +898,7 @@ TODO: mark as private once mutating fields of private records is allowed
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/PannerNode/coneOuterGain)
     */
+  @throws(JsExn)
   mutable coneOuterGain: float,
 }
 
@@ -907,6 +913,7 @@ type analyserNode = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnalyserNode/fftSize)
     */
+  @throws(JsExn)
   mutable fftSize: int,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnalyserNode/frequencyBinCount)
@@ -915,14 +922,17 @@ type analyserNode = {
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnalyserNode/minDecibels)
     */
+  @throws(JsExn)
   mutable minDecibels: float,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnalyserNode/maxDecibels)
     */
+  @throws(JsExn)
   mutable maxDecibels: float,
   /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/AnalyserNode/smoothingTimeConstant)
     */
+  @throws(JsExn)
   mutable smoothingTimeConstant: float,
 }
 
@@ -1262,7 +1272,7 @@ type stereoPannerOptions = {
 
 type waveShaperOptions = {
   ...audioNodeOptions,
-  mutable curve?: array<float>,
+  mutable curve?: Null.t<array<float>>,
   mutable oversample?: overSampleType,
 }
 

--- a/src/web-audio/WebAudioTypes.res
+++ b/src/web-audio/WebAudioTypes.res
@@ -1173,7 +1173,7 @@ type biquadFilterOptions = {
 }
 
 type audioBufferSourceOptions = {
-  mutable buffer?: Null.t<audioBuffer>,
+  mutable buffer?: Nullable.t<audioBuffer>,
   mutable detune?: float,
   mutable loop?: bool,
   mutable loopEnd?: float,
@@ -1195,7 +1195,7 @@ type constantSourceOptions = {mutable offset?: float}
 
 type convolverOptions = {
   ...audioNodeOptions,
-  mutable buffer?: Null.t<audioBuffer>,
+  mutable buffer?: Nullable.t<audioBuffer>,
   mutable disableNormalization?: bool,
 }
 
@@ -1272,7 +1272,7 @@ type stereoPannerOptions = {
 
 type waveShaperOptions = {
   ...audioNodeOptions,
-  mutable curve?: Null.t<array<float>>,
+  mutable curve?: array<float>,
   mutable oversample?: overSampleType,
 }
 

--- a/src/window/CustomElementRegistry.res
+++ b/src/window/CustomElementRegistry.res
@@ -1,7 +1,7 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/define)
 */
-@send
+@throws(JsExn) @send
 external define: (
   DOM.customElementRegistry,
   ~name: string,
@@ -13,7 +13,8 @@ external define: (
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/getName)
 */
 @send
-external getName: (DOM.customElementRegistry, DOM.customElementConstructor) => string = "getName"
+external getName: (DOM.customElementRegistry, DOM.customElementConstructor) => Null.t<string> =
+  "getName"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/whenDefined)

--- a/src/window/Document.res
+++ b/src/window/Document.res
@@ -11,7 +11,7 @@ Returns the first element within node's descendants whose ID is elementId.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getElementById)
 */
 @send
-external getElementById: (DOM.document, string) => null<DOMTree.element> = "getElementById"
+external getElementById: (DOM.document, string) => Null.t<DOMTree.element> = "getElementById"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getAnimations)
@@ -25,7 +25,7 @@ Inserts nodes before the first child of node, while replacing strings in nodes w
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/prepend)
 */
-@send
+@throws(JsExn) @send
 external prepend: (DOM.document, DOMTree.node) => unit = "prepend"
 
 /**
@@ -34,7 +34,7 @@ Inserts nodes before the first child of node, while replacing strings in nodes w
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/prepend)
 */
-@send
+@throws(JsExn) @send
 external prepend2: (DOM.document, string) => unit = "prepend"
 
 /**
@@ -43,7 +43,7 @@ Inserts nodes after the last child of node, while replacing strings in nodes wit
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/append)
 */
-@send
+@throws(JsExn) @send
 external append: (DOM.document, DOMTree.node) => unit = "append"
 
 /**
@@ -52,7 +52,7 @@ Inserts nodes after the last child of node, while replacing strings in nodes wit
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/append)
 */
-@send
+@throws(JsExn) @send
 external append2: (DOM.document, string) => unit = "append"
 
 /**
@@ -61,7 +61,7 @@ Replace all children of node with nodes, while replacing strings in nodes with e
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
 */
-@send
+@throws(JsExn) @send
 external replaceChildren: (DOM.document, DOMTree.node) => unit = "replaceChildren"
 
 /**
@@ -70,21 +70,21 @@ Replace all children of node with nodes, while replacing strings in nodes with e
 Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
 */
-@send
+@throws(JsExn) @send
 external replaceChildren2: (DOM.document, string) => unit = "replaceChildren"
 
 /**
 Returns the first element that is a descendant of node that matches selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/querySelector)
 */
-@send
+@throws(JsExn) @send
 external querySelector: (DOM.document, string) => Null.t<DOMTree.element> = "querySelector"
 
 /**
 Returns all element descendants of node that match selectors.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/querySelectorAll)
 */
-@send
+@throws(JsExn) @send
 external querySelectorAll: (DOM.document, string) => DOM.nodeList<DOMTree.element> =
   "querySelectorAll"
 
@@ -156,7 +156,7 @@ type elementCreationOptions = {mutable is?: string}
 Creates an instance of the element for the specified tag.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createElement)
 */
-@send
+@throws(JsExn) @send
 external createElement: (
   DOM.document,
   string,
@@ -179,7 +179,7 @@ namespace is the XMLNS namespace and neither qualifiedName nor namespace prefix 
 When supplied, options's is can be used to create a customized built-in element.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createElementNS)
 */
-@send
+@throws(JsExn) @send
 external createElementNS: (
   DOM.document,
   ~namespace: string,
@@ -203,7 +203,7 @@ namespace is the XMLNS namespace and neither qualifiedName nor namespace prefix 
 When supplied, options's is can be used to create a customized built-in element.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createElementNS)
 */
-@send
+@throws(JsExn) @send
 external createElementNS2: (
   DOM.document,
   ~namespace: string,
@@ -245,7 +245,7 @@ external createComment: (DOM.document, string) => Comment.t = "createComment"
 Returns a ProcessingInstruction node whose target is target and data is data. If target does not match the Name production an "InvalidCharacterError" DOMException will be thrown. If data contains "?>" an "InvalidCharacterError" DOMException will be thrown.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createProcessingInstruction)
 */
-@send
+@throws(JsExn) @send
 external createProcessingInstruction: (
   DOM.document,
   ~target: string,
@@ -258,7 +258,7 @@ Returns a copy of node. If deep is true, the copy also includes the node's desce
 If node is a document or a shadow root, throws a "NotSupportedError" DOMException.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/importNode)
 */
-@send
+@throws(JsExn) @send
 external importNode: (DOM.document, 't, ~deep: bool=?) => 't = "importNode"
 
 /**
@@ -267,7 +267,7 @@ Moves node from another document and returns it.
 If node is a document, throws a "NotSupportedError" DOMException or, if node is a shadow root, throws a "HierarchyRequestError" DOMException.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/adoptNode)
 */
-@send
+@throws(JsExn) @send
 external adoptNode: (DOM.document, 't) => 't = "adoptNode"
 
 /**
@@ -275,13 +275,13 @@ Creates an attribute object with a specified name.
 @param name String that sets the attribute object's name.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createAttribute)
 */
-@send
+@throws(JsExn) @send
 external createAttribute: (DOM.document, string) => Attr.t = "createAttribute"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/createAttributeNS)
 */
-@send
+@throws(JsExn) @send
 external createAttributeNS: (DOM.document, ~namespace: string, ~qualifiedName: string) => Attr.t =
   "createAttributeNS"
 
@@ -348,7 +348,7 @@ external caretPositionFromPoint: (
   ~x: float,
   ~y: float,
   ~options: caretPositionFromPointOptions=?,
-) => DOM.caretPosition = "caretPositionFromPoint"
+) => Null.t<DOM.caretPosition> = "caretPositionFromPoint"
 
 /**
 Stops document's fullscreen element from being displayed fullscreen and resolves promise when done.
@@ -360,7 +360,7 @@ external exitFullscreen: DOM.document => promise<unit> = "exitFullscreen"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/parseHTMLUnsafe_static)
 */
-@scope("Document")
+@throws(JsExn) @scope("Document")
 external parseHTMLUnsafe: string => DOM.document = "parseHTMLUnsafe"
 
 /**
@@ -392,8 +392,12 @@ Opens a new window and loads a document specified by a given URL. Also, opens a 
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/open)
 */
 @send
-external open2: (DOM.document, ~url: string, ~name: string, ~features: string) => DOM.window =
-  "open"
+external open2: (
+  DOM.document,
+  ~url: string,
+  ~name: string,
+  ~features: string,
+) => Null.t<DOM.window> = "open"
 
 /**
 Closes an output stream and forces the sent data to display.
@@ -407,7 +411,7 @@ Writes one or more HTML expressions to a document in the specified window.
 @param content Specifies the text and HTML tags to write.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/write)
 */
-@send
+@throws(JsExn) @send
 external write: (DOM.document, string) => unit = "write"
 
 /**
@@ -415,7 +419,7 @@ Writes one or more HTML expressions, followed by a carriage return, to a documen
 @param content The text and HTML tags to write.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/writeln)
 */
-@send
+@throws(JsExn) @send
 external writeln: (DOM.document, string) => unit = "writeln"
 
 /**
@@ -442,7 +446,7 @@ Returns an object representing the current selection of the document that is loa
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/getSelection)
 */
 @send
-external getSelection: DOM.document => null<Selection.t> = "getSelection"
+external getSelection: DOM.document => Null.t<Selection.t> = "getSelection"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess)
@@ -463,4 +467,4 @@ Returns the Location associated with this document, which provides information a
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Document/location)
 */
 @get
-external location: DOM.document => Location.t = "location"
+external location: DOM.document => Null.t<Location.t> = "location"

--- a/src/window/DomGlobal.res
+++ b/src/window/DomGlobal.res
@@ -84,7 +84,7 @@ external length: int = "length"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/top)
 */
-external top: DOM.window = "top"
+external top: Null.t<DOM.window> = "top"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/opener)
@@ -97,12 +97,12 @@ Refers to either the parent WindowProxy, or itself.
 It can rarely be null e.g. for contentWindow of an iframe that is already removed from the parent.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/parent)
 */
-external parent: DOM.window = "parent"
+external parent: Null.t<DOM.window> = "parent"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/frameElement)
 */
-external frameElement: DOMTree.element = "frameElement"
+external frameElement: Null.t<DOMTree.element> = "frameElement"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/navigator)
@@ -117,7 +117,7 @@ external screen: DOM.screen = "screen"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/visualViewport)
 */
-external visualViewport: VisualViewport.t = "visualViewport"
+external visualViewport: Null.t<VisualViewport.t> = "visualViewport"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/innerWidth)
@@ -217,11 +217,13 @@ external caches: CacheTypes.cacheStorage = "caches"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/sessionStorage)
 */
+@throws(JsExn)
 external sessionStorage: WebStorageTypes.storage = "sessionStorage"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/localStorage)
 */
+@throws(JsExn)
 external localStorage: WebStorageTypes.storage = "localStorage"
 
 /**
@@ -232,11 +234,13 @@ external reportError: JSON.t => unit = "reportError"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/btoa)
 */
+@throws(JsExn)
 external btoa: string => string = "btoa"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/atob)
 */
+@throws(JsExn)
 external atob: string => string = "atob"
 
 /**
@@ -256,6 +260,7 @@ external clearTimeout: DOM.timeoutId => unit = "clearTimeout"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setInterval)
 */
+@throws(JsExn)
 external setInterval: (~handler: string, ~timeout: int=?) => int = "setInterval"
 
 /**
@@ -276,17 +281,20 @@ external queueMicrotask: unit => unit => unit = "queueMicrotask"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/structuredClone)
 */
+@throws(JsExn)
 external structuredClone: ('t, ~options: ChannelMessagingTypes.structuredSerializeOptions=?) => 't =
   "structuredClone"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)
 */
+@throws(JsExn)
 external requestAnimationFrame: (float => unit) => int = "requestAnimationFrame"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/cancelAnimationFrame)
 */
+@throws(JsExn)
 external cancelAnimationFrame: int => unit = "cancelAnimationFrame"
 
 /**
@@ -310,7 +318,8 @@ external focus: unit => unit = "focus"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/open)
 */
-external open_: (~url: string=?, ~target: string=?, ~features: string=?) => DOM.window = "open"
+external open_: (~url: string=?, ~target: string=?, ~features: string=?) => Null.t<DOM.window> =
+  "open"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/alert)
@@ -325,7 +334,7 @@ external confirm: (~message: string=?) => bool = "confirm"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/prompt)
 */
-external prompt: (~message: string=?, ~default: string=?) => string = "prompt"
+external prompt: (~message: string=?, ~default: string=?) => Null.t<string> = "prompt"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/print)
@@ -344,6 +353,7 @@ If the origin of the target window doesn't match the given target origin, the me
 Throws a "DataCloneError" DOMException if transfer array contains duplicate objects or if message could not be cloned.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
 */
+@throws(JsExn)
 external postMessage: (
   ~message: JSON.t,
   ~targetOrigin: string,
@@ -362,6 +372,7 @@ If the origin of the target window doesn't match the given target origin, the me
 Throws a "DataCloneError" DOMException if transfer array contains duplicate objects or if message could not be cloned.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
 */
+@throws(JsExn)
 external postMessageWithOptions: (
   ~message: JSON.t,
   ~options: DOM.windowPostMessageOptions=?,
@@ -425,6 +436,7 @@ external scrollBy2: (~x: float, ~y: float) => unit = "scrollBy"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)
 */
+@throws(JsExn)
 external getComputedStyle: (~elt: DOMTree.element, ~pseudoElt: string=?) => CSSStyleDeclaration.t =
   "getComputedStyle"
 
@@ -444,4 +456,4 @@ external cancelIdleCallback: int => unit = "cancelIdleCallback"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/getSelection)
 */
-external getSelection: unit => null<Selection.t> = "getSelection"
+external getSelection: unit => Null.t<Selection.t> = "getSelection"

--- a/src/window/History.res
+++ b/src/window/History.res
@@ -1,32 +1,32 @@
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/go)
 */
-@send
+@throws(JsExn) @send
 external go: (HistoryTypes.history, ~delta: int=?) => unit = "go"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/back)
 */
-@send
+@throws(JsExn) @send
 external back: HistoryTypes.history => unit = "back"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/forward)
 */
-@send
+@throws(JsExn) @send
 external forward: HistoryTypes.history => unit = "forward"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/pushState)
 */
-@send
+@throws(JsExn) @send
 external pushState: (HistoryTypes.history, ~data: JSON.t, ~unused: string, ~url: string=?) => unit =
   "pushState"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/History/replaceState)
 */
-@send
+@throws(JsExn) @send
 external replaceState: (
   HistoryTypes.history,
   ~data: JSON.t,

--- a/src/window/Location.res
+++ b/src/window/Location.res
@@ -76,21 +76,21 @@ Can be set, to navigate to the same WebApiURL with a changed fragment (ignores l
 Navigates to the given URL.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Location/assign)
 */
-@send
+@throws(JsExn) @send
 external assign: (t, string) => unit = "assign"
 
 /**
 Removes the current page from the session history and navigates to the given URL.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Location/replace)
 */
-@send
+@throws(JsExn) @send
 external replace: (t, string) => unit = "replace"
 
 /**
 Reloads the current page.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Location/reload)
 */
-@send
+@throws(JsExn) @send
 external reload: t => unit = "reload"
 
 /**

--- a/src/window/Window.res
+++ b/src/window/Window.res
@@ -128,7 +128,7 @@ It can rarely be null e.g. for contentWindow of an iframe that is already remove
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/parent)
     */
 @get
-external parent: t => t = "parent"
+external parent: t => Null.t<t> = "parent"
 
 /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/frameElement)
@@ -271,13 +271,13 @@ external caches: t => CacheTypes.cacheStorage = "caches"
 /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/sessionStorage)
     */
-@get
+@throws(JsExn) @get
 external sessionStorage: t => WebStorageTypes.storage = "sessionStorage"
 
 /**
     [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/localStorage)
     */
-@get
+@throws(JsExn) @get
 external localStorage: t => WebStorageTypes.storage = "localStorage"
 
 /**
@@ -289,13 +289,13 @@ external reportError: (t, JSON.t) => unit = "reportError"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/btoa)
 */
-@send
+@throws(JsExn) @send
 external btoa: (t, string) => string = "btoa"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/atob)
 */
-@send
+@throws(JsExn) @send
 external atob: (t, string) => string = "atob"
 
 /**
@@ -317,7 +317,7 @@ external clearTimeout: (t, DOM.timeoutId) => unit = "clearTimeout"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/setInterval)
 */
-@send
+@throws(JsExn) @send
 external setInterval: (t, ~handler: string, ~timeout: int=?) => int = "setInterval"
 
 /**
@@ -348,7 +348,7 @@ external queueMicrotask: (t, unit => unit) => unit = "queueMicrotask"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/structuredClone)
 */
-@send
+@throws(JsExn) @send
 external structuredClone: (
   t,
   't,
@@ -392,7 +392,7 @@ external focus: t => unit = "focus"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/open)
 */
 @send
-external open_: (t, ~url: string=?, ~target: string=?, ~features: string=?) => t = "open"
+external open_: (t, ~url: string=?, ~target: string=?, ~features: string=?) => Null.t<t> = "open"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/alert)
@@ -410,7 +410,7 @@ external confirm: (t, ~message: string=?) => bool = "confirm"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/prompt)
 */
 @send
-external prompt: (t, ~message: string=?, ~default: string=?) => string = "prompt"
+external prompt: (t, ~message: string=?, ~default: string=?) => Null.t<string> = "prompt"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/print)
@@ -430,7 +430,7 @@ If the origin of the target window doesn't match the given target origin, the me
 Throws a "DataCloneError" DOMException if transfer array contains duplicate objects or if message could not be cloned.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
 */
-@send
+@throws(JsExn) @send
 external postMessage: (
   t,
   ~message: JSON.t,
@@ -450,7 +450,7 @@ If the origin of the target window doesn't match the given target origin, the me
 Throws a "DataCloneError" DOMException if transfer array contains duplicate objects or if message could not be cloned.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/postMessage)
 */
-@send
+@throws(JsExn) @send
 external postMessageWithOptions: (
   t,
   ~message: JSON.t,
@@ -526,7 +526,7 @@ external scrollByXY: (t, ~x: float, ~y: float) => unit = "scrollBy"
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)
 */
-@send
+@throws(JsExn) @send
 external getComputedStyle: (
   t,
   ~elt: DOMTree.element,
@@ -553,4 +553,4 @@ external cancelIdleCallback: (t, int) => unit = "cancelIdleCallback"
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Window/getSelection)
 */
 @send
-external getSelection: t => null<Selection.t> = "getSelection"
+external getSelection: t => Null.t<Selection.t> = "getSelection"

--- a/src/window/XPathResult.res
+++ b/src/window/XPathResult.res
@@ -37,10 +37,10 @@ type t = private {
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/XPathResult/iterateNext)
 */
 @send
-external iterateNext: t => DOMTree.node = "iterateNext"
+external iterateNext: t => Null.t<DOMTree.node> = "iterateNext"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/XPathResult/snapshotItem)
 */
 @send
-external snapshotItem: (t, int) => DOMTree.node = "snapshotItem"
+external snapshotItem: (t, int) => Null.t<DOMTree.node> = "snapshotItem"

--- a/src/workers/Clients.res
+++ b/src/workers/Clients.res
@@ -8,10 +8,8 @@ Returns a `Promise` for a `Client` matching a given id.
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/Clients/get)
 */
 @send
-external get: (
-  ServiceWorkerTypes.clients,
-  string,
-) => promise<Nullable.t<ServiceWorkerTypes.client>> = "get"
+external get: (ServiceWorkerTypes.clients, string) => promise<option<ServiceWorkerTypes.client>> =
+  "get"
 
 /**
 Returns a `Promise` for an array of `Client` objects matching the given options.
@@ -31,7 +29,7 @@ Opens a new browser window for a given WebApiURL and returns a `Promise` for the
 external openWindow: (
   ServiceWorkerTypes.clients,
   string,
-) => promise<ServiceWorkerTypes.windowClient> = "openWindow"
+) => promise<Null.t<ServiceWorkerTypes.windowClient>> = "openWindow"
 
 /**
 Allows an active service worker to set itself as the controller for all clients within its scope.

--- a/src/workers/ServiceWorkerContainer.res
+++ b/src/workers/ServiceWorkerContainer.res
@@ -17,7 +17,7 @@ external register: (
 external getRegistration: (
   ServiceWorkerTypes.serviceWorkerContainer,
   ~clientURL: string=?,
-) => Nullable.t<ServiceWorkerTypes.serviceWorkerRegistration> = "getRegistration"
+) => promise<option<ServiceWorkerTypes.serviceWorkerRegistration>> = "getRegistration"
 
 /**
 [Read more on MDN](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/getRegistrations)

--- a/src/workers/SharedWorker.res
+++ b/src/workers/SharedWorker.res
@@ -16,7 +16,7 @@ let shared: SharedWorker.t = SharedWorker.make("sharedworker.js")
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
-@new
+@throws(JsExn) @new
 external make: string => t = "SharedWorker"
 
 /**
@@ -31,7 +31,7 @@ let shared: SharedWorker.t = SharedWorker.makeWithName("sharedworker.js", "name"
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
-@new
+@throws(JsExn) @new
 external makeWithName: (string, string) => t = "SharedWorker"
 
 /**
@@ -49,7 +49,7 @@ let shared: SharedWorker.t = SharedWorker.makeWithOptions("sharedworker.js", {
 
 [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/)
 */
-@new
+@throws(JsExn) @new
 external makeWithOptions: (string, workerOptions) => t = "SharedWorker"
 
 /**

--- a/src/workers/WebWorkersTypes.res
+++ b/src/workers/WebWorkersTypes.res
@@ -42,5 +42,5 @@ the complete list of functions available to workers.
 @editor.completeFrom(SharedWorkerGlobalScope)
 type sharedWorkerGlobalScope = private {
   ...workerGlobalScope,
-  name: option<string>,
+  name: string,
 }

--- a/tests/BindingAbsence__test.res
+++ b/tests/BindingAbsence__test.res
@@ -1,0 +1,27 @@
+let requestWithNullBody: Request.requestInit = {body: Nullable.null}
+
+let requestWithUndefinedBody: Request.requestInit = {body: Nullable.undefined}
+
+let intersectionWithNullRoot: IntersectionObserverTypes.intersectionObserverInit = {
+  root: Nullable.null,
+}
+
+let waveShaperWithCurve: WebAudioTypes.waveShaperOptions = {curve: [0., 1.]}
+
+let decodingConfiguration = (
+  info: MediaCapabilities.Types.mediaCapabilitiesDecodingInfo,
+): MediaCapabilities.Types.mediaDecodingConfiguration => info.configuration
+
+let decodingKeySystemAccess = (info: MediaCapabilities.Types.mediaCapabilitiesDecodingInfo): Null.t<
+  BaseEncryptedMediaExtensions.mediaKeySystemAccess,
+> => info.keySystemAccess
+
+let encodingConfiguration = (
+  info: MediaCapabilities.Types.mediaCapabilitiesEncodingInfo,
+): MediaCapabilities.Types.mediaEncodingConfiguration => info.configuration
+
+let sharedWorkerName = (scope: SharedWorkerScope.t): string => scope.name
+
+let imagePattern = (context: DOM.canvasRenderingContext2D, image: HTMLImageElement.t): Null.t<
+  CanvasTypes.canvasPattern,
+> => context->CanvasRenderingContext2D.createPattern(~image, ~repetition="repeat")

--- a/tests/DOMAPI/HTMLCanvasElement__test.res
+++ b/tests/DOMAPI/HTMLCanvasElement__test.res
@@ -11,7 +11,7 @@ external setTextBaseline: (DOM.canvasRenderingContext2D, CanvasTypes.canvasTextB
 
 let myCanvas: HTMLCanvasElement.t =
   DomGlobal.document->Document.getElementById("myCanvas")->toHTMLCanvasElement
-let ctx = myCanvas->HTMLCanvasElement.getContext2D
+let ctx = myCanvas->HTMLCanvasElement.getContext2D->Null.getOrThrow
 
 ctx->setFillStyle(FillStyle.fromString("red"))
 ctx->CanvasRenderingContext2D.fillRect(~x=50., ~y=50., ~w=200., ~h=200.)

--- a/tests/DOMAPI/HTMLElementHidden__test.res
+++ b/tests/DOMAPI/HTMLElementHidden__test.res
@@ -11,14 +11,6 @@ let setHiddenStates = (element: HTMLElement.t) => {
   element->HTMLElement.setHidden(HTMLElement.Visible)
 }
 
-let setRawHiddenValues = (element: HTMLElement.t) => {
-  element->HTMLElement.setHiddenRaw(HTMLElement.Boolean(true))
-  element->HTMLElement.setHiddenRaw(HTMLElement.Number(0.))
-  element->HTMLElement.setHiddenRaw(HTMLElement.String("until-found"))
-  element->HTMLElement.setHiddenRaw(HTMLElement.Null)
-  element->HTMLElement.setHiddenRaw(HTMLElement.Undefined)
-}
-
 let formHidden = (element: HTMLFormElement.t): HTMLElement.hiddenState =>
   element->HTMLFormElement.hidden
 

--- a/tests/DOMAPI/HTMLElementHidden__test.res
+++ b/tests/DOMAPI/HTMLElementHidden__test.res
@@ -16,6 +16,7 @@ let setRawHiddenValues = (element: HTMLElement.t) => {
   element->HTMLElement.setHiddenRaw(HTMLElement.Number(0.))
   element->HTMLElement.setHiddenRaw(HTMLElement.String("until-found"))
   element->HTMLElement.setHiddenRaw(HTMLElement.Null)
+  element->HTMLElement.setHiddenRaw(HTMLElement.Undefined)
 }
 
 let formHidden = (element: HTMLFormElement.t): HTMLElement.hiddenState =>

--- a/tests/DOMAPI/HTMLElementHidden__test.res
+++ b/tests/DOMAPI/HTMLElementHidden__test.res
@@ -1,0 +1,37 @@
+let describeHidden = (element: HTMLElement.t) =>
+  switch element->HTMLElement.hidden {
+  | HTMLElement.Visible => "visible"
+  | HTMLElement.Hidden => "hidden"
+  | HTMLElement.HiddenUntilFound => "hidden until found"
+  }
+
+let setHiddenStates = (element: HTMLElement.t) => {
+  element->HTMLElement.setHidden(HTMLElement.Hidden)
+  element->HTMLElement.setHidden(HTMLElement.HiddenUntilFound)
+  element->HTMLElement.setHidden(HTMLElement.Visible)
+}
+
+let setRawHiddenValues = (element: HTMLElement.t) => {
+  element->HTMLElement.setHiddenRaw(HTMLElement.Boolean(true))
+  element->HTMLElement.setHiddenRaw(HTMLElement.Number(0.))
+  element->HTMLElement.setHiddenRaw(HTMLElement.String("until-found"))
+  element->HTMLElement.setHiddenRaw(HTMLElement.Null)
+}
+
+let formHidden = (element: HTMLFormElement.t): HTMLElement.hiddenState =>
+  element->HTMLFormElement.hidden
+
+let setFormHidden = (element: HTMLFormElement.t) =>
+  element->HTMLFormElement.setHidden(HTMLElement.Hidden)
+
+let slotHidden = (element: HTMLSlotElement.t): HTMLElement.hiddenState =>
+  element->HTMLSlotElement.hidden
+
+let setSlotHidden = (element: HTMLSlotElement.t) =>
+  element->HTMLSlotElement.setHidden(HTMLElement.HiddenUntilFound)
+
+let anchorHidden = (element: HTMLAnchorElement.t): HTMLElement.hiddenState =>
+  element->HTMLAnchorElement.hidden
+
+let setAnchorHidden = (element: HTMLAnchorElement.t) =>
+  element->HTMLAnchorElement.setHidden(HTMLElement.Visible)

--- a/tests/FetchAPI/Request__test.res
+++ b/tests/FetchAPI/Request__test.res
@@ -13,7 +13,10 @@ let paramsBody = BodyInit.fromURLSearchParams(params)
 let formDataBody = BodyInit.fromFormData(formData)
 let streamBody = BodyInit.fromReadableStream(stream)
 
-let req1 = Request.fromURL("https://example.com/api", ~init={method: "POST", body: stringBody})
+let req1 = Request.fromURL(
+  "https://example.com/api",
+  ~init={method: "POST", body: stringBody->Nullable.make},
+)
 
 let req2 = Request.fromRequest(req1)
 
@@ -21,7 +24,7 @@ let _blob: Blob.t = await req2->Request.clone->Request.blob
 
 let formDataReq = Request.fromURL(
   "https://example.com/form",
-  ~init={method: "POST", body: formDataBody},
+  ~init={method: "POST", body: formDataBody->Nullable.make},
 )
 let _formData: FormData.t = await formDataReq->Request.formData
 

--- a/tests/Fetch__test.res
+++ b/tests/Fetch__test.res
@@ -9,7 +9,7 @@ let response2 = await Fetch.fetch(
         "Authorization": "Bearer token",
       },
     ),
-    body: BodyInit.fromString(`secret=foo&response=bar`),
+    body: BodyInit.fromString(`secret=foo&response=bar`)->Nullable.make,
   },
 )
 
@@ -22,7 +22,7 @@ let response3 = await Fetch.fetchWithRequest(
         "Content-Type": "application/x-www-form-urlencoded",
       },
     ),
-    body: BodyInit.fromString(`secret=foo&response=bar`),
+    body: BodyInit.fromString(`secret=foo&response=bar`)->Nullable.make,
   },
 )
 
@@ -39,7 +39,7 @@ let registrationResult = await Window.current
 let subscription = await registrationResult.pushManager->PushManager.subscribe(
   ~options={
     userVisibleOnly: true,
-    applicationServerKey: ApplicationServerKey.fromString("MyPublicKey")->Null.make,
+    applicationServerKey: ApplicationServerKey.fromString("MyPublicKey")->Nullable.make,
   },
 )
 

--- a/tests/Fetch__test.res
+++ b/tests/Fetch__test.res
@@ -39,7 +39,7 @@ let registrationResult = await Window.current
 let subscription = await registrationResult.pushManager->PushManager.subscribe(
   ~options={
     userVisibleOnly: true,
-    applicationServerKey: ApplicationServerKey.fromString("MyPublicKey"),
+    applicationServerKey: ApplicationServerKey.fromString("MyPublicKey")->Null.make,
   },
 )
 

--- a/tests/IntersectionObserverAPI/IntersectionObserver__test.res
+++ b/tests/IntersectionObserverAPI/IntersectionObserver__test.res
@@ -12,7 +12,7 @@ let observer2 = IObserver.make(
     Console.log2(entry, observer)
   },
   ~options={
-    root: root->IRoot.fromElement->Null.make,
+    root: root->IRoot.fromElement->Nullable.make,
     rootMargin: "10px",
     threshold: [0.1],
   },

--- a/tests/IntersectionObserverAPI/IntersectionObserver__test.res
+++ b/tests/IntersectionObserverAPI/IntersectionObserver__test.res
@@ -12,16 +12,20 @@ let observer2 = IObserver.make(
     Console.log2(entry, observer)
   },
   ~options={
-    root: root->IRoot.fromElement,
+    root: root->IRoot.fromElement->Null.make,
     rootMargin: "10px",
     threshold: [0.1],
   },
 )
 
-switch observer2.root->IRoot.decode {
-| Element(_) => Console.log("Element")
-| Document(_) => Console.log("Document")
-| Null => Console.log("Null")
+switch observer2.root->Null.toOption {
+| Some(root) =>
+  switch root->IRoot.decode {
+  | Element(_) => Console.log("Element")
+  | Document(_) => Console.log("Document")
+  | Null => Console.log("Null")
+  }
+| None => Console.log("Null")
 }
 let rootMargin2 = observer2.rootMargin
 

--- a/tests/ServiceWorkerAPI/ServiceWorker__test.res
+++ b/tests/ServiceWorkerAPI/ServiceWorker__test.res
@@ -4,7 +4,7 @@ self->ServiceWorkerScope.addEventListener(EventType.Push, (event: PushEvent.t) =
   Console.log("received push event")
 
   // Extract data
-  let (title, body) = switch event.data {
+  let (title, body) = switch event.data->Null.toOption {
   | Some(data) =>
     switch data->PushMessageData.json {
     | JSON.Object(dict{"title": JSON.String(title), "body": JSON.String(body)}) => (title, body)


### PR DESCRIPTION
## Summary

- Corrects nullability and optionality across affected Web API bindings.
- Adds `@throws(JsExn)` where synchronous browser APIs can raise exceptions.
- Models `HTMLElement.hidden` with the semantic states `Visible`, `Hidden`, and `HiddenUntilFound`, without a raw coercion API.
- Updates compile-time fixtures for the corrected contracts.

## `HTMLElement.hidden`

The getter and setter use the same semantic type:

```rescript
element->HTMLElement.setHidden(HTMLElement.Hidden)
element->HTMLElement.setHidden(HTMLElement.HiddenUntilFound)
element->HTMLElement.setHidden(HTMLElement.Visible)

switch element->HTMLElement.hidden {
| HTMLElement.Visible => "visible"
| HTMLElement.Hidden => "hidden"
| HTMLElement.HiddenUntilFound => "hidden until found"
}
```

Because `setHidden` is an `@set` external, these calls emit direct property assignments such as `element.hidden = true`.

An earlier version also exposed `hiddenInput` and `setHiddenRaw` to mirror every Web IDL setter input. Those were removed because numbers, arbitrary strings, `null`, and `undefined` only invoke coercion and do not represent additional states. The binding intentionally restricts writes to the three useful outcomes. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/hidden) and the [HTML Standard](https://html.spec.whatwg.org/multipage/interaction.html#dom-hidden).
