### PR TITLE
Add repository CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fhammerschmidt @brnrdog @tsnobip @jderochervlk


### PR DESCRIPTION
## Summary

- add a repository-wide CODEOWNERS rule
- assign ownership to the human reviewers from #350 and @jderochervlk
- automatically request this group on future pull requests

## Code owners

- @fhammerschmidt
- @brnrdog
- @tsnobip
- @jderochervlk

## Validation

- confirmed every owner has write or admin access to the repository
- confirmed GitHub reports no CODEOWNERS errors for the branch